### PR TITLE
Conditional import of devtools based on NODE_ENV

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -1,4 +1,4 @@
-import { initDevTools } from './devtools';
-
-initDevTools();
-
+if (NODE_ENV !== 'production') {
+	const initDevTools = require('./devtools').initDevTools;
+	initDevTools();
+}


### PR DESCRIPTION
An attempt to address https://github.com/developit/preact/issues/431 to make `devtools` conditional and NOT in production.