### PR TITLE
Speed up children pairing by avoiding array holes & branching

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -227,11 +227,11 @@ function innerDiffNode(dom, vchildren, context, mountAll, absorb) {
 			else if (!child && min<childrenLen) {
 				for (j=min; j<childrenLen; j++) {
 					c = children[j];
-					if (c && isSameNodeType(c, vchild)) {
+					if (isSameNodeType(c, vchild)) {
 						child = c;
-						children[j] = undefined;
-						if (j===childrenLen-1) childrenLen--;
-						if (j===min) min++;
+						children[j] = children[min];
+						children[min] = undefined;
+						min++
 						break;
 					}
 				}

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -231,7 +231,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, absorb) {
 						child = c;
 						children[j] = children[min];
 						children[min] = undefined;
-						min++
+						min++;
 						break;
 					}
 				}


### PR DESCRIPTION
In my (admittedly, limited) testing, this looks like about a 2% win on the existing perf tests.

In certain circumstances, it does change the order in which key-less child vnodes get paired with child DOM nodes. Here's an example:

Previous contents were: `<a>1</a> <a>2</a> <div>3</div>`
New vnode children are: `<div>0</div> <a>1</a> <a>2</a>`

When searching for a child dom node to match the new first `div`, we end up finding `<div>3</div>` and reusing it. We then fill in its hole with `<a>1</a>`, meaning that the new nodes will be paired with the flipped DOM nodes.

So whether this is a win or loss depends in large part on the structure of changes inside each component.