### PR TITLE
Updated code to call the 'empty' function instead of doing direct comparison

### DIFF
--- a/src/preact.js
+++ b/src/preact.js
@@ -574,7 +574,7 @@ function build(dom, vnode) {
 		return document.createTextNode(vnode);
 	}
 
-	if (nodeName===null || nodeName===undefined) {
+	if (empty(nodeName)) {
 		nodeName = 'x-undefined-element';
 	}
 
@@ -597,7 +597,7 @@ function build(dom, vnode) {
 		for (let name in old) {
 			if (hop.call(old, name)) {
 				let o = attrs[name];
-				if (o===undefined || o===null) {
+				if (empty(o)) {
 					setAccessor(out, name, null, old[name]);
 				}
 			}
@@ -609,7 +609,7 @@ function build(dom, vnode) {
 		for (let name in attrs) {
 			if (hop.call(attrs, name)) {
 				let value = attrs[name];
-				if (value!==undefined && value!==null) {
+				if (!empty(value)) {
 					let prev = getAccessor(out, name, old[name]);
 					if (value!=prev) {
 						setAccessor(out, name, value, prev);


### PR DESCRIPTION
Found three cases where the exact logic for the 'empty' function was being used directly in the code instead of a call to the 'empty' function and updated them.