### PR TITLE
Add preact flow definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "minified:main": "dist/preact.min.js",
   "scripts": {
     "clean": "rimraf dist/",
-    "build": "npm-run-all clean transpile strip optimize minify size",
+    "copy-flow-definition": "cp src/preact.js.flow dist/preact.js.flow",
+    "build": "npm-run-all clean transpile copy-flow-definition strip optimize minify size",
     "transpile": "rollup -c rollup.config.js -m ${npm_package_dev_main}.map -f umd -n $npm_package_amdName $npm_package_jsnext_main -o $npm_package_dev_main",
     "optimize": "uglifyjs $npm_package_dev_main -c conditionals=false,sequences=false,loops=false,join_vars=false,collapse_vars=false --pure-funcs=Object.defineProperty -b width=120,quote_style=3 -o $npm_package_main -p relative --in-source-map ${npm_package_dev_main}.map --source-map ${npm_package_main}.map",
     "minify": "uglifyjs $npm_package_main -c screw_ie8,unsafe,loops=false,keep_fargs=false,pure_getters,unused,dead_code -m -o $npm_package_minified_main -p relative --in-source-map ${npm_package_dev_main}.map --source-map ${npm_package_minified_main}.map",

--- a/src/preact.js.flow
+++ b/src/preact.js.flow
@@ -1,0 +1,9 @@
+/* @flow */
+
+import { createElement as h, cloneElement, Component, render } from 'react';
+
+export { h, cloneElement, Component, render };
+export default { h, cloneElement, Component, render };
+
+declare export function rerender(): void;
+declare export var options: Object;


### PR DESCRIPTION
Because flow has special built-in support for React/JSX, we can piggy back on that by re-exporting everything from react in the preact flow definition (and also adding h = React.createElement).

I tested this out on my project and get correct errors for JSX property type mismatches and such!

for review @developit 

Fixes #219