### PR TITLE
Correct "preact/devtools" type definitions

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -74,16 +74,13 @@ declare namespace preact {
 	};
 }
 
-declare namespace preactDevTools {
-	function initDevTools():void;
-}
-
 declare module "preact" {
 	export = preact;
 }
 
 declare module "preact/devtools" {
-	export = preactDevTools;
+	// Empty. This module initializes the React Developer Tools integration
+	// when imported.
 }
 
 declare namespace JSX {


### PR DESCRIPTION
The `initDevTools()` function was removed in favor of just initializing
the devtools integration when the "preact/devtools" module is imported.