### PR TITLE
Install missing dependency for npm t

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.24",
     "chai": "^3.4.1",
+    "diff": "^3.0.0",
     "eslint": "^3.0.0",
     "eslint-plugin-react": "^6.0.0",
     "gzip-size-cli": "^1.0.0",


### PR DESCRIPTION
When running `npm t`, I got the following error:

```
Error loading module mocha!
You have enabled diff output. That only works with karma-mocha and mocha installed!
Run the following command in your command line:
  npm install karma-mocha mocha diff
```

So I ran 

`npm install --save-dev karma-mocha mocha diff`

and it turns out `diff` was missing from package.json.