### PR TITLE
Stop stringifying true values in h

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -28,8 +28,8 @@ export function h(nodeName, attributes) {
 		if ((child = stack.pop()) instanceof Array) {
 			for (i=child.length; i--; ) stack.push(child[i]);
 		}
-		else if (child!=null && child!==false) {
-			if (typeof child=='number' || child===true) child = String(child);
+		else if (child!=null && child!==true && child!==false) {
+			if (typeof child=='number') child = String(child);
 			simple = typeof child=='string';
 			if (simple && lastSimple) {
 				children[children.length-1] += child;

--- a/src/h.js
+++ b/src/h.js
@@ -28,7 +28,7 @@ export function h(nodeName, attributes) {
 		if ((child = stack.pop()) instanceof Array) {
 			for (i=child.length; i--; ) stack.push(child[i]);
 		}
-		else if (child!=null && child!==true && child!==false) {
+		else if (child!=null && typeof child !== 'boolean') {
 			if (typeof child=='number') child = String(child);
 			simple = typeof child=='string';
 			if (simple && lastSimple) {

--- a/src/h.js
+++ b/src/h.js
@@ -28,7 +28,7 @@ export function h(nodeName, attributes) {
 		if ((child = stack.pop()) instanceof Array) {
 			for (i=child.length; i--; ) stack.push(child[i]);
 		}
-		else if (child!=null && typeof child !== 'boolean') {
+		else if (child!=null && child!==true && child!==false) {
 			if (typeof child=='number') child = String(child);
 			simple = typeof child=='string';
 			if (simple && lastSimple) {

--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -193,4 +193,19 @@ describe('h(jsx)', () => {
 				'onetwothreefourfivesix'
 			]);
 	});
+	it('should not merge children that are boolean values', () => {
+		let r = h(
+			'foo',
+			null,
+			'one',
+			true,
+			'two',
+			false,
+			'three'
+		);
+
+		expect(r).to.be.an('object')
+			.with.property('children')
+			.that.deep.equals(['onetwothree']);
+	});
 });


### PR DESCRIPTION
# Fix Issue https://github.com/developit/preact/issues/433
It has been requested that we would no longer want to render true bool values. Similar to that of functionality seen in React.

### Before:
##### Input:
`<div>{true}</div>`
##### Output:
`<div>true</div>`

### After:
##### Input:
`<div>{true}</div>`
##### Output:
`<div></div>`
