### PR TITLE
allow input's list to pass through as an attribute

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -65,7 +65,7 @@ export function setAccessor(node, name, value, old, isSvg) {
 		}
 		l[name] = value;
 	}
-	else if (name!=='type' && !isSvg && name in node) {
+	else if (name!=='list' && name!=='type' && !isSvg && name in node) {
 		setProperty(node, name, empty(value) ? '' : value);
 		if (falsey(value)) node.removeAttribute(name);
 	}

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -396,4 +396,19 @@ describe('render()', () => {
 		expect(scratch.firstChild.firstChild).to.equal(b);
 		expect(scratch.firstChild.lastChild).to.equal(a);
 	});
+
+	// Discussion: https://github.com/developit/preact/issues/287
+	it('should allow <input list /> to pass through as an attribute', () => {
+		render((
+			<div>
+				<input type="range" min="0" max="100" step="50" list="steplist"/>
+				<datalist id="steplist">
+					<option>0</option>
+					<option>50</option>
+					<option>100</option>
+				</datalist>
+			</div>
+		), scratch);
+		expect(scratch.firstChild.firstChild).to.have.property('outerHTML', '<input type="range" min="0" max="100" step="50" list="steplist">');
+	});
 });


### PR DESCRIPTION
This PR should fix #287 so `list` can be passed through as an attribute since this specific DOM attribute becomes normalized as a ref to the HTMLElement itself.