### PR TITLE
Fix test case in IE

### DIFF
--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -214,7 +214,7 @@ describe('Components', () => {
 
 		let good, bad;
 		let root = render(<GoodContainer ref={c=>good=c} />, scratch);
-		expect(scratch.innerText, 'new component with key present').to.equal('A\nB');
+		expect(scratch.textContent, 'new component with key present').to.equal('AB');
 		expect(Comp.prototype.componentWillMount).to.have.been.calledTwice;
 		expect(sideEffect).to.have.been.calledTwice;
 
@@ -222,7 +222,7 @@ describe('Components', () => {
 		Comp.prototype.componentWillMount.reset();
 		good.setState({alt: true});
 		good.forceUpdate();
-		expect(scratch.innerText, 'new component with key present re-rendered').to.equal('C');
+		expect(scratch.textContent, 'new component with key present re-rendered').to.equal('C');
 		//we are recycling the first 2 components already rendered, just need a new one
 		expect(Comp.prototype.componentWillMount).to.have.been.calledOnce;
 		expect(sideEffect).to.have.been.calledOnce;
@@ -230,7 +230,7 @@ describe('Components', () => {
 		sideEffect.reset();
 		Comp.prototype.componentWillMount.reset();
 		root = render(<BadContainer ref={c=>bad=c} />, scratch, root);
-		expect(scratch.innerText, 'new component without key').to.equal('D\nE');
+		expect(scratch.textContent, 'new component without key').to.equal('DE');
 		expect(Comp.prototype.componentWillMount).to.have.been.calledTwice;
 		expect(sideEffect).to.have.been.calledTwice;
 
@@ -238,7 +238,7 @@ describe('Components', () => {
 		Comp.prototype.componentWillMount.reset();
 		bad.setState({alt: true});
 		bad.forceUpdate();
-		expect(scratch.innerText, 'new component without key re-rendered').to.equal('D');
+		expect(scratch.textContent, 'new component without key re-rendered').to.equal('D');
 		expect(Comp.prototype.componentWillMount).to.not.have.been.called;
 		expect(sideEffect).to.not.have.been.called;
 


### PR DESCRIPTION
We have a problem with test case introduced in #388 when running in IE.

I'm heading to `bug/ie`, so we can put together all of the IE fixes and then merge it to master.

The line feeds won't match with what is being expected.

I switched to `textContent`.

I don't know if this is OK. At least it fixes the test case and don't break others.

Please review this when possible.

Thanks.