### PR TITLE
Added check for component.__ref as function.

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -62,7 +62,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 		}
 	}
 
-	if (component.__ref) component.__ref(component);
+	if (component.__ref && isFunction(component.__ref)) component.__ref(component);
 }
 
 
@@ -274,6 +274,6 @@ export function unmountComponent(component, remove) {
 		removeOrphanedChildren(base.childNodes, !remove);
 	}
 
-	if (component.__ref) component.__ref(null);
+	if (component.__ref && isFunction(component.__ref)) component.__ref(null);
 	if (component.componentDidUnmount) component.componentDidUnmount();
 }


### PR DESCRIPTION
I'm trying to migrate a code base from react to preact and encountered instances where `component.__ref` was a string value and not a function, thereby resulting in `component.__ref is not a function` errors. 

The fix in this PR seemed to fix the problem, but hopefully there aren't unintended consequences of `.__ref` not being a function.