### PR TITLE
Fix to allow props & context in componentWillMount

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -37,22 +37,22 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 	if ((component.__key = props.key)) delete props.key;
 
 	if (empty(b) || mountAll) {
-  component.context = context;
-  component.props = props;
+		component.context = context;
+		component.props = props;
 		if (component.componentWillMount) component.componentWillMount();
 	} else {
-	 if (component.componentWillReceiveProps) {
-		 component.componentWillReceiveProps(props, context);
-	 }
+		if (component.componentWillReceiveProps) {
+			component.componentWillReceiveProps(props, context);
+		}
 
- 	if (context && context!==component.context) {
-	 	if (!component.prevContext) component.prevContext = component.context;
-		 component.context = context;
- 	}
+		if (context && context!==component.context) {
+			if (!component.prevContext) component.prevContext = component.context;
+			component.context = context;
+		}
 
-	 if (!component.prevProps) component.prevProps = component.props;
- 	component.props = props;
- }
+		if (!component.prevProps) component.prevProps = component.props;
+		component.props = props;
+	}
 	component._disableRendering = false;
 
 	if (opts!==NO_RENDER) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -37,20 +37,22 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 	if ((component.__key = props.key)) delete props.key;
 
 	if (empty(b) || mountAll) {
+  component.context = context;
+  component.props = props;
 		if (component.componentWillMount) component.componentWillMount();
-	}
-	else if (component.componentWillReceiveProps) {
-		component.componentWillReceiveProps(props, context);
-	}
+	} else {
+	 if (component.componentWillReceiveProps) {
+		 component.componentWillReceiveProps(props, context);
+	 }
 
-	if (context && context!==component.context) {
-		if (!component.prevContext) component.prevContext = component.context;
-		component.context = context;
-	}
+ 	if (context && context!==component.context) {
+	 	if (!component.prevContext) component.prevContext = component.context;
+		 component.context = context;
+ 	}
 
-	if (!component.prevProps) component.prevProps = component.props;
-	component.props = props;
-
+	 if (!component.prevProps) component.prevProps = component.props;
+ 	component.props = props;
+ }
 	component._disableRendering = false;
 
 	if (opts!==NO_RENDER) {


### PR DESCRIPTION
I found that I was unable to access `this.context` from within `componentWillMount()`, and made the patch below.

I am not sure if this introduces differences vs React but I was unable to build a contextual component that functions like the following without the patch:

 ```
componentWillMount() {
 this.context.form.registerField(this);
}
componentWillUnmount() {
 this.context.form.unregisterField(this);
}

```







