### PR TITLE
Ensure node data for refs on pre-rendered nodes with no attributes

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -3,8 +3,8 @@ import options from '../options';
 import { toLowerCase, empty, falsey, isString, isFunction } from '../util';
 
 
-export function ensureNodeData(node, data) {
-	return node[ATTR_KEY] || (node[ATTR_KEY] = (data || {}));
+export function ensureNodeData(node, data={}) {
+	return node[ATTR_KEY] || (node[ATTR_KEY] = data);
 }
 
 
@@ -31,7 +31,7 @@ export function removeNode(node) {
  *	@private
  */
 export function setAccessor(node, name, value, old, isSvg) {
-	ensureNodeData(node)[name] = value;
+	node[ATTR_KEY][name] = value;
 
 	if (name==='key' || name==='children' || name==='innerHTML') return;
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -237,9 +237,8 @@ export function recollectNodeTree(node, unmountOnly) {
 
 /** Apply differences in attributes from a VNode to the given DOM Node. */
 function diffAttributes(dom, attrs) {
-	ensureNodeData(dom);
-
 	const old = dom[ATTR_KEY] || getRawNodeAttributes(dom);
+	ensureNodeData(dom);
 
 	// removeAttributes(dom, old, attrs || EMPTY);
 	for (let name in old) {

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -3,7 +3,7 @@ import { empty, isString, isFunction } from '../util';
 import { isSameNodeType, isNamedNode } from './index';
 import { isFunctionalComponent, buildFunctionalComponent } from './functional-component';
 import { buildComponentFromVNode } from './component';
-import { setAccessor, getRawNodeAttributes, getNodeType } from '../dom/index';
+import { setAccessor, getRawNodeAttributes, getNodeType, ensureNodeData } from '../dom/index';
 import { createNode, collectNode } from '../dom/recycler';
 import { unmountComponent } from './component';
 
@@ -105,6 +105,7 @@ function idiff(dom, vnode, context, mountAll, rootComponent) {
 	diffAttributes(out, vnode.attributes);
 
 	if (originalAttributes && originalAttributes.ref) {
+		ensureNodeData(out);
 		(out[ATTR_KEY].ref = originalAttributes.ref)(out);
 	}
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -105,7 +105,6 @@ function idiff(dom, vnode, context, mountAll, rootComponent) {
 	diffAttributes(out, vnode.attributes);
 
 	if (originalAttributes && originalAttributes.ref) {
-		ensureNodeData(out);
 		(out[ATTR_KEY].ref = originalAttributes.ref)(out);
 	}
 
@@ -238,7 +237,9 @@ export function recollectNodeTree(node, unmountOnly) {
 
 /** Apply differences in attributes from a VNode to the given DOM Node. */
 function diffAttributes(dom, attrs) {
-	let old = dom[ATTR_KEY] || getRawNodeAttributes(dom);
+	ensureNodeData(dom);
+
+	const old = dom[ATTR_KEY] || getRawNodeAttributes(dom);
 
 	// removeAttributes(dom, old, attrs || EMPTY);
 	for (let name in old) {

--- a/test/browser/refs.js
+++ b/test/browser/refs.js
@@ -284,4 +284,21 @@ describe('refs', () => {
 		expect(inst.handleMount.firstCall).to.have.been.calledWith(null);
 		expect(inst.handleMount.secondCall).to.have.been.calledWith(scratch.querySelector('#div'));
 	});
+
+	it('should add refs to components representing DOM nodes with no attributes if they have been pre-rendered', () => {
+		// Simulate pre-render
+		const parent = document.createElement('div');
+		const child = document.createElement('div');
+		parent.appendChild(child);
+		scratch.appendChild(parent); // scratch contains: <div><div></div></div>
+
+		let ref = spy('ref');
+
+		function Wrapper() {
+			return <div></div>;
+		}
+
+		render(<div><Wrapper ref={ref} /></div>, scratch, scratch.firstChild);
+		expect(ref).to.have.been.calledOnce.and.calledWith(scratch.firstChild.firstChild);
+	});
 });


### PR DESCRIPTION
I've come across an exception in diff.js where the node does not have the `[ATTR_KEY]` property, leading it to throw on this block of code near the end of the `idiff` function

```js
if (originalAttributes && originalAttributes.ref) {
    (out[ATTR_KEY].ref = originalAttributes.ref)(out);
}
```

The node may not have had `ensureNodeData` called on it because:
a) it has no attributes
b) the DOM node it's diffing against has been pre-rendered (and thus doesn't have an existing `[ATTR_KEY]` property)
c) there is an attempt to get a ref on the component for whom the node represents the root node

Here is the failing test case (a part of this PR):

```js
it('should add refs to components representing DOM nodes with no attributes if they have been pre-rendered', () => {
	// Simulate pre-render
	const parent = document.createElement('div');
	const child = document.createElement('div');
	parent.appendChild(child);
	scratch.appendChild(parent); // scratch contains: <div><div></div></div>

	let ref = spy('ref');

	function Wrapper() {
		return <div></div>;
	}

	render(<div><Wrapper ref={ref} /></div>, scratch, scratch.firstChild);
	expect(ref).to.have.been.calledOnce.and.calledWith(scratch.firstChild.firstChild);
});
```

But it passes if I make a small change by adding at least one attribute to the element:

```js
function Wrapper() {
	return <div class=""></div>;
}
```

The test case is slightly convoluted because it does not work if the node with the ref is the root node in the `render` function (hence the artificial component structure)

I'm not 100% sure the solution proposed in this PR is the best one, or if there is a more elegant way of describing the test case, but this PR fixes the issue.