### PR TITLE
Allowing other types for key (Typescript definitions)

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -18,7 +18,7 @@ declare namespace preact {
 		nodeName:ComponentConstructor<any, any>|string;
 		attributes:{[name:string]:any};
 		children:VNode[];
-		key:string | number | any;
+		key:string;
 	}
 
 	interface ComponentLifecycle<PropsType, StateType> {

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -1,7 +1,7 @@
 declare namespace preact {
 	interface ComponentProps {
 		children?:JSX.Element[];
-		key?:string;
+		key?:string | number | any;
 	}
 
 	interface DangerouslySetInnerHTML {
@@ -18,7 +18,7 @@ declare namespace preact {
 		nodeName:ComponentConstructor<any, any>|string;
 		attributes:{[name:string]:any};
 		children:VNode[];
-		key:string;
+		key:string | number | any;
 	}
 
 	interface ComponentLifecycle<PropsType, StateType> {


### PR DESCRIPTION
When the id of my object is a number then I don't want to use id.toString() so I've added number and any as valid types for the key prop.