### PR TITLE
Add basic typings for supported class-level (static) Component properties

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -39,6 +39,9 @@ declare namespace preact {
 	abstract class Component<PropsType, StateType> implements ComponentLifecycle<PropsType, StateType> {
 		constructor(props?:PropsType);
 
+		static displayName?:string;
+		static defaultProps?:any;
+
 		state:StateType;
 		props:PropsType & ComponentProps;
 		base:HTMLElement;


### PR DESCRIPTION
This PR addresses a few relatively minor obstacles to using Preact "out of the box" -- i.e., without having to create your own types to handle what are really ecosystem-standard properties -- in a TypeScript project. The obstacles are related to the absence of typings for static (class-level) Component variables, namely `displayName` and `defaultProps`.

**Obstacle 1:**

Suppose that you are writing a higher-order component (HOC) that wraps a Preact Component, and you want to create a reasonable displayName for the HOC on the basis of the wrapped component's displayName. Trying to read the `displayName` property of the Preact Component results in complaints from the TypeScript compiler that that property does not exist on the type. For example:

```typescript
function getName(component: typeof preact.Component): string {
    return component.displayName || component.name || 'Component';
}
```

The compiler complains that `displayName` does not exist on the type.

**Obstacle 2:**

If you're writing an ordinary (not higher-order) Preact Component and you want type-checking for ecosystem-standard static properties (`displayName` and `defaultProps`), you won't have any. For example:

```typescript
class SomeComponent extends Component<SomeProps, SomeState> {
    static displayName = { lol: 'wut' };
    // . . . 
}
```

In that case, the compiler will not complain, which is sub-optimal. Likewise:

```typescript
class SomeComponent extends Component<SomeProps, SomeState> {
    // . . . 
}
SomeComponent.displayName = 'SomeComponent';
SomeComponent.defaultProps = { someProp: 'lol' };
```

Here, the compiler complains that the latter two properties do not exist on the type.

The PR fixes these issues. It validates `displayName` as a string, if present, and `defaultProps` as "any", if present (at the moment, anyway; I might prefer changing the type for `defaultProps` to "object", which is really what's desired, but I'm not sure whether this project wants its type definitions to be supported only by the latest version of TypeScript (2.2); if so, please let me know and I will update the PR!).