### PR TITLE
clear src= on recycled <img>s

### DIFF
--- a/src/dom/recycler.js
+++ b/src/dom/recycler.js
@@ -1,3 +1,4 @@
+import { ATTR_KEY } from '../constants';
 import { toLowerCase } from '../util';
 import { removeNode } from './index';
 
@@ -9,6 +10,10 @@ export function collectNode(node) {
 	removeNode(node);
 
 	if (node instanceof Element) {
+		if (node.nodeName === 'IMG') {
+			node.src = node[ATTR_KEY].src = '';
+		}
+
 		node._component = node._componentConstructor = null;
 
 		let name = node.normalizedNodeName || toLowerCase(node.nodeName);

--- a/src/dom/recycler.js
+++ b/src/dom/recycler.js
@@ -11,7 +11,12 @@ export function collectNode(node) {
 
 	if (node instanceof Element) {
 		if (node.nodeName === 'IMG') {
-			node.src = node[ATTR_KEY].src = '';
+			node.removeAttribute ('src');
+			delete node[ATTR_KEY].src;
+		}
+		if (node.nodeName === 'IMAGE') {
+			node.removeAttributeNS ('http://www.w3.org/1999/xlink', 'href');
+			delete node[ATTR_KEY].xlinkhref;
 		}
 
 		node._component = node._componentConstructor = null;


### PR DESCRIPTION
This solves #351.  This will resets the `src` attribute to blank (`''`).  This is because most browsers will keeps displaying old image until the new one has loaded.

I've tested with a few other media-related attributes:  `<video src=>`, `<audio src=>`, and `<object data=>`.  None of them appear to care about previous attribute values.  I have not tested the SVG `<image xlink:href=>` attribute, it might also need a similar workaround.

I've closed my old PR, #353, in order to clean things up a bit with git.
