### PR TITLE
regression:  serializing class={{ }} objects for SVG tags

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -28,11 +28,15 @@ export function setAccessor(node, name, value, old, isSvg) {
 
 	if (name==='className') name = 'class';
 
+	if (name==='class') {
+		value = value && typeof value==='object' ? hashToClassName(value) : value;
+	}
+
 	if (name==='key' || name==='children' || name==='innerHTML') {
 		// skip these
 	}
 	else if (name==='class' && !isSvg) {
-		node.className = value && typeof value==='object' ? hashToClassName(value) : value || '';
+		node.className = value || '';
 	}
 	else if (name==='style') {
 		if (!value || isString(value) || isString(old)) {

--- a/test/browser/svg.js
+++ b/test/browser/svg.js
@@ -86,6 +86,14 @@ describe('svg', () => {
 		expect(scratch.innerHTML).to.contain(` class="foo bar"`);
 	});
 
+	it('should serialize class', () => {
+		render((
+			<svg viewBox="0 0 1 1" class={{ foo: true, bar: false, other: 'hello' }} />
+		), scratch);
+
+		expect(scratch.innerHTML).to.contain(` class="foo other"`);
+	});
+
 	it('should switch back to HTML for <foreignObject>', () => {
 		render((
 			<svg>


### PR DESCRIPTION
e7c6ab6 broke serializing `class={{ }}` for SVG elements.  This fixes
that regression and does a little cleans up the logic a little bit.

I've also added a test verifying the proper behavior for SVG.