### PR TITLE
Fix CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "karma-mocha": "^1.1.1",
     "karma-mocha-reporter": "^2.0.4",
     "karma-phantomjs-launcher": "^1.0.1",
-    "karma-sauce-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.1.0",
     "karma-source-map-support": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.6",
     "karma-webpack": "^1.7.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -21,6 +21,11 @@ var sauceLabsLaunchers = {
 		browserName: 'safari',
 		platform: 'OS X 10.11'
 	},
+	sl_edge: {
+		base: 'SauceLabs',
+		browserName: 'MicrosoftEdge',
+		platform: 'Windows 10'
+	},
 	sl_ie_11: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,6 +16,11 @@ var sauceLabsLaunchers = {
 		browserName: 'firefox',
 		platform: 'Windows 10'
 	},
+	sl_safari: {
+		base: 'SauceLabs',
+		browserName: 'safari',
+		platform: 'OS X 10.11'
+	},
 	sl_ie_11: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -8,32 +8,31 @@ var coverage = String(process.env.COVERAGE)!=='false',
 var sauceLabsLaunchers = {
 	sl_chrome: {
 		base: 'SauceLabs',
-		browserName: 'chrome'
+		browserName: 'chrome',
+		platform: 'Windows 10'
 	},
 	sl_firefox: {
 		base: 'SauceLabs',
-		browserName: 'firefox'
-	},
-	sl_ios_safari: {
-		base: 'SauceLabs',
-		browserName: 'iphone',
-		platform: 'OS X 10.9',
-		version: '7.1'
+		browserName: 'firefox',
+		platform: 'Windows 10'
 	},
 	sl_ie_11: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',
-		version: '11'
+		version: '11.103',
+		platform: 'Windows 10'
 	},
 	sl_ie_10: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',
-		version: '10'
+		version: '10.0',
+		platform: 'Windows 7'
 	},
 	sl_ie_9: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',
-		version: '9'
+		version: '9.0',
+		platform: 'Windows 7'
 	}
 };
 
@@ -68,6 +67,9 @@ module.exports = function(config) {
 		browserConsoleLogOptions: { terminal: true },
 
 		browserNoActivityTimeout: 5 * 60 * 1000,
+
+		// Use only two browsers concurrently, works better with open source Sauce Labs remote testing
+		concurrency: 2,
 
 		// sauceLabs: {
 		// 	tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('./package.json').version),


### PR DESCRIPTION
Hello.

I noticed that preact's Travis build is failing so I went on to investigate.

I discovered that the Sauce Labs integration is the problem.

The iPhone/iOS version that's been currently used is deprecated in the Sauce Labs platform. Besides that, the mobile browsers seems to take a lot longer to "boot" on Sauce Labs, which causes another problem:
 - The default timeout [karma-sauce-launcher](https://www.npmjs.com/package/karma-sauce-launcher) is providing is too low, causing the Sauce Labs tunnel to close before the mobile browser gets up and running.

I've seeing the same problem in my personal projects. In fact, there is an open [PR](https://github.com/karma-runner/karma-sauce-launcher/pull/99) suggesting the project to enable developers to set their own timeout of preference.

So I'm suggesting that we remove remote mobile testing for a while, until `karma-sauce-launcher` is OK to use for that purpose.

Also, I'm adding tests for two commonly used browsers: Desktop Safari and Edge.

The plan is to add iOS/Android as soon as it is possible with Karma.

I tested the changes of this PR and if you merge it, it should green the badge on README.
