### PR TITLE
[Bug] Fix multiple camelCase'd CSS properties

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -115,7 +115,7 @@ export function hashToClassName(c) {
  *	@private
  *	@function
  */
-export const jsToCss = memoize( s => s.replace(/([A-Z])/,'-$1').toLowerCase() );
+export const jsToCss = memoize( s => s.replace(/([A-Z])/g,'-$1').toLowerCase() );
 
 
 /** Just a memoized String.prototype.toLowerCase */


### PR DESCRIPTION
Currently, the function outputs the wrong `style` attribute format for CSS properties that have multiple camelCase'd parts i.e. `borderTopLeftRadius` or `borderTopWidth` etc.

Current output:
```
style: "border-topLeftRadius: 10px";
```

Expected output:
```
style: "border-top-left-radius: 10px";
```