### PR TITLE
Added child validation using strict render check

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -117,7 +117,8 @@ export function renderComponent(component, opts, mountAll) {
 			// set up high order component link
 
 			let inst = component._component;
-			if (inst && inst.constructor!==childComponent) {
+			let childRender = childComponent.prototype.render;
+			if (inst && !(inst.constructor===childComponent || inst.render===childRender)) {
 				toUnmount = inst;
 				inst = null;
 			}


### PR DESCRIPTION
When working on my new module [trixion](https://github.com/mrbar42/trixion), I saw this:
On consecutive renders, children are validated with a strict comparison to the child's constructor reference.

I try a method where the components can be object literals and if so they are converted to component class on the go whenever they are rendered.

Because the component constructor gets re-created - it breaks the comparison mechanism thus re-rendering the children every them.

This PR adds another mechanism where the render method is a validation options as well.
I figure that render strict ref is as good as constructor ref since they are both almost always composed solely for a given component.