### PR TITLE
Add link to preact-layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ As one would expect coming from React, Components are simple building blocks for
 - :satellite: [**preact-portal**](https://git.io/preact-portal): Render Preact components into (a) SPACE :milky_way:
 - :construction: [**preact-classless-component**](https://github.com/ld0rman/preact-classless-component): A utility method to create components without the `class` keyword
 - :hammer: [**preact-hyperscript**](https://github.com/queckezz/preact-hyperscript): Hyperscript-like syntax for creating elements
+- :triangular_ruler: [**preact-layout**](https://download.github.io/preact-layout/): Small and simple layout library
 
 
 ## Getting Started


### PR DESCRIPTION
Thank you so much for creating Preact! I thoroughly enjoy working with it and the size reduce it's giving me. Also I'm almost exclusively writing pure functions now and not using preact-compat at all. It really makes the code a lot simpler too. So I'm hoping I can contribute to your efforts.

This PR adds an entry with a link to [preact-layout](httpsL//download.github.io/preact-layout) to the  `Libraries & Add-ons` section of `README.md`.

I noticed you already saw the project I've been working on and starred it on GitHub (thanks!). I just released 1.0.0 and I am hoping you will do me the honor of adding it to the list of libraries on the Preact website. I'm not sure if you accept PR's for that (or how to make one), so this one just adds it to the README of this repo. 

I'm quitte happy with it as it solves some of my layout issues I've been having ever since I started with React. I works a bit like preact-portal, but I'm doing server-side rendering and preact-portal does not support that (afaik?), so I thought up a different approach of pre-rendering part of the tree and inspecting the outcome to move components to the right section. The simplicity of Preact and it's component tree gave me the courage to try this approach and so far it's working well for me. The test coverage is still a bit slim but I intend to improve that when/as bug reports come in.