### PR TITLE
Throw when passing undefined component to h()

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -15,6 +15,10 @@ const stack = [];
  *  render(<span>foo</span>, document.body);
  */
 export function h(nodeName, attributes) {
+	if (!nodeName) {
+		throw new Error('Component is missing');
+	}
+
 	let children = [],
 		lastSimple, child, simple, i;
 	for (i=arguments.length; i-- > 2; ) {


### PR DESCRIPTION
This so much helps in development, but probably don't worth it to ship that to production. Should we utilize `process.env.NODE_ENV === 'development` in Preact in this case?

Error message is not final too, of course :-)