### PR TITLE
Fix detection of whether a component is a root or not

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -344,7 +344,15 @@ function createDevToolsBridge() {
  * `render()` into a container Element.
  */
 function isRootComponent(component) {
-	return !component.base.parentElement || !component.base.parentElement[ATTR_KEY];
+	if (component._parentComponent) {
+		// Component with a composite parent
+		return false;
+	}
+	if (component.base.parentElement && component.base.parentElement[ATTR_KEY]) {
+		// Component with a parent DOM element rendered by Preact
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/test/browser/devtools.js
+++ b/test/browser/devtools.js
@@ -231,4 +231,30 @@ describe_('React Developer Tools integration', () => {
 		unmountComponent(node._component, true);
 		expect(Object.keys(renderer.Mount._instancesByReactRootID).length).to.equal(0);
 	});
+
+	it('counts root components correctly when a root renders a composite child', () => {
+		function Child() {
+			return h('main');
+		}
+		function Parent() {
+			return h(Child);
+		}
+
+		render(h(Parent), container);
+
+		expect(Object.keys(renderer.Mount._instancesByReactRootID).length).to.equal(1);
+	});
+
+	it('counts root components correctly when a native element has a composite child', () => {
+		function Link() {
+			return h('a');
+		}
+		function Root() {
+			return h('div', {}, h(Link));
+		}
+
+		render(h(Root), container);
+
+		expect(Object.keys(renderer.Mount._instancesByReactRootID).length).to.equal(1);
+	});
 });


### PR DESCRIPTION
This fixes one of the issues reported in #440 where the devtools shows multiple roots instead of only one (`<App>`). The problem was incorrect reporting to the devtools about whether a component was a root or not.

When a root component whose only child was a composite was mounted, the
previous method of detecting a root component would incorrectly report
both the actual root and the child as root components.