### PR TITLE
Improving performance by making direct calls to hook objects

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,4 @@
 import { FORCE_RENDER } from './constants';
-import { hook } from './hooks';
 import { extend, clone, isFunction } from './util';
 import { createLinkedState } from './linked-state';
 import { triggerComponentRender, renderComponent } from './vdom/component';
@@ -26,7 +25,7 @@ export function Component(props, context) {
 	/** @type {object} */
 	this.props = props;
 	/** @type {object} */
-	this.state = hook(this, 'getInitialState') || {};
+	this.state = this.getInitialState && this.getInitialState() || {};
 }
 
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -3,13 +3,5 @@ import options from './options';
 
 /** Invoke a hook on the `options` export. */
 export function optionsHook(name, a) {
-	return hook(options, name, a);
-}
-
-
-/** Invoke a "hook" method with arguments if it exists.
- *	@private
- */
-export function hook(obj, name, a, b, c) {
-	if (obj[name]) return obj[name](a, b, c);
+	if (options[name]) return options[name](a);
 }

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -1,7 +1,6 @@
 import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER, EMPTY_BASE, ATTR_KEY } from '../constants';
 import options from '../options';
 import { isFunction, clone, extend, empty } from '../util';
-import { hook } from '../hooks';
 import { enqueueRender } from '../render-queue';
 import { getNodeProps } from './index';
 import { diff, mounts, diffLevel, flushMounts, removeOrphanedChildren, recollectNodeTree } from './diff';
@@ -38,9 +37,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 	if ((component.__key = props.key)) delete props.key;
 
 	if (empty(b) || mountAll) {
-		if (component.componentWillMount) {
-			component.componentWillMount();
-		}
+		if (component.componentWillMount) component.componentWillMount();
 	}
 	else if (component.componentWillReceiveProps) {
 		component.componentWillReceiveProps(props, context);
@@ -65,9 +62,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 		}
 	}
 
-	if (component.__ref) {
-		component.__ref(component);
-	}
+	if (component.__ref) component.__ref(component);
 }
 
 
@@ -115,9 +110,7 @@ export function renderComponent(component, opts, mountAll) {
 	component._dirty = false;
 
 	if (!skip) {
-		if (component.render) {
-			rendered = component.render(props, state, context);
-		}
+		if (component.render) rendered = component.render(props, state, context);
 
 		// context to pass to the child, can be updated via (grand-)parent component
 		if (component.getChildContext) {
@@ -256,9 +249,7 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 export function unmountComponent(component, remove) {
 	// console.log(`${remove?'Removing':'Unmounting'} component: ${component.constructor.name}`);
 
-	if (component.componentWillUnmount) {
-		component.componentWillUnmount();
-	}
+	if (component.componentWillUnmount) component.componentWillUnmount();
 
 	// recursively tear down & recollect high-order component children:
 	let inner = component._component;
@@ -270,8 +261,8 @@ export function unmountComponent(component, remove) {
 		if (base) {
 			component.nextBase = base;
 			component.base = null;
-
-			if (base[ATTR_KEY]) hook(base[ATTR_KEY], 'ref', null);
+			const baseRef = base[ATTR_KEY];
+			if (baseRef && baseRef.ref) baseRef.ref(null);
 			if (remove) {
 				removeNode(base);
 				collectComponent(component);
@@ -281,10 +272,6 @@ export function unmountComponent(component, remove) {
 
 	}
 
-	if (component.__ref) {
-		component.__ref(null);
-	}
-	if (component.componentDidUnmount) {
-		component.componentDidUnmount();
-	}
+	if (component.__ref) component.__ref(null);
+	if (component.componentDidUnmount) component.componentDidUnmount();
 }

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,6 +1,5 @@
 import { ATTR_KEY } from '../constants';
 import { toLowerCase, empty, isString, isFunction } from '../util';
-import { hook } from '../hooks';
 import { isSameNodeType, isNamedNode } from './index';
 import { isFunctionalComponent, buildFunctionalComponent } from './functional-component';
 import { buildComponentFromVNode } from './component';
@@ -21,9 +20,7 @@ let isSvgMode = false;
 export function flushMounts() {
 	let c;
 	while ((c=mounts.pop())) {
-		if (c.componentDidMount) {
-			c.componentDidMount();
-		}
+		if (c.componentDidMount) c.componentDidMount();
 	}
 }
 
@@ -214,7 +211,8 @@ export function recollectNodeTree(node, unmountOnly) {
 		unmountComponent(component, !unmountOnly);
 	}
 	else {
-		if (node[ATTR_KEY]) hook(node[ATTR_KEY], 'ref', null);
+		const nodeRef = node[ATTR_KEY];
+		if (nodeRef && nodeRef.ref) nodeRef.ref(null);
 
 		if (!unmountOnly) {
 			if (getNodeType(node)!==1) {

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -20,7 +20,11 @@ let isSvgMode = false;
 
 export function flushMounts() {
 	let c;
-	while ((c=mounts.pop())) hook(c, 'componentDidMount');
+	while ((c=mounts.pop())) {
+		if (c.componentDidMount) {
+			c.componentDidMount();
+		}
+	}
 }
 
 


### PR DESCRIPTION
![roadhog_paris___overwatch_by_plank_69-d9apg7f](https://cloud.githubusercontent.com/assets/177491/16935220/9ceda79a-4d2b-11e6-8a88-c25b0920107d.jpg)

So I was profiling preact in uibench and one of the top hot areas is calling the **hook** function.

## [Inferno](https://github.com/trueadm/inferno/blob/61ab85c780b0e4938f8f8166bdbeb9f918cde5e4/src/DOM/utils.js#L247)
```javascript
if (!isNullOrUndefined(hooks.created)) {
  hooks.created(dom);
}
```
## [Preact](https://github.com/developit/preact/blob/master/src/hooks.js#L14)
```javascript
export function hook(obj, name, a, b, c) {
	if (obj[name]) return obj[name](a, b, c);
}
// ...
if (empty(b) || mountAll) {
	hook(component, 'componentWillMount');
}
```

In inferno each place that calls a hook does its own if check and calls the hook via a dot call. Its unclear to me if its the extra function call or its the dot notation vs bracket lookup that's the issue here but I swapped out preact's implementation for the style inferno's doing and we seem to be getting a 5-10% speed bump. 

Other small note I left the hook calls that were weirder to me. Like the options hook stuff and the ATTR hook stuff. Wasnt clear if I could cleanly swap them out for dot calls.

# Bench: Left Column my branch. Right is master
![ui benchmark](https://cloud.githubusercontent.com/assets/177491/16934770/a0817520-4d27-11e6-8469-68f2dfbd549c.png)
