### PR TITLE
fix instanceof not pointing to the right function

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -32,7 +32,7 @@ export default function h(nodeName, attributes) {
 			}
 			for (let j=0; j<arr.length; j++) {
 				let child = arr[j],
-					simple = !empty(child) && !(child instanceof VNode);
+					simple = !empty(child) && !(child.nodeName);
 				if (simple) child = String(child);
 				if (simple && lastSimple) {
 					children[children.length-1] += child;


### PR DESCRIPTION
This was pretty brutal to track down, but I was running into a situation where the dev version works, but the production version doesn't (vnode's get stringified into `[Object object]`).

While I'm not sure exactly the state of my build to produce that, I'm assuming that the VNode was created inside another instance of Preact so `child instanceof VNode` is false. Here's the build if you'd like to have a look: https://gist.github.com/matthewmueller/bca6d225cd15c95a61939c77f1bb8648

This is an example I used to recreate this issue:

```js
const { HTML, render } = require('vcom')
const { h } = require('preact')

function app () {
  // return another
  return HTML.div(h('div', {}, ['hi there!']))
}

render(app(), document.body)
```