### PR TITLE
feat: add an attribute hook (WIP)

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -15,6 +15,6 @@ import { diff } from './vdom/diff';
  *	const Thing = ({ name }) => <span>{ name }</span>;
  *	render(<Thing name="one" />, document.querySelector('#foo'));
  */
-export function render(vnode, parent, merge) {
-	return diff(merge, vnode, {}, false, parent);
+export function render(vnode, parent, merge, options) {
+	return diff(merge, vnode, {}, false, parent, false, options);
 }

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -103,9 +103,7 @@ function idiff(dom, vnode, context, mountAll, options) {
 	let props = out[ATTR_KEY];
 	if (!props) {
 		out[ATTR_KEY] = props = {};
-		for (let a=out.attributes, i=a.length; i--; ) {
-			props[a[i].name] = a[i].value;
-		}
+		for (let a=out.attributes, i=a.length; i--; ) props[a[i].name] = a[i].value;
 	}
 
 	if (vnode && vnode.attributes) {


### PR DESCRIPTION
This is a non-breaking change and the mirror of: https://github.com/developit/preact-render-to-string/pull/15

I wanted to get this out there early for feedback. It basically allows you to customize the attributes centrally from the renderer. 

Here's an example:

```js
root = preact.render(app, parent, root, {
  attributeValueHook (key, value) {
    // replace all classes values with 'replacement'
    if (key === 'class') {
      return 'replacement'
    }
  }
})
```

If this works for you, here's the remaining TODO:

- [ ] currently, you can't modify the `ref` attribute. 

> I don't really understand the relationship between `vnode.attributes` and `originalAttributes`, so I could use some help there, but ideally you could also modify the ref attribute (important for adding onMount, onUnmount hooks)

- [ ] add tests for the hook
- [ ] document the updated render function signature
