### PR TITLE
Run remote tests only when pushing to master

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,8 +3,9 @@
 var coverage = String(process.env.COVERAGE)!=='false',
 	ci = String(process.env.CI).match(/^(1|true)$/gi),
 	pullRequest = !String(process.env.TRAVIS_PULL_REQUEST).match(/^(0|false|undefined)$/gi),
+	masterBranch = String(process.env.TRAVIS_BRANCH).match(/^master$/gi),
 	realBrowser = String(process.env.BROWSER).match(/^(1|true)$/gi),
-	sauceLabs = realBrowser && ci && !pullRequest,
+	sauceLabs = realBrowser && ci && !pullRequest && masterBranch,
 	performance = !coverage && !realBrowser && String(process.env.PERFORMANCE)!=='false',
 	webpack = require('webpack');
 


### PR DESCRIPTION
Related to #424.

We now handle `TRAVIS_BRANCH` to decide whether we use Sauce Labs (remote) testing or not.

With this change, we will only use Sauce Labs if it is pushing to `master`.

We can only close the issue #424 once we know it is actually running Sauce Labs once we merge this PR.

Please let me know it looks good before we proceed.

Thanks!