### PR TITLE
Allow on* handlers defined as strings to be handled by the EventProxy

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -79,9 +79,17 @@ function setComplexAccessor(node, name, value) {
 		let type = normalizeEventName(name),
 			l = node._listeners || (node._listeners = {}),
 			fn = !l[type] ? 'add' : !value ? 'remove' : null;
-		if (fn) node[fn+'EventListener'](type, eventProxy);
 		l[type] = value;
-		return;
+		if (typeof(value) === "string"){
+			node.setAttribute(name, value);
+			value = node['on'+type];
+			l[type] = value;
+		}
+		if (fn && typeof(value) !== "string"){
+			node[fn+'EventListener'](type, eventProxy);
+			node.removeAttribute(name);
+			return;
+		}
 	}
 
 	let type = typeof value;

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -154,6 +154,21 @@ describe('render()', () => {
 		proto.addEventListener.restore();
 	});
 
+	it('should correctly proxy on* handlers defined as strings', () => {
+		window.stub = sinon.stub();
+		let click = () => {},
+			onclick = "stub(arguments[0]);";
+		render(<div click={ click } onClick={ onclick } />, scratch);
+		let element = scratch.childNodes[0];
+		let ev = document.createEvent("MouseEvent");
+		ev.initMouseEvent("click");
+		expect(window.stub.called,"stub should not be called before click handler").to.equal(false);
+		element.dispatchEvent(ev);
+		expect(window.stub.called,"stub should be called from click handler").to.equal(true);
+		expect(window.stub, "click handler should be supplied event as argument").to.have.been.calledWithExactly(ev);
+		delete window.stub;
+	});
+
 	it('should add and remove event handlers', () => {
 		let click = sinon.spy(),
 			mousedown = sinon.spy();


### PR DESCRIPTION
This change allows on* handlers defined as strings to be correctly registered as listeners and handled by preact's EventProxy. 

For example, `render(<div onClick="console.log(arguments[0]);" />);` should allow the user to click on an element and see a console log of the MouseEvent that triggered it. 

This is particularly useful for parsing html that has been generated server side. 