### PR TITLE
Stop event listener from being added when event handler is null

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -51,8 +51,8 @@ export function setAccessor(node, name, value, isSvg) {
 	else if (name[0]==='o' && name[1]==='n') {
 		let l = node._listeners || (node._listeners = {});
 		name = toLowerCase(name.substring(2));
-		if (!l[name]) node.addEventListener(name, eventProxy);
-		else if (!value) node.removeEventListener(name, eventProxy);
+		if (!value && l[name]) node.removeEventListener(name, eventProxy);
+		else if (!l[name]) node.addEventListener(name, eventProxy);
 		l[name] = value;
 	}
 	else {


### PR DESCRIPTION
Hi,

I've discovered a minor problem with the removal of event listeners. More specifically this problem is triggered by replacing a component that has an event handler attribute with another component having no such handler. It turns out that in these cases `!l[name] == true` and `value == null` in setAccessor(), meaning that an event listener is added in this case. This leads to an error in eventProxy() since null is called as a function.

I've set up a simple example reproducing the behavior here: http://jsfiddle.net/jsLhf3Lz/. Hovering up & down the list of items should produce the error I've described here. Please excuse me if I simply misunderstood how this is supposed to work.