### PR TITLE
Add support for single level of array children in h()

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -1,6 +1,6 @@
 import { VNode } from './vnode';
 import options from './options';
-import { falsey, isFunction, isString, hashToClassName } from './util';
+import { falsey, isFunction, isString, hashToClassName, toArray, flattenOnce } from './util';
 
 
 const SHARED_TEMP_ARRAY = [];
@@ -18,8 +18,10 @@ export function h(nodeName, attributes, firstChild) {
 	let len = arguments.length,
 		children, arr, lastSimple;
 
+	const flatChildren = flattenOnce(toArray(arguments, 2));
 
 	if (len>2) {
+		let firstChild = flatChildren[0];
 		let type = typeof firstChild;
 		if (len===3 && type!=='object' && type!=='function') {
 			if (!falsey(firstChild)) {
@@ -27,9 +29,10 @@ export function h(nodeName, attributes, firstChild) {
 			}
 		}
 		else {
+			let len = flatChildren.length;
 			children = [];
-			for (let i=2; i<len; i++) {
-				let p = arguments[i];
+			for (let i=0; i<len; i++) {
+				let p = flatChildren[i];
 				if (falsey(p)) continue;
 				if (p.join) arr = p;
 				else (arr = SHARED_TEMP_ARRAY)[0] = p;

--- a/src/h.js
+++ b/src/h.js
@@ -1,6 +1,6 @@
 import { VNode } from './vnode';
 import options from './options';
-import { falsey, isObject, isFunction, isString, hashToClassName, toArray, flattenOnce } from './util';
+import { falsey, isFunction, isString, hashToClassName, toArray, flattenOnce } from './util';
 
 
 const SHARED_TEMP_ARRAY = [];

--- a/src/h.js
+++ b/src/h.js
@@ -1,6 +1,6 @@
 import { VNode } from './vnode';
 import options from './options';
-import { falsey, isFunction, isString, hashToClassName, toArray, flattenOnce } from './util';
+import { falsey, isFunction, isString, hashToClassName } from './util';
 
 
 const SHARED_TEMP_ARRAY = [];
@@ -17,9 +17,21 @@ export function h(nodeName, attributes, firstChild) {
 	let outChildren, arr, lastSimple;
 
 	if (arguments.length > 2) {
-		const inChildren = flattenOnce(toArray(arguments, 2));
-		const firstChild = inChildren[0];
-		const type = typeof firstChild;
+		let inChildren = [];
+
+		// Flatten one layer of children.
+		for (let i=2, ilen=arguments.length; i < ilen; i++) {
+			if (Array.isArray(arguments[i])) {
+				for (let j=0, jlen=arguments[i].length; j < jlen; j++) {
+					inChildren.push(arguments[i][j]);
+				}
+			} else {
+				inChildren.push(arguments[i]);
+			}
+		}
+
+		let firstChild = inChildren[0];
+		let type = typeof firstChild;
 
 		if (inChildren.length === 1 && type!=='object' && type!=='function') {
 			if (!falsey(firstChild)) {
@@ -29,7 +41,7 @@ export function h(nodeName, attributes, firstChild) {
 		else {
 			outChildren = [];
 			for (let i=0, ilen=inChildren.length; i<ilen; i++) {
-				const p = inChildren[i];
+				let p = inChildren[i];
 	
 				if (falsey(p)) continue;
 				if (p.join) arr = p;

--- a/src/util.js
+++ b/src/util.js
@@ -81,21 +81,6 @@ export function hashToClassName(c) {
 	return str;
 }
 
-export function flattenOnce(arr) {
-	const out = [];
-
-	for (let i=0, ilen=arr.length; i < ilen; i++) {
-		if (Array.isArray(arr[i])) {
-			for (let j=0, jlen=arr[i].length; j < jlen; j++) {
-				out.push(arr[i][j]);
-			}
-		} else {
-			out.push(arr[i]);
-		}
-	}
-	return out;
-}
-
 /** Just a memoized String#toLowerCase */
 let lcCache = {};
 export const toLowerCase = s => lcCache[s] || (lcCache[s] = s.toLowerCase());

--- a/src/util.js
+++ b/src/util.js
@@ -81,6 +81,20 @@ export function hashToClassName(c) {
 	return str;
 }
 
+export function flattenOnce(arr) {
+	const out = [];
+
+	for (let i=0, ilen=arr.length; i < ilen; i++) {
+		if (Array.isArray(arr[i])) {
+			for (let j=0, jlen=arr[i].length; j < jlen; j++) {
+				out.push(arr[i][j]);
+			}
+		} else {
+			out.push(arr[i]);
+		}
+	}
+	return out;
+}
 
 /** Just a memoized String#toLowerCase */
 let lcCache = {};

--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 
 let flatten = obj => JSON.parse(JSON.stringify(obj));
 
-describe.only('h(jsx)', () => {
+describe('h(jsx)', () => {
 	it('should return a VNode', () => {
 		let r;
 		expect( () => r = h('foo') ).not.to.throw();

--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 
 let flatten = obj => JSON.parse(JSON.stringify(obj));
 
-describe('h(jsx)', () => {
+describe.only('h(jsx)', () => {
 	it('should return a VNode', () => {
 		let r;
 		expect( () => r = h('foo') ).not.to.throw();
@@ -43,12 +43,56 @@ describe('h(jsx)', () => {
 			]);
 	});
 
-	it('should support element children', () => {
+	it('should support multiple element children, given as arg list', () => {
 		let r = h(
 			'foo',
 			null,
 			h('bar'),
 			h('baz', null, h('test'))
+		);
+
+		r = flatten(r);
+
+		expect(r).to.be.an('object')
+			.with.property('children')
+			.that.deep.equals([
+				{ nodeName:'bar' },
+				{ nodeName:'baz', children:[
+					{ nodeName:'test' }
+				]}
+			]);
+	});
+
+	it('should handle multiple element children, given as an array', () => {
+		let r = h(
+			'foo',
+			null,
+			[
+				h('bar'),
+				h('baz', null, h('test'))
+			]
+		);
+
+		r = flatten(r);
+
+		expect(r).to.be.an('object')
+			.with.property('children')
+			.that.deep.equals([
+				{ nodeName:'bar' },
+				{ nodeName:'baz', children:[
+					{ nodeName:'test' }
+				]}
+			]);
+	});
+
+	it('should handle multiple children, flattening one layer as needed', () => {
+		let r = h(
+			'foo',
+			null,
+			h('bar'),
+			[
+				h('baz', null, h('test'))
+			]
 		);
 
 		r = flatten(r);
@@ -127,4 +171,5 @@ describe('h(jsx)', () => {
 				'onetwothreefourfivesix'
 			]);
 	});
+
 });

--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -171,5 +171,4 @@ describe('h(jsx)', () => {
 				'onetwothreefourfivesix'
 			]);
 	});
-
 });


### PR DESCRIPTION
Should be pretty straightforward: if any of the "...children" arguments passed to h() is an Array, flatten them once and iterate over the resulting array, rather than the raw arguments list. The 'core' algorithm doesn't change, other than referencing the new array.

Note that this commit _does_ introduce two extra Array allocations: once for `toArray` and again in `flattenOnce` (which returns a new Array which is the 'flattened' version of its parameter). If this is unacceptable, let me know and I'll keep tinkering with it.