### PR TITLE
Use SVG namespace comparison instead of instanceof

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -15,8 +15,9 @@ export const mounts = [];
 /** Diff recursion count, used to track the end of the diff cycle. */
 export let diffLevel = 0;
 
-let isSvgMode = false;
+const svgNamespace = "http://www.w3.org/2000/svg";
 
+let isSvgMode = false;
 
 export function flushMounts() {
 	let c;
@@ -34,7 +35,7 @@ export function flushMounts() {
  *	@private
  */
 export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
-	if (!diffLevel++) isSvgMode = parent instanceof SVGElement;
+	if (!diffLevel++) isSvgMode = parent && parent.namespaceURI === svgNamespace;
 	let ret = idiff(dom, vnode, context, mountAll);
 	if (parent && ret.parentNode!==parent) parent.appendChild(ret);
 	if (!--diffLevel && !componentRoot) flushMounts();

--- a/test/browser/svg.js
+++ b/test/browser/svg.js
@@ -56,6 +56,14 @@ describe('svg', () => {
 		expect(html).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 Z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 Z"></path></svg>'));
 	});
 
+	it('should render with the correct namespace URI', () => {
+		render(<svg />, scratch);
+
+		let namespace = scratch.querySelector('svg').namespaceURI;
+
+		expect(namespace).to.equal("http://www.w3.org/2000/svg");
+	});
+
 	it('should use attributes for className', () => {
 		const Demo = ({ c }) => (
 			<svg viewBox="0 0 360 360" {...(c ? {class:'foo_'+c} : {})}>


### PR DESCRIPTION
I'm having trouble testing with Jest because JSDOM does not implement SVGElement. This PR changes the SVG check to compare the namespace URI.