### PR TITLE
TS: Add missing onLoad event declaration

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -364,6 +364,9 @@ declare namespace JSX {
 	type GenericEventHandler = EventHandler<Event>;
 
 	interface DOMAttributes {
+		// Image Events
+		onLoad?:GenericEventHandler;
+
 		// Clipboard Events
 		onCopy?:ClipboardEventHandler;
 		onCut?:ClipboardEventHandler;


### PR DESCRIPTION
The definition fils for TypeScript currently lack an `onLoad` handler for `<img>`-Elements. This PR adds the missing declaration.