### PR TITLE
Add a new demo [v2ex-preact]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ As one would expect coming from React, Components are simple building blocks for
 - [**Create your Own!**](https://jsfiddle.net/developit/rs6zrh5f/embedded/result/) (@ JSFiddle)
 - [**Preact Coffeescript**](https://github.com/crisward/preact-coffee)
 - [**GuriVR**](https://gurivr.com) _([Github Project](https://github.com/opennewslabs/guri-vr))_
+- [**V2EX Preact**](https://github.com/yanni4night/v2ex-preact)
 
 ## Libraries & Add-ons
 


### PR DESCRIPTION
May I add a new demo? [v2ex-preact](https://github.com/yanni4night/v2ex-preact), it proves that _preact_ could work with [redux](http://npm.im/redux)/[react-router](http://npm.im/react-router)/[react-redux](http://npm.im/react-redux)/[react-router-redux](http://npm.im/react-router-redux) perfectly. That's OK if not necessary.