### PR TITLE
Add ref to ComponentProps interface

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -1,7 +1,8 @@
 declare namespace preact {
-	interface ComponentProps {
+	interface ComponentProps<C extends Component<any, any>> {
 		children?:JSX.Element[];
 		key?:string | number | any;
+		ref?:(el: C) => void;
 	}
 
 	interface DangerouslySetInnerHTML {
@@ -40,7 +41,7 @@ declare namespace preact {
 		constructor(props?:PropsType);
 
 		state:StateType;
-		props:PropsType & ComponentProps;
+		props:PropsType & ComponentProps<this>;
 		base:HTMLElement;
 
 		linkState:(name:string) => (event: Event) => void;
@@ -50,7 +51,7 @@ declare namespace preact {
 
 		forceUpdate(): void;
 
-		abstract render(props:PropsType & ComponentProps, state:any):JSX.Element;
+		abstract render(props:PropsType & ComponentProps<this>, state:any):JSX.Element;
 	}
 
 	function h<PropsType>(node:ComponentConstructor<PropsType, any>, params:PropsType, ...children:(JSX.Element|JSX.Element[]|string)[]):JSX.Element;


### PR DESCRIPTION
Allows ref to be used on components, and will correctly type the instance passed through in the args.