### PR TITLE
Support for Buble and Rollup

### DIFF
--- a/src/dom/recycler.js
+++ b/src/dom/recycler.js
@@ -1,5 +1,5 @@
 import { toLowerCase } from '../util';
-import { ensureNodeData, getNodeType, getRawNodeAttributes, removeNode } from '.';
+import { ensureNodeData, getNodeType, getRawNodeAttributes, removeNode } from './index';
 
 /** DOM node pool, keyed on nodeName. */
 

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -3,11 +3,11 @@ import options from '../options';
 import { isFunction, clone, extend, empty } from '../util';
 import { hook, deepHook } from '../hooks';
 import { enqueueRender } from '../render-queue';
-import { getNodeProps } from '.';
+import { getNodeProps } from './index';
 import { diff, removeOrphanedChildren, recollectNodeTree } from './diff';
 import { isFunctionalComponent, buildFunctionalComponent } from './functional-component';
 import { createComponent, collectComponent } from './component-recycler';
-import { removeNode } from '../dom';
+import { removeNode } from '../dom/index';
 
 
 /** Mark component as dirty and queue up a render.

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -129,7 +129,7 @@ function innerDiffNode(dom, vchildren, context, mountAll) {
 	if (vlen) {
 		for (let i=0; i<vlen; i++) {
 			let vchild = vchildren[i],
-				child;
+				child = null;
 
 			// if (isFunctionalComponent(vchild)) {
 			// 	vchild = buildFunctionalComponent(vchild);

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,10 +1,10 @@
 import { ATTR_KEY } from '../constants';
 import { toLowerCase, empty, isString, isFunction } from '../util';
 import { hook, deepHook } from '../hooks';
-import { isSameNodeType, isNamedNode } from '.';
+import { isSameNodeType, isNamedNode } from './index';
 import { isFunctionalComponent, buildFunctionalComponent } from './functional-component';
 import { buildComponentFromVNode } from './component';
-import { removeNode, setAccessor, getRawNodeAttributes, getNodeType } from '../dom';
+import { removeNode, setAccessor, getRawNodeAttributes, getNodeType } from '../dom/index';
 import { createNode, collectNode } from '../dom/recycler';
 import { unmountComponent } from './component';
 

--- a/src/vdom/functional-component.js
+++ b/src/vdom/functional-component.js
@@ -1,5 +1,5 @@
 import { EMPTY, EMPTY_BASE } from '../constants';
-import { getNodeProps } from '.';
+import { getNodeProps } from './index';
 import { isFunction } from '../util';
 
 

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,6 +1,6 @@
 import { clone, extend, isString, toLowerCase } from '../util';
 import { isFunctionalComponent } from './functional-component';
-import { getNodeType } from '../dom';
+import { getNodeType } from '../dom/index';
 
 
 /** Check if two nodes are equivalent.


### PR DESCRIPTION
Hello. I had to make some very minor tweaks to get Preact working with Buble (Bublé?) and Rollup JS.

Most changes are tweaks to the imports. Rollup JS (without plugins) doesn't support NPM style implicit `index.js` files, so anywhere an `import blah from '.'` or `import blah from '../dom'` was used had to be tweaked. According to the Rollup JS author (and several bug reports suggesting this behaviour), implicit `index.js` files aren't part of the module import spec. Best I can tell he's right.

https://developer.mozilla.org/en/docs/web/javascript/reference/statements/import

As for Buble, there is one tiny change I made in `vdom/diff.js`. The variable `child` is an uninitialised variable inside a loop. It's possible for the variable never to be set before it's used, and sometimes carries the value from the prior iteration. This was causing JSX code to only ever output the last child node. i.e:

```jsx
render((
    <div id="foo">
        <div>Hello, world!</div>
        <div>How are you?</div>
        <div>Good</div>
    </div>
), document.body);
```

Would output this:

```html
<div id="foo">
    <div>Good</div>
</div>
```