### PR TITLE
Do not inner diff dangerouslySetInnerHTML.

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -152,17 +152,15 @@ function idiff(dom, vnode, context, mountAll) {
 	diffAttributes(out, vnode.attributes, props);
 
 
-	if (!props.dangerouslySetInnerHTML) {
-		// Optimization: fast-path for elements containing a single TextNode:
-		if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
-			if (fc.nodeValue!=vchildren[0]) {
-				fc.nodeValue = vchildren[0];
-			}
+	// Optimization: fast-path for elements containing a single TextNode:
+	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
+		if (fc.nodeValue!=vchildren[0]) {
+			fc.nodeValue = vchildren[0];
 		}
-		// otherwise, if there are existing or new children, diff them:
-		else if (vchildren && vchildren.length || fc) {
-			innerDiffNode(out, vchildren, context, mountAll);
-		}
+	}
+	// otherwise, if there are existing or new children, diff them:
+	else if ((vchildren && vchildren.length || fc) && !props.dangerouslySetInnerHTML) {
+		innerDiffNode(out, vchildren, context, mountAll);
 	}
 
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -152,15 +152,17 @@ function idiff(dom, vnode, context, mountAll) {
 	diffAttributes(out, vnode.attributes, props);
 
 
-	// Optimization: fast-path for elements containing a single TextNode:
-	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
-		if (fc.nodeValue!=vchildren[0]) {
-			fc.nodeValue = vchildren[0];
+	if (!props.dangerouslySetInnerHTML) {
+		// Optimization: fast-path for elements containing a single TextNode:
+		if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
+			if (fc.nodeValue!=vchildren[0]) {
+				fc.nodeValue = vchildren[0];
+			}
 		}
-	}
-	// otherwise, if there are existing or new children, diff them:
-	else if (vchildren && vchildren.length || fc) {
-		innerDiffNode(out, vchildren, context, mountAll);
+		// otherwise, if there are existing or new children, diff them:
+		else if (vchildren && vchildren.length || fc) {
+			innerDiffNode(out, vchildren, context, mountAll);
+		}
 	}
 
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -367,6 +367,15 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<div>'+html+'</div>');
 	});
 
+	it('should hydrate with dangerouslySetInnerHTML', () => {
+		let html = '<b>foo &amp; bar</b>';
+		scratch.innerHTML = `<div>${html}</div>`;
+		render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, scratch.lastChild);
+
+		expect(scratch.firstChild).to.have.property('innerHTML', html);
+		expect(scratch.innerHTML).to.equal(`<div>${html}</div>`);
+	});
+
 	it('should reconcile mutated DOM attributes', () => {
 		let check = p => render(<input type="checkbox" checked={p} />, scratch, scratch.lastChild),
 			value = () => scratch.lastChild.checked,


### PR DESCRIPTION
The children of a node with dangerouslySetInnerHTML should not be diffed because this will always cause all children to be removed.

I'm not sure if this is a good solution or not. Let me know what you think! 😺 