### PR TITLE
Added support for children that may be arrays.

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -16,7 +16,7 @@ const SHARED_TEMP_ARRAY = [];
  */
 export function h(nodeName, attributes, firstChild) {
 	let len = arguments.length,
-		children, arr, lastSimple;
+		children, arr, lastSimple, lastSimple2;
 
 
 	if (len>2) {
@@ -35,10 +35,24 @@ export function h(nodeName, attributes, firstChild) {
 				else (arr = SHARED_TEMP_ARRAY)[0] = p;
 				for (let j=0; j<arr.length; j++) {
 					let child = arr[j],
-						simple = !(falsey(child) || isFunction(child) || child instanceof VNode);
+						simple = !(falsey(child) || isFunction(child) || child instanceof VNode || child.join);
 					if (simple && !isString(child)) child = String(child);
 					if (simple && lastSimple) {
 						children[children.length-1] += child;
+					}
+					else if (child.join) {
+						let arr2 = child;
+						for (let k = 0; k < arr2.length; k++) {
+							let child2 = arr2[k],
+								simple2 = !(falsey(child2) || isFunction(child2) || child2 instanceof VNode);
+							if (simple2 && !isString(child2)) child2 = String(child2);
+							if (simple2 && lastSimple2)
+								children[children.length - 1] += child2;
+							else if (!falsey(child2)) {
+								children.push(child2);
+								lastSimple2 = simple;
+							}
+						}
 					}
 					else if (!falsey(child)) {
 						children.push(child);


### PR DESCRIPTION
I encountered this scenario when trying to use preact and preact-compat with radium (https://github.com/FormidableLabs/radium). For whatever reason, when rendering radium-enhanced components, sometimes the child components aren't `simple` or `VNode` or `function`, but instead are 1-element arrays with the first element being `simple` or `VNode`. 

When that is the case, the array is evaluated as a string and rendered as [Object Object] where you would normally expect the component markup to be. The code in this PR attempts to detect the array, then effectively flatten it and add the elements to the children collection.

While the code I've added in this PR "works", it's terribly ugly and may have unintended side effects. So while I'm submitting a PR, I'm mostly trying to bring awareness to the issue and hoping that a more elegant solution can be implemented by someone with better skills/understanding of preact.