### PR TITLE
improve typings, install via typings cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "5.6.0",
   "description": "Tiny & fast Component-based virtual DOM framework.",
   "main": "dist/preact.js",
-  "typings": "src/preact.d.ts",
   "jsnext:main": "src/preact.js",
   "dev:main": "dist/preact.dev.js",
   "minified:main": "dist/preact.min.js",

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,5 @@
+{
+  "name": "preact",
+  "main": "src/preact.d.ts",
+  "version": false
+}


### PR DESCRIPTION
this will allow preact typings to be installed globally via typings cli
`typings install github:developit/preact --global`

the reason to do it is that JSX typings will not work if they are not global

the next step would be to add a reference in typings/registry