### PR TITLE
Correct jsnext:main

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,8 +1,13 @@
+import fs from 'fs';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
 import memory from 'rollup-plugin-memory';
 
+const pkg = JSON.parse(fs.readFileSync('./package.json'));
+
 export default {
+	entry: 'src/preact',
+	sourceMap: true,
 	exports: 'named',
 	useStrict: false,
 	plugins: [
@@ -19,5 +24,9 @@ export default {
 			blacklist: ['es6.tailCall'],
 			exclude: 'node_modules/**'
 		})
+	],
+	targets: [
+		{ dest: pkg['dev:main'], format: 'umd', moduleName: pkg.amdName },
+		{ dest: pkg.module, format: 'es' }
 	]
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "5.6.0",
   "description": "Tiny & fast Component-based virtual DOM framework.",
   "main": "dist/preact.js",
-  "jsnext:main": "src/preact.js",
+  "jsnext:main": "dist/preact.es.js",
+  "module": "dist/preact.es.js",
   "dev:main": "dist/preact.dev.js",
   "minified:main": "dist/preact.min.js",
   "scripts": {
@@ -12,7 +13,7 @@
     "copy-flow-definition": "cp src/preact.js.flow dist/preact.js.flow",
     "copy-typescript-definition": "cp src/preact.d.ts dist/preact.d.ts",
     "build": "npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size",
-    "transpile": "rollup -c config/rollup.config.js -m ${npm_package_dev_main}.map -f umd -n $npm_package_amdName $npm_package_jsnext_main -o $npm_package_dev_main",
+    "transpile": "rollup -c config/rollup.config.js",
     "optimize": "uglifyjs $npm_package_dev_main -c conditionals=false,sequences=false,loops=false,join_vars=false,collapse_vars=false --pure-funcs=Object.defineProperty -b width=120,quote_style=3 -o $npm_package_main -p relative --in-source-map ${npm_package_dev_main}.map --source-map ${npm_package_main}.map",
     "minify": "uglifyjs $npm_package_main -c collapse_vars,evaluate,screw_ie8,unsafe,loops=false,keep_fargs=false,pure_getters,unused,dead_code -m -o $npm_package_minified_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_minified_main}.map",
     "strip": "jscodeshift --run-in-band -s -t config/codemod-strip-tdz.js dist/preact.dev.js && jscodeshift --run-in-band -s -t config/codemod-const.js dist/preact.dev.js",


### PR DESCRIPTION
According to jsforum/jsforum#5 jsnext:main should contain the transpiled version with the exception of ES6 modules.

Similar to developit/preact-compat#144 however the build process here is slightly different.
