### PR TITLE
Changed ATTR_KEY value to be a bit shorter and save 12 bytes of bandwidth

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ export const FORCE_RENDER = 2;
 export const ASYNC_RENDER = 3;
 
 
-export const ATTR_KEY = '__preactattr_';
+export const ATTR_KEY = '__preattr_';
 
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;


### PR DESCRIPTION
This probably won't get merged but I just had this crazy idea that preact might save some bandwith by reducing the `ATTR_KEY` internal property value to be a bit shorter

Before:
```js
MacBook-Pro-2:preact TomaszLakomy$ npm run build

> preact@8.0.1 build /Users/macos/Stuff/preact
> npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size

⚠️   'default' is imported from external module 'rollup-plugin-node-resolve' but never used

Inlining constant: NO_RENDER=0
Inlining constant: SYNC_RENDER=1
Inlining constant: FORCE_RENDER=2
Inlining constant: ASYNC_RENDER=3
Inlining constant: ATTR_KEY='__preactattr_'
gzip size: 3372
```

After:
```js
MacBook-Pro-2:preact TomaszLakomy$ npm run build

> preact@8.0.1 build /Users/macos/Stuff/preact
> npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size

⚠️   'default' is imported from external module 'rollup-plugin-node-resolve' but never used

Inlining constant: NO_RENDER=0
Inlining constant: SYNC_RENDER=1
Inlining constant: FORCE_RENDER=2
Inlining constant: ASYNC_RENDER=3
Inlining constant: ATTR_KEY='__preattr_'
gzip size: 3360
```