### PR TITLE
Add TypeScript typings for functional components and inclusive components

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -1,5 +1,5 @@
 declare namespace preact {
-	interface ComponentProps<C extends Component<any, any>> {
+	interface ComponentProps<C extends (Component<any, any> | StatelessComponent<any>)> {
 		children?:JSX.Element[];
 		key?:string | number | any;
 		ref?:(el: C) => void;
@@ -37,15 +37,14 @@ declare namespace preact {
 		new (props?:PropsType):Component<PropsType, StateType>;
 	}
 
-	interface FunctionalComponent<PropsType> {
-		(props:PropsType & ComponentProps, context?:any):JSX.Element;
+	interface StatelessComponent<PropsType> {
+		(props:PropsType & ComponentProps<this>, context?:any):JSX.Element;
 		displayName?:string;
 		defaultProps?:any;
 	}
 
-	// An "inclusive" component is a component that is either a functional
-	// component or a more full-fledged component.
-	type InclusiveComponent<PropsType, StateType> = FunctionalComponent<PropsType> | typeof Component;
+    // Type alias for a component considered generally, whether stateless or stateful.
+	type AnyComponent<PropsType, StateType> = StatelessComponent<PropsType> | typeof Component;
 
 	abstract class Component<PropsType, StateType> implements ComponentLifecycle<PropsType, StateType> {
 		constructor(props?:PropsType);

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -36,6 +36,16 @@ declare namespace preact {
 		new (props?:PropsType):Component<PropsType, StateType>;
 	}
 
+	interface FunctionalComponent<PropsType> {
+		(props:PropsType & ComponentProps, context?:any):JSX.Element;
+		displayName?:string;
+		defaultProps?:any;
+	}
+
+	// An "inclusive" component is a component that is either a functional
+	// component or a more full-fledged component.
+	type InclusiveComponent<PropsType, StateType> = FunctionalComponent<PropsType> | typeof Component;
+
 	abstract class Component<PropsType, StateType> implements ComponentLifecycle<PropsType, StateType> {
 		constructor(props?:PropsType);
 


### PR DESCRIPTION
This PR contains a few more proposed improvements to Preact's TypeScript declarations, related tangentially to some things mentioned in PR #573. In #573, I mentioned that the compiler complains at times when you do things with higher-order components, like so:

```typescript
function getName(component: typeof preact.Component): string {
    return component.displayName || component.name || 'Component';
}
```

The issue in #573 was with the `displayName` property. But _this_ PR addresses the fact that there also appears to be no out-of-the-box way to do similar things with _functional_ Preact components as opposed to "full-fledged" components (i.e., components with the full lifecycle implementation). That is, there seems to be no _out-of-the-box_ way (i.e., without creating my own custom types) to do something like this:

```typescript
// I avoided the name "GenericComponent" because the term "generic" is overloaded in the context of Typescript, so "InclusiveComponent" it is.
function getName(component: preact.InclusiveComponent<any, any>): string {
    return component.displayName || component.name || 'Component';
}
```

or even like this:

```typescript
function getName(component: typeof preact.Component | preact.FunctionalComponent<any>): string {
    return component.displayName || component.name || 'Component';
}
```

Ideally, I would be able to specify that a higher-order function accepts Preact components generally, whether those components are mere functional components or are "full-fledged" components, as in the first of the two preceding examples (without having to create my own types, since functional components are standard to the ecosystem and are widely used interchangeably with full-fledged components). This PR lets you do that, with type-checking/without the TypeScript compiler complaining.