### PR TITLE
Faster if a little more verbose case insensitive 'on' match

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -54,7 +54,7 @@ export function setAccessor(node, name, value, old, isSvg) {
 	else if (name==='dangerouslySetInnerHTML') {
 		if (value) node.innerHTML = value.__html;
 	}
-	else if (name.match(/^on/i)) {
+	else if ((name[0] === 'o' || name[0] === 'O') && (name[1] === 'n' || name[1] === 'N')) {
 		let l = node._listeners || (node._listeners = {});
 		name = toLowerCase(name.substring(2));
 		if (value) {


### PR DESCRIPTION
See: https://jsfiddle.net/c2h5oh/rr9b6Leb/1/

string.match: 3,418,862 ops/sec ±2.79% 
char compare: 38,104,121 ops/sec ±2.67%