### PR TITLE
Fix eslint warnings

### DIFF
--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -167,7 +167,6 @@ describe('Components', () => {
 		class Comp extends Component {
 			componentWillMount() {
 				this.innerMsg = msgs[(idx++ % 8)];
-				console.log('innerMsg', this.innerMsg);
 				sideEffect();
 			}
 			render() {

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -161,7 +161,6 @@ describe('Components', () => {
 	it('should not recycle common class children with different keys', () => {
 		let idx = 0;
 		let msgs = ['A','B','C','D','E','F','G','H'];
-		let comp1, comp2, comp3;
 		let sideEffect = sinon.spy();
 
 		class Comp extends Component {
@@ -185,9 +184,9 @@ describe('Components', () => {
 			render(_, {alt}) {
 				return (
 					<div>
-						{alt ? null : (<Comp ref={c=>comp1=c} key={1} alt={alt}/>)}
-						{alt ? null : (<Comp ref={c=>comp2=c} key={2} alt={alt}/>)}
-						{alt ? (<Comp ref={c=>comp3=c} key={3} alt={alt}/>) : null}
+						{alt ? null : (<Comp key={1} alt={alt}/>)}
+						{alt ? null : (<Comp key={2} alt={alt}/>)}
+						{alt ? (<Comp key={3} alt={alt}/>) : null}
 					</div>
 				);
 			}
@@ -203,9 +202,9 @@ describe('Components', () => {
 			render(_, {alt}) {
 				return (
 					<div>
-						{alt ? null : (<Comp ref={c=>comp1=c} alt={alt}/>)}
-						{alt ? null : (<Comp ref={c=>comp2=c} alt={alt}/>)}
-						{alt ? (<Comp ref={c=>comp3=c} alt={alt}/>) : null}
+						{alt ? null : (<Comp alt={alt}/>)}
+						{alt ? null : (<Comp alt={alt}/>)}
+						{alt ? (<Comp alt={alt}/>) : null}
 					</div>
 				);
 			}

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -227,7 +227,7 @@ describe('Components', () => {
 
 		sideEffect.reset();
 		Comp.prototype.componentWillMount.reset();
-		root = render(<BadContainer ref={c=>bad=c} />, scratch, root);
+		render(<BadContainer ref={c=>bad=c} />, scratch, root);
 		expect(scratch.innerText, 'new component without key').to.equal('D\nE');
 		expect(Comp.prototype.componentWillMount).to.have.been.calledTwice;
 		expect(sideEffect).to.have.been.calledTwice;

--- a/test/browser/keys.js
+++ b/test/browser/keys.js
@@ -20,14 +20,14 @@ describe('keys', () => {
 
 	// See developit/preact-compat#21
 	it('should remove orphaned keyed nodes', () => {
-		let root = render((
+		const root = render((
 			<div>
 				<div>1</div>
 				<li key="a">a</li>
 			</div>
 		), scratch);
 
-		root = render((
+		render((
 			<div>
 				<div>2</div>
 				<li key="b">b</li>

--- a/test/browser/performance.js
+++ b/test/browser/performance.js
@@ -21,7 +21,7 @@ function loop(iter, time) {
 
 
 function benchmark(iter, callback) {
-	let a = 0;
+	let a = 0; // eslint-disable-line no-unused-vars
 	function noop() {
 		try { a++; } finally { a += Math.random(); }
 	}

--- a/test/browser/refs.js
+++ b/test/browser/refs.js
@@ -175,7 +175,7 @@ describe('refs', () => {
 		outer.reset();
 		inner.reset();
 		innermost.reset();
-		root = render(<div />, scratch, root);
+		render(<div />, scratch, root);
 
 		expect(outer, 'outer unmount').to.have.been.calledOnce.and.calledWith(null);
 		expect(inner, 'inner unmount').to.have.been.calledOnce.and.calledWith(null);
@@ -238,7 +238,7 @@ describe('refs', () => {
 		expect(TestUnmount.prototype.componentWillUnmount).not.to.have.been.called;
 		expect(TestUnmount.prototype.componentDidUnmount).not.to.have.been.called;
 
-		root = render(<div />, scratch, root);
+		render(<div />, scratch, root);
 
 		expect(TestUnmount.prototype.componentWillUnmount).to.have.been.calledOnce;
 		expect(TestUnmount.prototype.componentDidUnmount).to.have.been.calledOnce;

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -1,8 +1,6 @@
 /* global DISABLE_FLAKEY */
 
 import { h, render, Component } from '../../src/preact';
-import { diff } from '../../src/vdom/diff';
-import { ATTR_KEY } from '../../src/constants';
 /** @jsx h */
 
 function getAttributes(node) {


### PR DESCRIPTION
I think we can remove those eslint warnings so we can spot real code mistakes easier.

I'm sending three commits just to make the changes easier to understand, could squash them later.

Build and tests OK in my local env.

Please review this and see if it's suitable for merge.

Thanks!