### PR TITLE
Devtools: Protect against instantiating Map in browsers that don't support it

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -132,7 +132,7 @@ function createReactCompositeComponent(component) {
  * The same React*Component instance must be used when notifying devtools
  * about the initial mount of a component and subsequent updates.
  */
-let instanceMap = new Map();
+let instanceMap = typeof Map==='function' && new Map();
 
 /**
  * Update (and create if necessary) the ReactDOMComponent|ReactCompositeComponent-like
@@ -177,7 +177,7 @@ function findRoots(node, roots) {
 /**
  * Map of functional component name -> wrapper class.
  */
-let functionalComponentWrappers = new Map();
+let functionalComponentWrappers = typeof Map==='function' && new Map();
 
 /**
  * Wrap a functional component with a stateful component.


### PR DESCRIPTION
For pages that have react/devtools loaded, if you open them in older browsers like IE9, they fail because of the attempt to instantiate Map at the top level of the devtools file.  Just add some protection to only instantiate them if you can.  Since you can't add devtools to browsers that don't support Map, no harm is done with this.