### PR TITLE
Dom mutation was not happening for elements with dangerouslySetInnerHTML.

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -306,7 +306,8 @@ export function recollectNodeTree(node, unmountOnly) {
  */
 function diffAttributes(dom, attrs, old) {
 	// remove attributes no longer present on the vnode by setting them to undefined
-	for (let name in old) {
+	let name;
+	for (name in old) {
 		if (!(attrs && name in attrs) && old[name]!=null) {
 			setAccessor(dom, name, old[name], old[name] = undefined, isSvgMode);
 		}
@@ -314,7 +315,7 @@ function diffAttributes(dom, attrs, old) {
 
 	// add new & update changed attributes
 	if (attrs) {
-		for (let name in attrs) {
+		for (name in attrs) {
 			if (
 				name!=='children' &&  // break if attributeName is children
 				name!=='innerHTML' &&  // break if attributeName is innerHTML

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -315,7 +315,17 @@ function diffAttributes(dom, attrs, old) {
 	// add new & update changed attributes
 	if (attrs) {
 		for (let name in attrs) {
-			if (name!=='children' && name!=='innerHTML' && (!(name in old) || attrs[name]!==(name==='value' || name==='checked' ? dom[name] : old[name]))) {
+			if (
+				name!=='children' &&  // break if attributeName is children
+				name!=='innerHTML' &&  // break if attributeName is innerHTML
+				(
+					( name=== 'dangerouslySetInnerHTML' ) || // continue if attributeName is dangerouslySetInnerHTML
+					(
+						!(name in old) ||  // continue if attr doesn't exists
+						attrs[name] !== (name==='value' || name==='checked' ? dom[name] : old[name]) // continue if attr is different
+					)
+				)
+			) {
 				setAccessor(dom, name, old[name], old[name] = attrs[name], isSvgMode);
 			}
 		}

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -378,7 +378,7 @@ describe('render()', () => {
 		existingEl[ATTR_KEY] = vdomEl.attributes; // For an element fetched from its element cache, ATTR_KEY will be set with previous state values.
 		diff( existingEl, vdomEl );
 		expect( existingEl.outerHTML ).to.equal('<div>'+html+'</div>');
-	})
+	});
 
 	it('should reconcile mutated DOM attributes', () => {
 		let check = p => render(<input type="checkbox" checked={p} />, scratch, scratch.lastChild),

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -1,6 +1,8 @@
 /* global DISABLE_FLAKEY */
 
 import { h, render, Component } from '../../src/preact';
+import { diff } from '../../src/vdom/diff';
+import { ATTR_KEY } from '../../src/constants';
 /** @jsx h */
 
 function getAttributes(node) {
@@ -366,6 +368,17 @@ describe('render()', () => {
 
 		expect(scratch.innerHTML).to.equal('<div>'+html+'</div>');
 	});
+
+	it( 'should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
+		let html = '<b><i>test</i></b>';
+		let existingEl = document.createElement('div');
+
+		let vdomEl = ( <div dangerouslySetInnerHTML={{ __html: html }} /> );
+
+		existingEl[ATTR_KEY] = vdomEl.attributes; // For an element fetched from its element cache, ATTR_KEY will be set with previous state values.
+		diff( existingEl, vdomEl );
+		expect( existingEl.outerHTML ).to.equal('<div>'+html+'</div>');
+	})
 
 	it('should reconcile mutated DOM attributes', () => {
 		let check = p => render(<input type="checkbox" checked={p} />, scratch, scratch.lastChild),


### PR DESCRIPTION
For elements with dangerouslySetInnerHTML attr, 

initial rendering will take place correctly. ( only Test case for initial render is present in the unit tests ).

after that, after some updating, if we are again rendering the same element, It was not working. 

This pull request fixes that issue. ( Unit test also included )