### PR TITLE
Run only local tests for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,19 @@ cache:
   directories:
     - node_modules
 
+# Make chrome browser available for testing
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
 install:
   - npm install
 
 script:
   - npm run build
   - npm run test
-  - SAUCELABS=true COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
+  - BROWSER=true COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
 
 # Necessary to compile native modules for io.js v3 or Node.js v4
 env:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "karma-babel-preprocessor": "^5.2.2",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.5",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.0.0",
     "karma-mocha": "^1.1.1",
     "karma-mocha-reporter": "^2.0.4",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,8 +1,10 @@
 /*eslint no-var:0, object-shorthand:0 */
 
 var coverage = String(process.env.COVERAGE)!=='false',
-	sauceLabs = String(process.env.SAUCELABS).match(/^(1|true)$/gi) && !String(process.env.TRAVIS_PULL_REQUEST).match(/^(1|true)$/gi),
-	performance = !coverage && !sauceLabs && String(process.env.PERFORMANCE)!=='false',
+	pullRequest = !String(process.env.TRAVIS_PULL_REQUEST).match(/^(0|false|undefined)$/gi),
+	realBrowser = String(process.env.BROWSER).match(/^(1|true)$/gi),
+	sauceLabs = realBrowser && !pullRequest,
+	performance = !coverage && !realBrowser && String(process.env.PERFORMANCE)!=='false',
 	webpack = require('webpack');
 
 var sauceLabsLaunchers = {
@@ -46,9 +48,18 @@ var sauceLabsLaunchers = {
 	}
 };
 
+var travisLaunchers = {
+	chrome_travis: {
+		base: 'Chrome',
+		flags: ['--no-sandbox']
+	}
+};
+
+var localBrowsers = realBrowser ? Object.keys(travisLaunchers) : ['PhantomJS'];
+
 module.exports = function(config) {
 	config.set({
-		browsers: sauceLabs ? Object.keys(sauceLabsLaunchers) : ['PhantomJS'],
+		browsers: sauceLabs ? Object.keys(sauceLabsLaunchers) : localBrowsers,
 
 		frameworks: ['source-map-support', 'mocha', 'chai-sinon'],
 
@@ -86,7 +97,7 @@ module.exports = function(config) {
 		// 	startConnect: false
 		// },
 
-		customLaunchers: sauceLabsLaunchers,
+		customLaunchers: sauceLabs ? sauceLabsLaunchers : travisLaunchers,
 
 		files: [
 			{ pattern: 'polyfills.js', watched: false },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,9 +1,10 @@
 /*eslint no-var:0, object-shorthand:0 */
 
 var coverage = String(process.env.COVERAGE)!=='false',
+	ci = String(process.env.CI).match(/^(1|true)$/gi),
 	pullRequest = !String(process.env.TRAVIS_PULL_REQUEST).match(/^(0|false|undefined)$/gi),
 	realBrowser = String(process.env.BROWSER).match(/^(1|true)$/gi),
-	sauceLabs = realBrowser && !pullRequest,
+	sauceLabs = realBrowser && ci && !pullRequest,
 	performance = !coverage && !realBrowser && String(process.env.PERFORMANCE)!=='false',
 	webpack = require('webpack');
 


### PR DESCRIPTION
This PR is regarding the discussion #387.

From my understanding of [this article](https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables) from Travis Docs the TRAVIS_PULL_REQUEST env variable gets set to the current PR **number** if it is a build from a PR.

Considering we are using a RegExp expecting to match '1' or 'true' values in the TRAVIS_PULL_REQUEST variable the match will always be false.

That said lets simply check for falses, if it is 'false' (not a PR) we use PhantomJS else we use Sauce Labs browsers.