### PR TITLE
fix: isSameNodeType between Component and real DOM

### DIFF
--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,5 +1,6 @@
 import { clone, extend, isString, isFunction, toLowerCase } from '../util';
 import { isFunctionalComponent } from './functional-component';
+import { buildComponentFromVNode } from './component';
 import { getNodeType } from '../dom/index';
 
 
@@ -16,7 +17,9 @@ export function isSameNodeType(node, vnode) {
 		return isNamedNode(node, vnode.nodeName);
 	}
 	if (isFunction(vnode.nodeName)) {
-		return node._componentConstructor===vnode.nodeName || isFunctionalComponent(vnode);
+		return node._componentConstructor===vnode.nodeName
+			|| isNamedNode(node, buildComponentFromVNode(null, vnode).nodeName)
+			|| isFunctionalComponent(vnode);
 	}
 }
 


### PR DESCRIPTION
This might be an solution of #260 fixing rendering Component with merge.

`isSameNodeType` in `innerDiffNode` (`src/vdom/diff.js` [line 170](https://github.com/developit/preact/blob/master/src/vdom/diff.js#L170)) return `false` in this use case:

```html
<div id="my-app">
  <p id="before">Before</p>
  <p id="cmp" className="my-cmp">Cmp</p>
  <p id="after">After</p>
</div>
```

```jsx
class Cmp extends Component {
  render() {
    return <p id="cmp" className="my-cmp">Cmp</p>;
  }
}

class App extends Component {
  render() {
    return (<div id="my-app">
      <p id="before">Before</p>
      <Cmp />
      <p id="after">After</p>
    </div>);
  }
}
render(
  <App />,
  document.body,
  document.getElementById('my-app')
);
```

`isSameNodeType` between `p#cmp` and `<Cmp>` SHOULD be `TRUE`.
