### PR TITLE
Typescript: Add `class` & `className` to `SVGAttributes`

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -88,6 +88,8 @@ declare namespace JSX {
 	}
 
 	interface SVGAttributes {
+		class?:string | { [key:string]: boolean };
+		className?:string | { [key:string]: boolean };
 		clipPath?:string;
 		cx?:number | string;
 		cy?:number | string;


### PR DESCRIPTION
There are many SVG attributes missing, but I think `class` should be considered essential - especially as its absence breaks the TS compilation.