### PR TITLE
Rename DomAttributed typo to DomAttributes.

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -23,19 +23,12 @@ declare namespace preact {
 
 	interface ComponentLifecycle<PropsType, StateType> {
 		componentWillMount?():void;
-
 		componentDidMount?():void;
-
 		componentWillUnmount?():void;
-
 		componentDidUnmount?():void;
-
 		componentWillReceiveProps?(props:PropsType):void;
-
 		shouldComponentUpdate?(props:PropsType):boolean;
-
 		componentWillUpdate?():void;
-
 		componentDidUpdate?():void;
 	}
 
@@ -51,19 +44,14 @@ declare namespace preact {
 		base:HTMLElement;
 
 		linkState:(name:string) => void;
-
 		setState(state:StateType, opts?:any):void;
-
 		abstract render(props:PropsType & ComponentProps, state:any):JSX.Element;
 	}
 
 	function h<PropsType>(node:ComponentConstructor<PropsType, any>, params:PropsType, ...children:(JSX.Element|JSX.Element[]|string)[]):JSX.Element;
 	function h(node:string, params:JSX.HTMLAttributes&JSX.SVGAttributes&{[propName: string]: any}, ...children:(JSX.Element|JSX.Element[]|string)[]):JSX.Element;
-
 	function render(node:JSX.Element, parent:Element, mergeWith?:Element):Element;
-
 	function rerender():void;
-
 	function cloneElement(element:JSX.Element, props:any):JSX.Element;
 
 	var options:{
@@ -85,11 +73,9 @@ declare module "preact/devtools" {
 
 declare namespace JSX {
 	interface Element extends preact.VNode {
-
 	}
 
 	interface ElementClass extends preact.Component<any, any> {
-
 	}
 
 	interface ElementAttributesProperty {
@@ -173,10 +159,9 @@ declare namespace JSX {
 	type WheelEventHandler = EventHandler<WheelEvent>;
 	type AnimationEventHandler = EventHandler<AnimationEvent>;
 	type TransitionEventHandler = EventHandler<TransitionEvent>;
-
 	type GenericEventHandler = EventHandler<Event>;
 
-	interface DOMAttributed {
+	interface DOMAttributes {
 		// Clipboard Events
 		onCopy?:ClipboardEventHandler;
 		onCut?:ClipboardEventHandler;
@@ -269,7 +254,7 @@ declare namespace JSX {
 		onTransitionEnd?:TransitionEventHandler;
 	}
 
-	interface HTMLAttributes extends preact.PreactHTMLAttributes, DOMAttributed {
+	interface HTMLAttributes extends preact.PreactHTMLAttributes, DOMAttributes {
 		// Standard HTML Attributes
 		accept?:string;
 		acceptCharset?:string;


### PR DESCRIPTION
Removing extra lines for nicely sectionized .d.ts.

