### PR TITLE
Add default export for compatibility

### DIFF
--- a/src/preact.js
+++ b/src/preact.js
@@ -1,5 +1,21 @@
-export { h } from './h';
-export { Component } from './component';
-export { render } from './render';
-export { rerender } from './render-queue';
-export { default as options } from './options';
+import { h } from './h';
+import { Component } from './component';
+import { render } from './render';
+import { rerender } from './render-queue';
+import options from './options';
+
+export default {
+	h,
+	Component,
+	render,
+	rerender,
+	options
+};
+
+export {
+	h,
+	Component,
+	render,
+	rerender,
+	options
+};


### PR DESCRIPTION
For example, many people have `preact.h` as their pragma. They also configure their `eslint` config to ignore `preact` variable, because it's required for transforming `jsx`.

This PR makes it possible to import stuff like this(if you use `webpack-2`+ or `rollup`):

```js
import preact, { Component } from 'preact';
```

Which is exactly how you import `react`. Haven't found example of this in official react docs, but here it is in `react-native` docs(first lines of first code example): https://facebook.github.io/react-native/.

So tree-shaking will work for people who want it. They just won't use the default import. But it's still going to be possible to use for people, who need the `preact` variable if they use `webpack-2`+ or `rollup`.