### PR TITLE
Support the breadth of possible SVG attributes

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -87,7 +87,7 @@ declare namespace JSX {
 		props:any;
 	}
 
-	interface SVGAttributes {
+	interface SVGAttributes extends HTMLAttributes {
 		clipPath?:string;
 		cx?:number | string;
 		cy?:number | string;


### PR DESCRIPTION
This change extends the allowable attributes on SVG elements by extending `HTMLAttributes`.  This change brings parity with the React typings (see: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/react/index.d.ts#L2206)

This handles #541 and supersedes #542.

