### PR TITLE
🎨 Add built-in support for inline SVG

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -30,7 +30,7 @@ export function removeNode(node) {
  *	@param {any} previousValue	The last value that was set for this name/node pair
  *	@private
  */
-export function setAccessor(node, name, value) {
+export function setAccessor(node, name, value, isSvg) {
 	ensureNodeData(node)[name] = value;
 
 	if (name==='key' || name==='children') return;
@@ -44,7 +44,7 @@ export function setAccessor(node, name, value) {
 	else if (name==='dangerouslySetInnerHTML') {
 		if (value && value.__html) node.innerHTML = value.__html;
 	}
-	else if (name!=='type' && name in node) {
+	else if (!isSvg && name!=='type' && name in node) {
 		setProperty(node, name, empty(value) ? '' : value);
 		if (falsey(value)) node.removeAttribute(name);
 	}
@@ -55,11 +55,16 @@ export function setAccessor(node, name, value) {
 		else if (!value) node.removeEventListener(name, eventProxy);
 		l[name] = value;
 	}
-	else if (falsey(value)) {
-		node.removeAttribute(name);
-	}
-	else if (typeof value!=='object' && !isFunction(value)) {
-		node.setAttribute(name, value);
+	else {
+		let ns = isSvg && name.match(/^xlink\:?(.+)/);
+		if (falsey(value)) {
+			if (ns) node.removeAttributeNS('http://www.w3.org/1999/xlink', ns[1]);
+			else node.removeAttribute(name);
+		}
+		else if (typeof value!=='object' && !isFunction(value)) {
+			if (ns) node.setAttributeNS('http://www.w3.org/1999/xlink', ns[1], value);
+			else node.setAttribute(name, value);
+		}
 	}
 }
 

--- a/src/dom/recycler.js
+++ b/src/dom/recycler.js
@@ -14,10 +14,9 @@ export function collectNode(node) {
 }
 
 
-export function createNode(nodeName) {
+export function createNode(nodeName, isSvg) {
 	let name = toLowerCase(nodeName),
-		list = nodes[name],
-		node = list && list.pop() || document.createElement(nodeName);
+		node = nodes[name] && nodes[name].pop() || (isSvg ? document.createElementNS('http://www.w3.org/2000/svg', nodeName) : document.createElement(nodeName));
 	ensureNodeData(node);
 	node.normalizedNodeName = name;
 	return node;

--- a/test/browser/svg.js
+++ b/test/browser/svg.js
@@ -1,0 +1,45 @@
+import { h, render } from '../../src/preact';
+/** @jsx h */
+
+describe('svg', () => {
+	let scratch;
+
+	before( () => {
+		scratch = document.createElement('div');
+		(document.body || document.documentElement).appendChild(scratch);
+	});
+
+	beforeEach( () => {
+		scratch.innerHTML = '';
+	});
+
+	after( () => {
+		scratch.parentNode.removeChild(scratch);
+		scratch = null;
+	});
+
+	it('should render SVG to string', () => {
+		render((
+			<svg viewBox="0 0 360 360">
+				<path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z" />
+			</svg>
+		), scratch);
+
+		expect(scratch.innerHTML).to.equal(`
+			<svg viewBox="0 0 360 360">
+				<path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path>
+			</svg>
+		`.replace(/[\n\t]+/g,''));
+	});
+
+	it('should render SVG to DOM', () => {
+		const Demo = () => (
+			<svg viewBox="0 0 360 360">
+				<path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z" />
+			</svg>
+		);
+		render(<Demo />, scratch);
+
+		expect(scratch.innerHTML).to.equal('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>');
+	});
+});


### PR DESCRIPTION
It looks like around 3/4 of people wanted to merge SVG support into Preact itself.  I did a poor job of conveying the fact that there would actually be a massive size _savings_ for anyone using not only `preact-svg`, but actually also `preact-compat`, since it in turn pulls in `preact-svg` (to normalize for the fact that React ships SVG support by default).

Total added weight is `114 bytes`.