### PR TITLE
closure compiler experiment 🗿

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -jar $CLOSURE_PATH --externs=externs.js --language_in=ECMASCRIPT6 --js=dist/preact.dev.js --compilation_level ADVANCED_OPTIMIZATIONS

--- a/externs.js
+++ b/externs.js
@@ -12,7 +12,7 @@ function VNode(nodeName, opt_attributes, opt_children) {}
 function NodeName() { }
 
 /** @type {Object} */
-NodeName.prototype.defaultProps
+NodeName.prototype.defaultProps;
 
 /** @type {(string|!NodeName)} */
 VNode.prototype.nodeName;
@@ -21,7 +21,7 @@ VNode.prototype.nodeName;
 VNode.prototype.attributes;
 
 /** @type {Array<VNode>|undefined} */
-VNode.prototypechildren;
+VNode.prototype.children;
 
 /** @type{boolean|string} */
 VNode.prototype.key;
@@ -45,21 +45,6 @@ Component.prototype.prevContext;
 Component.prototype.base;
 /** @type {?} */
 Component.prototype.nextBase;
-/** @type {?} */
-Component.prototype._parentComponent;
-/** @type {?} */
-Component.prototype._component;
-/** @type {?} */
-Component.prototype.__ref;
-/** @type {?} */
-Component.prototype.__key;
-/** @type {?} */
-Component.prototype._linkedStates;
-/** @type {?} */
-Component.prototype._renderCallbacks;
-
-/** @type {boolean} */
-Component.prototype._dirty;
 
 /** @type {Object} */
 Component.prototype.context;

--- a/externs.js
+++ b/externs.js
@@ -1,13 +1,21 @@
 /**
  * @constructor
- * @param {string|Function} nodeName
+ * @param {(string|!NodeName)} nodeName
  * @param {Object|undefined} attributes
  * @param {Array<VNode>|undefined} children
  * @return {undefined}
  */
 function VNode(nodeName, attributes, children) {}
 
-/** @type {string|Function} */
+/** @record
+ * @return {?}
+ */
+function NodeName() { }
+
+/** @type {Object} */
+NodeName.prototype.defaultProps
+
+/** @type {(string|!NodeName)} */
 VNode.prototype.nodeName;
 
 /** @type {Object|undefined} */

--- a/externs.js
+++ b/externs.js
@@ -1,0 +1,103 @@
+/**
+ * @constructor
+ * @param {string|Function} nodeName
+ * @param {Object|undefined} attributes
+ * @param {Array<VNode>|undefined} children
+ * @return {undefined}
+ */
+function VNode(nodeName, attributes, children) {}
+
+/** @type {string|Function} */
+VNode.prototype.nodeName;
+
+/** @type {Object|undefined} */
+VNode.prototype.attributes;
+
+/** @type {Array<VNode>|undefined} */
+VNode.prototypechildren;
+
+/** @type{boolean|string} */
+VNode.prototype.key;
+
+
+/** Base Component class, for the ES6 Class method of creating Components
+ * @constructor
+ * @param {Object} props
+ * @param {Object} context
+ * @return {undefined}
+ */
+function Component(props, context){}
+
+/** @type {?} */
+Component.prototype.prevState;
+/** @type {?} */
+Component.prototype.prevProps;
+/** @type {?} */
+Component.prototype.prevContext;
+/** @type {?} */
+Component.prototype.base;
+/** @type {?} */
+Component.prototype.nextBase;
+/** @type {?} */
+Component.prototype._parentComponent;
+/** @type {?} */
+Component.prototype._component;
+/** @type {?} */
+Component.prototype.__ref;
+/** @type {?} */
+Component.prototype.__key;
+/** @type {?} */
+Component.prototype._linkedStates;
+/** @type {?} */
+Component.prototype._renderCallbacks;
+
+/** @type {boolean} */
+Component.prototype._dirty;
+
+/** @type {Object} */
+Component.prototype.context;
+
+/** @type {Object} */
+Component.prototype.props;
+
+/** @type {Object|undefined} */
+Component.prototype.state;
+
+/**
+ *	@param {Object} nextProps
+ *	@param {Object|undefined} nextState
+ *	@param {Object} nextContext
+ *	@return {boolean} should the component re-render
+ */
+Component.prototype.shouldComponentUpdate = function(nextProps, nextState, nextContext){};
+
+/**
+ *	@param {string} key		The path to set - can be a dot-notated deep key
+ *	@param {string} [eventPath]	If set, attempts to find the new state value at a given dot-notated path within the object passed to the linkedState setter.
+ *	@return {Function} linkStateSetter(e)
+ */
+Component.prototype.linkState = function(key, eventPath){};
+
+/**
+ * Update component state by copying properties from `state` to `this.state`.
+ * @param {Object} state		A hash of state properties to update with new values
+ */
+Component.prototype.setState = function(state) {};
+
+/** Accepts `props` and `state`, and returns a new Virtual DOM tree to build.
+ *	Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
+ *	@param {Object} props		Props (eg: JSX attributes) received from parent element/component
+ *	@param {Object|undefined} state		The component's current state
+ *	@param {Object} context		Context object (if a parent component has provided context)
+ *	@return VNode
+ */
+Component.prototype.render = function(props, state, context){}
+
+/**
+ * Immediately perform a synchronous re-render of the component.
+ * @private
+ */
+Component.prototype.forceUpdate = function(){}
+
+/** @typedef {{syncComponentUpdates: (boolean|undefined), vnode: (Function|undefined), afterMount: (Function|undefined), beforeUnmount: (Function|undefined)}}*/
+var Options;

--- a/externs.js
+++ b/externs.js
@@ -1,11 +1,10 @@
 /**
  * @constructor
  * @param {(string|!NodeName)} nodeName
- * @param {Object|undefined} attributes
- * @param {Array<VNode>|undefined} children
- * @return {undefined}
+ * @param {Object=} opt_attributes
+ * @param {Array<VNode>=} opt_children
  */
-function VNode(nodeName, attributes, children) {}
+function VNode(nodeName, opt_attributes, opt_children) {}
 
 /** @record
  * @return {?}
@@ -82,7 +81,7 @@ Component.prototype.shouldComponentUpdate = function(nextProps, nextState, nextC
 /**
  *	@param {string} key		The path to set - can be a dot-notated deep key
  *	@param {string} [eventPath]	If set, attempts to find the new state value at a given dot-notated path within the object passed to the linkedState setter.
- *	@return {Function} linkStateSetter(e)
+ *	@return {function(!Event)}
  */
 Component.prototype.linkState = function(key, eventPath){};
 
@@ -109,3 +108,12 @@ Component.prototype.forceUpdate = function(){}
 
 /** @typedef {{syncComponentUpdates: (boolean|undefined), vnode: (Function|undefined), afterMount: (Function|undefined), beforeUnmount: (Function|undefined)}}*/
 var Options;
+
+
+/**
+ * @param {!{nodeName: !NodeName}} vnode
+ * @param {?} context
+ * @return {?}
+ */
+function buildFunctionalComponent(vnode, context) {}
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist/ aliases.js aliases.js.map  devtools.js devtools.js.map",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",
     "copy-typescript-definition": "copyfiles -f src/preact.d.ts dist",
-    "build": "npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size",
+    "build": "npm-run-all --silent clean transpile",
     "transpile:main": "rollup -c config/rollup.config.js -m dist/preact.dev.js.map -f umd -n preact src/preact.js -o dist/preact.dev.js",
     "transpile:devtools": "rollup -c config/rollup.config.devtools.js -o devtools.js -m devtools.js.map",
     "transpile:aliases": "rollup -c config/rollup.config.aliases.js -m aliases.js.map -f umd -n preact src/preact.js -o aliases.js",

--- a/src/component.js
+++ b/src/component.js
@@ -5,9 +5,9 @@ import { renderComponent } from './vdom/component';
 import { enqueueRender } from './render-queue';
 
 /** Base Component class, for the ES6 Class method of creating Components
- *	@public
- *
- *	@example
+ *	@constructor
+ *	@param {Object} props
+ *	@param {Object} context
  *	class MyFoo extends Component {
  *		render(props, state) {
  *			return <div />;
@@ -15,36 +15,22 @@ import { enqueueRender } from './render-queue';
  *	}
  */
 export function Component(props, context) {
-	/** @private */
+	/** @private */{}
 	this._dirty = true;
 	// /** @public */
 	// this._disableRendering = false;
 	// /** @public */
 	// this.prevState = this.prevProps = this.prevContext = this.base = this.nextBase = this._parentComponent = this._component = this.__ref = this.__key = this._linkedStates = this._renderCallbacks = null;
-	/** @public */
 	this.context = context;
-	/** @type {object} */
+	/** @type {Object} */
 	this.props = props;
-	/** @type {object} */
-	if (!this.state) this.state = {};
+	if (!this.state) {
+    /** @type {Object} */
+    this.state = {};
+  }
 }
 
-
 extend(Component.prototype, {
-
-	/** Returns a `boolean` value indicating if the component should re-render when receiving the given `props` and `state`.
-	 *	@param {object} nextProps
-	 *	@param {object} nextState
-	 *	@param {object} nextContext
-	 *	@returns {Boolean} should the component re-render
-	 *	@name shouldComponentUpdate
-	 *	@function
-	 */
-	// shouldComponentUpdate() {
-	// 	return true;
-	// },
-
-
 	/** Returns a function that sets a state property when called.
 	 *	Calling linkState() repeatedly with the same arguments returns a cached link function.
 	 *
@@ -54,14 +40,10 @@ extend(Component.prototype, {
 	 *		- Event paths fall back to any associated Component if not found on an element
 	 *		- If linked value is a function, will invoke it and use the result
 	 *
-	 *	@param {string} key		The path to set - can be a dot-notated deep key
-	 *	@param {string} [eventPath]	If set, attempts to find the new state value at a given dot-notated path within the object passed to the linkedState setter.
-	 *	@returns {function} linkStateSetter(e)
-	 *
-	 *	@example Update a "text" state value when an input changes:
+	 *	Update a "text" state value when an input changes:
 	 *		<input onChange={ this.linkState('text') } />
 	 *
-	 *	@example Set a deep state value on click
+	 *	Set a deep state value on click
 	 *		<button onClick={ this.linkState('touch.coords', 'touches.0') }>Tap</button
 	 */
 	linkState(key, eventPath) {
@@ -69,10 +51,6 @@ extend(Component.prototype, {
 		return c[key+eventPath] || (c[key+eventPath] = createLinkedState(this, key, eventPath));
 	},
 
-
-	/** Update component state by copying properties from `state` to `this.state`.
-	 *	@param {object} state		A hash of state properties to update with new values
-	 */
 	setState(state, callback) {
 		let s = this.state;
 		if (!this.prevState) this.prevState = clone(s);
@@ -81,22 +59,9 @@ extend(Component.prototype, {
 		enqueueRender(this);
 	},
 
-
-	/** Immediately perform a synchronous re-render of the component.
-	 *	@private
-	 */
 	forceUpdate() {
 		renderComponent(this, FORCE_RENDER);
 	},
 
-
-	/** Accepts `props` and `state`, and returns a new Virtual DOM tree to build.
-	 *	Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
-	 *	@param {object} props		Props (eg: JSX attributes) received from parent element/component
-	 *	@param {object} state		The component's current state
-	 *	@param {object} context		Context object (if a parent component has provided context)
-	 *	@returns VNode
-	 */
 	render() {}
-
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,10 +11,10 @@ export const ATTR_KEY = typeof Symbol!=='undefined' ? Symbol.for('preactattr') :
 
 // DOM properties that should NOT have "px" added when numeric
 export const NON_DIMENSION_PROPS = {
-	boxFlex:1, boxFlexGroup:1, columnCount:1, fillOpacity:1, flex:1, flexGrow:1,
-	flexPositive:1, flexShrink:1, flexNegative:1, fontWeight:1, lineClamp:1, lineHeight:1,
-	opacity:1, order:1, orphans:1, strokeOpacity:1, widows:1, zIndex:1, zoom:1
+	'boxFlex':1, 'boxFlexGroup':1, 'columnCount':1, 'fillOpacity':1, 'flex':1, 'flexGrow':1,
+	'flexPositive':1, 'flexShrink':1, 'flexNegative':1, 'fontWeight':1, 'lineClamp':1, 'lineHeight':1,
+	'opacity':1, 'order':1, 'orphans':1, 'strokeOpacity':1, 'widows':1, 'zIndex':1, 'zoom':1
 };
 
 // DOM event types that do not bubble and should be attached via useCapture
-export const NON_BUBBLING_EVENTS = { blur:1, error:1, focus:1, load:1, resize:1, scroll:1 };
+export const NON_BUBBLING_EVENTS = { 'blur':1, 'error':1, 'focus':1, 'load':1, 'resize':1, 'scroll':1 };

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -70,13 +70,17 @@ export function setAccessor(node, name, old, value, isSvg) {
 	}
 	else {
 		let ns = isSvg && name.match(/^xlink\:?(.+)/);
+		if (ns) {
+			name = toLowerCase(ns[1]);
+			ns = 'http://www.w3.org/1999/xlink';
+		} else {
+			ns = '';
+		}
 		if (value==null || value===false) {
-			if (ns) node.removeAttributeNS('http://www.w3.org/1999/xlink', toLowerCase(ns[1]));
-			else node.removeAttribute(name);
+			node.removeAttributeNS(ns, name);
 		}
 		else if (typeof value!=='object' && !isFunction(value)) {
-			if (ns) node.setAttributeNS('http://www.w3.org/1999/xlink', toLowerCase(ns[1]), value);
-			else node.setAttribute(name, value);
+			node.setAttributeNS(ns, name, value);
 		}
 	}
 }

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -16,8 +16,8 @@ export function removeNode(node) {
  *	If `value` is `null`, the attribute/handler will be removed.
  *	@param {Element} node	An element to mutate
  *	@param {string} name	The name/key to set, such as an event or attribute name
- *	@param {any} old	The last value that was set for this name/node pair
- *	@param {any} value	An attribute value, such as a function to be used as an event handler
+ *	@param {?} old	The last value that was set for this name/node pair
+ *	@param {?} value	An attribute value, such as a function to be used as an event handler
  *	@param {Boolean} isSvg	Are we currently diffing inside an svg?
  *	@private
  */

--- a/src/h.js
+++ b/src/h.js
@@ -9,10 +9,10 @@ const EMPTY_CHILDREN = [];
 /** JSX/hyperscript reviver
  *  Benchmarks: https://esbench.com/bench/57ee8f8e330ab09900a1a1a0
  *  @param {(string|!NodeName)} nodeName
- *  @param {(Object|undefined)} attributes
- *  @param {...?} args
+ *  @param {Object=} attributes
+ *  @param {...?} var_args
  */
-export function h(nodeName, attributes) {
+export function h(nodeName, attributes, var_args) {
 	let children, lastSimple, child, simple, i;
 	for (i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);

--- a/src/h.js
+++ b/src/h.js
@@ -7,10 +7,10 @@ const stack = [];
 const EMPTY_CHILDREN = [];
 
 /** JSX/hyperscript reviver
-*	Benchmarks: https://esbench.com/bench/57ee8f8e330ab09900a1a1a0
- *	@see http://jasonformat.com/wtf-is-jsx
- *	@public
- *  @example
+ *  Benchmarks: https://esbench.com/bench/57ee8f8e330ab09900a1a1a0
+ *  @param {string} nodeName
+ *  @param {Object|undefined} attributes
+ *  @param {...*}
  *  /** @jsx h *\/
  *  import { render, h } from 'preact';
  *  render(<span>foo</span>, document.body);

--- a/src/h.js
+++ b/src/h.js
@@ -8,12 +8,9 @@ const EMPTY_CHILDREN = [];
 
 /** JSX/hyperscript reviver
  *  Benchmarks: https://esbench.com/bench/57ee8f8e330ab09900a1a1a0
- *  @param {string} nodeName
- *  @param {Object|undefined} attributes
- *  @param {...*}
- *  /** @jsx h *\/
- *  import { render, h } from 'preact';
- *  render(<span>foo</span>, document.body);
+ *  @param {(string|!NodeName)} nodeName
+ *  @param {(Object|undefined)} attributes
+ *  @param {...?} args
  */
 export function h(nodeName, attributes) {
 	let children, lastSimple, child, simple, i;

--- a/src/linked-state.js
+++ b/src/linked-state.js
@@ -4,7 +4,7 @@ import { isString, delve } from './util';
  *	@param {Component} component	The component whose state should be updated
  *	@param {string} key				A dot-notated key path to update in the component's state
  *	@param {string} eventPath		A dot-notated key path to the value that should be retrieved from the Event or component
- *	@returns {function} linkedStateHandler
+ *	@return {Function} linkedStateHandler
  *	@private
  */
 export function createLinkedState(component, key, eventPath) {

--- a/src/options.js
+++ b/src/options.js
@@ -1,12 +1,11 @@
-/** Global options
- *	@public
- *	@namespace options {Object}
+/**
+ * @type {Options}
  */
 export default {
 
 	/** If `true`, `prop` changes trigger synchronous component updates.
 	 *	@name syncComponentUpdates
-	 *	@type Boolean
+	 *	@type boolean
 	 *	@default true
 	 */
 	//syncComponentUpdates: true,

--- a/src/render.js
+++ b/src/render.js
@@ -3,14 +3,11 @@ import { diff } from './vdom/diff';
 /** Render JSX into a `parent` Element.
  *	@param {VNode} vnode		A (JSX) VNode to render
  *	@param {Element} parent		DOM element to render into
- *	@param {Element} [merge]	Attempt to re-use an existing DOM tree rooted at `merge`
- *	@public
+ *	@param {Element} merge Attempt to re-use an existing DOM tree rooted at `merge`
  *
- *	@example
  *	// render a div into <body>:
  *	render(<div id="hello">hello!</div>, document.body);
  *
- *	@example
  *	// render a "Thing" component into #foo:
  *	const Thing = ({ name }) => <span>{ name }</span>;
  *	render(<Thing name="one" />, document.querySelector('#foo'));

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
 /** Copy own-properties from `props` onto `obj`.
- *	@returns obj
+ *	@return obj
  *	@private
  */
 export function extend(obj, props) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -11,10 +11,11 @@ import { removeNode } from '../dom/index';
 
 
 /** Set a component's `props` (generally derived from JSX attributes).
+ *	@param {Component} component
  *	@param {Object} props
- *	@param {Object} [opts]
- *	@param {boolean} [opts.renderSync=false]	If `true` and {@link options.syncComponentUpdates} is `true`, triggers synchronous rendering.
- *	@param {boolean} [opts.render=true]			If `false`, no render will be triggered.
+ *	@param {number=} opts
+ *	@param {Object=} context
+ *	@param {boolean=} mountAll
  */
 export function setComponentProps(component, props, opts, context, mountAll) {
 	if (component._disable) return;
@@ -56,9 +57,9 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 
 /** Render a Component, triggering necessary lifecycle events and taking High-Order Components into account.
  *	@param {Component} component
- *	@param {Object} [opts]
- *	@param {boolean} [opts.build=false]		If `true`, component will build and store a DOM node if not already associated with one.
- *	@private
+ *	@param {number=} opts
+ *	@param {boolean=} mountAll
+ *  @param {boolean=} isChild
  */
 export function renderComponent(component, opts, mountAll, isChild) {
 	if (component._disable) return;
@@ -198,7 +199,9 @@ export function renderComponent(component, opts, mountAll, isChild) {
 /** Apply the Component referenced by a VNode to the DOM.
  *	@param {Element} dom	The DOM node to mutate
  *	@param {VNode} vnode	A Component-referencing VNode
- *	@returns {Element} dom	The created/mutated element
+ *	@param {Object} context
+ *	@param {boolean=} mountAll
+ *	@return {Element} dom	The created/mutated element
  *	@private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {
@@ -243,8 +246,8 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 
 
 /** Remove a component from the DOM and recycle it.
- *	@param {Element} dom			A DOM node from which to unmount the given Component
- *	@param {Component} component	The Component instance to unmount
+ *	@param {Element} component A DOM node from which to unmount the given Component
+ *	@param {boolean} remove
  *	@private
  */
 export function unmountComponent(component, remove) {

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -32,9 +32,13 @@ export function flushMounts() {
 
 
 /** Apply differences in a given vnode (and it's deep children) to a real DOM Node.
- *	@param {Element} [dom=null]		A DOM node to mutate into the shape of the `vnode`
- *	@param {VNode} vnode			A VNode (with descendants forming a tree) representing the desired DOM structure
- *	@returns {Element} dom			The created/mutated element
+ *	@param {Element} dom A DOM node to mutate into the shape of the `vnode`
+ *	@param {VNode} vnode  VNode (with descendants forming a tree) representing the desired DOM structure
+ *	@param {Object=} context
+ *	@param {boolean=} mountAll
+ *  @param {Element=} parent
+ *	@param {boolean=} componentRoot
+ *	@return {Element} dom			The created/mutated element
  *	@private
  */
 export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
@@ -174,10 +178,10 @@ function idiff(dom, vnode, context, mountAll) {
 
 /** Apply child and attribute changes between a VNode and a DOM Node to the DOM.
  *	@param {Element} dom		Element whose children should be compared & mutated
- *	@param {Array} vchildren	Array of VNodes to compare to `dom.childNodes`
+ *	@param {Array<VNode>} vchildren	Array of VNodes to compare to `dom.childNodes`
  *	@param {Object} context		Implicitly descendant context object (from most recent `getChildContext()`)
- *	@param {Boolean} mountAll
- *	@param {Boolean} absorb		If `true`, consumes externally created elements similar to hydration
+ *	@param {boolean} mountAll
+ *	@param {boolean} absorb		If `true`, consumes externally created elements similar to hydration
  */
 function innerDiffNode(dom, vchildren, context, mountAll, absorb) {
 	let originalChildren = dom.childNodes,
@@ -269,8 +273,8 @@ function innerDiffNode(dom, vchildren, context, mountAll, absorb) {
 
 
 /** Recursively recycle (or just unmount) a node an its descendants.
- *	@param {Node} node						DOM node to start unmount/removal from
- *	@param {Boolean} [unmountOnly=false]	If `true`, only triggers unmount lifecycle, skips removal
+ *	@param {Node} node DOM node to start unmount/removal from
+ *	@param {boolean=} unmountOnly `true`, only triggers unmount lifecycle, skips removal
  */
 export function recollectNodeTree(node, unmountOnly) {
 	let component = node._component;

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -68,7 +68,7 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 
 
 function idiff(dom, vnode, context, mountAll) {
-	let ref = vnode && vnode.attributes && vnode.attributes.ref;
+	let ref = vnode && vnode.attributes.ref;
 
 
 	// Resolve ephemeral Pure Functional Components
@@ -150,13 +150,13 @@ function idiff(dom, vnode, context, mountAll) {
 	}
 
 	// Optimization: fast-path for elements containing a single TextNode:
-	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
+	if (!hydrating && vchildren.length===1 && typeof vchildren[0]==='string' && fc && fc instanceof Text && !fc.nextSibling) {
 		if (fc.nodeValue!=vchildren[0]) {
 			fc.nodeValue = vchildren[0];
 		}
 	}
 	// otherwise, if there are existing or new children, diff them:
-	else if (vchildren && vchildren.length || fc) {
+	else if (vchildren.length || fc) {
 		innerDiffNode(out, vchildren, context, mountAll, !!props.dangerouslySetInnerHTML);
 	}
 
@@ -316,11 +316,9 @@ function diffAttributes(dom, attrs, old) {
 	}
 
 	// add new & update changed attributes
-	if (attrs) {
-		for (name in attrs) {
-			if (name!=='children' && name!=='innerHTML' && (!(name in old) || attrs[name]!==(name==='value' || name==='checked' ? dom[name] : old[name]))) {
-				setAccessor(dom, name, old[name], old[name] = attrs[name], isSvgMode);
-			}
+	for (name in attrs) {
+		if (name!=='children' && name!=='innerHTML' && (!(name in old) || attrs[name]!==(name==='value' || name==='checked' ? dom[name] : old[name]))) {
+			setAccessor(dom, name, old[name], old[name] = attrs[name], isSvgMode);
 		}
 	}
 }

--- a/src/vdom/functional-component.js
+++ b/src/vdom/functional-component.js
@@ -21,5 +21,6 @@ export function isFunctionalComponent(vnode) {
  *	@private
  */
 export function buildFunctionalComponent(vnode, context) {
-	return vnode.nodeName(getNodeProps(vnode), context || EMPTY);
+  let /** @type {!NodeName} */ nodeName = vnode.nodeName;
+  return (nodeName())(getNodeProps(vnode), context || EMPTY);
 }

--- a/src/vdom/functional-component.js
+++ b/src/vdom/functional-component.js
@@ -16,10 +16,9 @@ export function isFunctionalComponent(vnode) {
 
 
 
-/** Construct a resultant VNode from a VNode referencing a stateless functional component.
- *	@param {VNode} vnode	A VNode with a `nodeName` property that is a reference to a function.
- *	@private
+/**
+ * Construct a resultant VNode from a VNode referencing a stateless functional component.
  */
 export function buildFunctionalComponent(vnode, context) {
-  return /** @type {!NodeName} */(vnode.nodeName)()(getNodeProps(vnode), context || EMPTY);
+  return vnode.nodeName()(getNodeProps(vnode), context || EMPTY);
 }

--- a/src/vdom/functional-component.js
+++ b/src/vdom/functional-component.js
@@ -21,6 +21,5 @@ export function isFunctionalComponent(vnode) {
  *	@private
  */
 export function buildFunctionalComponent(vnode, context) {
-  let /** @type {!NodeName} */ nodeName = vnode.nodeName;
-  return (nodeName())(getNodeProps(vnode), context || EMPTY);
+  return /** @type {!NodeName} */(vnode.nodeName)()(getNodeProps(vnode), context || EMPTY);
 }

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -30,7 +30,7 @@ export function isNamedNode(node, nodeName) {
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
  * @param {VNode} vnode
- * @returns {Object} props
+ * @return {Object} props
  */
 export function getNodeProps(vnode) {
 	let props = clone(vnode.attributes);

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,13 +1,9 @@
 /**
  * Virtual DOM Node
- * @constructor
- * @param {(string|!NodeName)} nodeName
- * @param {Object|undefined} attributes
- * @param {Array<VNode>|undefined} children
  */
-export function VNode(nodeName, attributes, children) {
+export function VNode(nodeName, opt_attributes, opt_children) {
 	this.nodeName = nodeName;
-	this.attributes = attributes;
-	this.children = children;
+	this.attributes = opt_attributes;
+	this.children = opt_children;
 	this.key = attributes && attributes.key;
 }

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -2,8 +2,9 @@
  * Virtual DOM Node
  */
 export function VNode(nodeName, opt_attributes, opt_children) {
+	opt_attributes=opt_attributes||{};
 	this.nodeName = nodeName;
 	this.attributes = opt_attributes;
-	this.children = opt_children;
-	this.key = attributes && attributes.key;
+	this.children = opt_children||[];
+	this.key = opt_attributes.key;
 }

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,7 +1,7 @@
 /**
  * Virtual DOM Node
  * @constructor
- * @param {string|Function} nodeName
+ * @param {(string|!NodeName)} nodeName
  * @param {Object|undefined} attributes
  * @param {Array<VNode>|undefined} children
  */

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,14 +1,13 @@
-/** Virtual DOM Node */
+/**
+ * Virtual DOM Node
+ * @constructor
+ * @param {string|Function} nodeName
+ * @param {Object|undefined} attributes
+ * @param {Array<VNode>|undefined} children
+ */
 export function VNode(nodeName, attributes, children) {
-	/** @type {string|function} */
 	this.nodeName = nodeName;
-
-	/** @type {object<string>|undefined} */
 	this.attributes = attributes;
-
-	/** @type {array<VNode>|undefined} */
 	this.children = children;
-
-	/** Reference to the given key. */
 	this.key = attributes && attributes.key;
 }


### PR DESCRIPTION
Over the past week I have been investigating what kind of optimization wins we could get with preact, if instead of using uglify we switched to using closure compiler.

After getting the typings in place and cleaning up some invalid typings in the code, I ended up with a bundle that would compile and pass some of my naive tests.

### Size Details:

Current master gzip size w/o closure compiler
**GZIP SIZE:** 3923

Current master gzip size w closure compiler
**GZIP SIZE:** 3755

Compiled bundle diff (after pretty printing diff):
https://gist.github.com/samccone/7eb10742f632e4de08af594de35e4aca


--------

### Opportunities for additional shrinking

Looking at the bundle we can see places where we can get some major wins:

If anyone can think of a smaller way to represent or create either of these structures please do share:

```js
        sa = {
            boxFlex: 1,
            boxFlexGroup: 1,
            columnCount: 1,
            fillOpacity: 1,
            flex: 1,
            flexGrow: 1,
            flexPositive: 1,
            flexShrink: 1,
            flexNegative: 1,
            fontWeight: 1,
            lineClamp: 1,
            lineHeight: 1,
            opacity: 1,
            order: 1,
            orphans: 1,
            strokeOpacity: 1,
            widows: 1,
            zIndex: 1,
            zoom: 1
        },
```

```js
        fa = {
            blur: 1,
            error: 1,
            focus: 1,
            load: 1,
            resize: 1,
            scroll: 1
        },
```



--------

Now the question is, is a 4% savings really worth the overhead and maintenance cost of closure compiler.. maybe maybe not..

~~So on that note I will close this out and leave it as an engineering artifact to potentially be referenced in the future. 🕊~~

<details>
```
**3/4/17**

ok now we are at 1 warning which I am not sure why closure is not matching up the types.. but... I choose to ignore it for now

dist/preact.dev.js:83: WARNING - cannot instantiate non-constructor
        var p = new VNode(nodeName, attributes || undefined, children || EMPTY_CHILDREN);
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
</details>
