### PR TITLE
Fix `ref` becoming null before `componentWillUnmount`.

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -247,7 +247,6 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 export function unmountComponent(component, remove) {
 	// console.log(`${remove?'Removing':'Unmounting'} component: ${component.constructor.name}`);
 
-	hook(component, '__ref', null);
 	hook(component, 'componentWillUnmount');
 
 	// recursively tear down & recollect high-order component children:
@@ -267,5 +266,6 @@ export function unmountComponent(component, remove) {
 
 	}
 
+	hook(component, '__ref', null);
 	hook(component, 'componentDidUnmount');
 }


### PR DESCRIPTION
Hi @developit!

While checking `preact` with my big app I found this issue:

```es6
class TestUnmount extends React.Component {
	componentWillUnmount() {
		console.assert(
			this.refs.works,
			'`works` points to a DOM-element as it should'
		)

		console.assert(
			this.refs.breaks,
			'`breaks` should point to a DOM-element but contains null'
		)
	}

	render() {
		return (
			<div ref="breaks">
				<div ref="works" />
			</div>
		)
	}
}
```

EDIT: ~~I moved the hook which nullifies `ref` to be executed just before the `componentDidUnmount` hook to solve this issue.~~

Sorry, looks like I've been checking the fix with ```React``` instead of ```preact```. It doesn't resolve the issue.

P.S. nevertheless, by looking at the code I found a function call responsible for this issue:
https://github.com/developit/preact/blob/master/src/vdom/component.js#L265

Looks like `removeOrphanedChildren` nullifies nodes before the `componentWillUnmount`. By disabling this call I was able to evade the issue but I don't know all ins and outs, your assistance would be very much appreciated.