### PR TITLE
Disable React Developer Tools integration tests under IE

### DIFF
--- a/test/browser/devtools.js
+++ b/test/browser/devtools.js
@@ -33,7 +33,13 @@ class MultiChild extends Component {
 	}
 }
 
-describe('React Developer Tools integration', () => {
+let describe_ = describe;
+if (!('name' in Function.prototype)) {
+	// Skip these tests under Internet Explorer
+	describe_ = describe.skip;
+}
+
+describe_('React Developer Tools integration', () => {
 	let cleanup;
 	let container;
 	let renderer;


### PR DESCRIPTION
Disable React Developer Tools integration tests under IE

Developer tools integration is currently not supported in Internet
Explorer. The immediate issue is that Function.name is not supported,
though there may be other issues as well.
