### PR TITLE
Reduced minimied & gzipped preact size by 25 bytes

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -32,6 +32,7 @@ export function removeNode(node) {
  *	@private
  */
 export function setAccessor(node, name, old, value, isSvg) {
+	let i;
 	if (name==='className') name = 'class';
 
 
@@ -51,9 +52,9 @@ export function setAccessor(node, name, old, value, isSvg) {
 		}
 		if (value && typeof value==='object') {
 			if (typeof old!=='string') {
-				for (let i in old) if (!(i in value)) node.style[i] = '';
+				for (i in old) if (!(i in value)) node.style[i] = '';
 			}
-			for (let i in value) {
+			for (i in value) {
 				node.style[i] = typeof value[i]==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (value[i]+'px') : value[i];
 			}
 		}
@@ -61,7 +62,7 @@ export function setAccessor(node, name, old, value, isSvg) {
 	else if (name==='dangerouslySetInnerHTML') {
 		if (value) node.innerHTML = value.__html || '';
 	}
-	else if (name[0]=='o' && name[1]=='n') {
+	else if (name.slice(0,2)==='on') {
 		let useCapture = name !== (name=name.replace(/Capture$/, ''));
 		name = name.toLowerCase().substring(2);
 		if (value) {
@@ -73,7 +74,12 @@ export function setAccessor(node, name, old, value, isSvg) {
 		(node._listeners || (node._listeners = {}))[name] = value;
 	}
 	else if (name!=='list' && name!=='type' && !isSvg && name in node) {
-		setProperty(node, name, value==null ? '' : value);
+        /** Attempt to set a DOM property to the given value.
+         *	IE & FF throw for certain property-value combinations.
+         */
+		try {
+			node[name] = value==null ? '' : value;
+		} catch (e) { }
 		if (value==null || value===false) node.removeAttribute(name);
 	}
 	else {
@@ -88,17 +94,6 @@ export function setAccessor(node, name, old, value, isSvg) {
 		}
 	}
 }
-
-
-/** Attempt to set a DOM property to the given value.
- *	IE & FF throw for certain property-value combinations.
- */
-function setProperty(node, name, value) {
-	try {
-		node[name] = value;
-	} catch (e) { }
-}
-
 
 /** Proxy an event to hooked event handlers
  *	@private

--- a/src/h.js
+++ b/src/h.js
@@ -4,15 +4,13 @@ import options from './options';
 
 const stack = [];
 
-const EMPTY_CHILDREN = [];
-
 /** JSX/hyperscript reviver
 *	Benchmarks: https://esbench.com/bench/57ee8f8e330ab09900a1a1a0
  *	@see http://jasonformat.com/wtf-is-jsx
  *	@public
  */
 export function h(nodeName, attributes) {
-	let children=EMPTY_CHILDREN, lastSimple, child, simple, i;
+	let children=[], lastSimple, child, simple, i;
 	for (i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
 	}
@@ -36,7 +34,7 @@ export function h(nodeName, attributes) {
 			if (simple && lastSimple) {
 				children[children.length-1] += child;
 			}
-			else if (children===EMPTY_CHILDREN) {
+			else if (children===[]) {
 				children = [child];
 			}
 			else {

--- a/src/render-queue.js
+++ b/src/render-queue.js
@@ -15,7 +15,7 @@ export function enqueueRender(component) {
 export function rerender() {
 	let p, list = items;
 	items = [];
-	while ( (p = list.pop()) ) {
+	while ((p = list.pop()) ) {
 		if (p._dirty) renderComponent(p);
 	}
 }

--- a/src/util.js
+++ b/src/util.js
@@ -6,5 +6,3 @@ export function extend(obj, props) {
 	for (let i in props) obj[i] = props[i];
 	return obj;
 }
-
-

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -9,8 +9,7 @@ const components = {};
 
 /** Reclaim a component for later re-use by the recycler. */
 export function collectComponent(component) {
-	let name = component.constructor.name;
-	(components[name] || (components[name] = [])).push(component);
+	(components[component.constructor.name] || (components[component.constructor.name] = [])).push(component);
 }
 
 

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -78,12 +78,8 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		component.props = previousProps;
 		component.state = previousState;
 		component.context = previousContext;
-		if (opts!==FORCE_RENDER
-			&& component.shouldComponentUpdate
-			&& component.shouldComponentUpdate(props, state, context) === false) {
-			skip = true;
-		}
-		else if (component.componentWillUpdate) {
+		skip = opts!==FORCE_RENDER && component.shouldComponentUpdate && component.shouldComponentUpdate(props, state, context) === false;
+		if (component.componentWillUpdate) {
 			component.componentWillUpdate(props, state, context);
 		}
 		component.props = props;

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -166,7 +166,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 		j, c, vchild, child;
 
 	// Build up a map of keyed children and an Array of unkeyed children:
-	if (len!==0) {
+	if (len!=0) {
 		for (let i=0; i<len; i++) {
 			let child = originalChildren[i],
 				props = child[ATTR_KEY],
@@ -181,7 +181,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 		}
 	}
 
-	if (vlen!==0) {
+	if (vlen!=0) {
 		for (let i=0; i<vlen; i++) {
 			vchild = vchildren[i];
 			child = null;
@@ -254,7 +254,7 @@ export function recollectNodeTree(node, unmountOnly) {
 	else {
 		// If the node's VNode had a ref function, invoke it with null here.
 		// (this is part of the React spec, and smart for unsetting references)
-		if (node[ATTR_KEY]!=null && node[ATTR_KEY].ref) node[ATTR_KEY].ref(null);
+		if (node[ATTR_KEY]  && node[ATTR_KEY].ref) node[ATTR_KEY].ref(null);
 
 		if (unmountOnly===false || node[ATTR_KEY]==null) {
 			removeNode(node);


### PR DESCRIPTION
Before:
```js
MacBook-Pro-2:preact TomaszLakomy$ npm run build

> preact@8.0.1 build /Users/macos/Stuff/preact
> npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size

⚠️   'default' is imported from external module 'rollup-plugin-node-resolve' but never used

Inlining constant: NO_RENDER=0
Inlining constant: SYNC_RENDER=1
Inlining constant: FORCE_RENDER=2
Inlining constant: ASYNC_RENDER=3
Inlining constant: ATTR_KEY='__preactattr_'
gzip size: 3372
```

After:
```js
MacBook-Pro-2:preact TomaszLakomy$ npm run build

> preact@8.0.1 build /Users/macos/Stuff/preact
> npm-run-all --silent clean transpile copy-flow-definition copy-typescript-definition strip optimize minify size

⚠️   'default' is imported from external module 'rollup-plugin-node-resolve' but never used

Inlining constant: NO_RENDER=0
Inlining constant: SYNC_RENDER=1
Inlining constant: FORCE_RENDER=2
Inlining constant: ASYNC_RENDER=3
Inlining constant: ATTR_KEY='__preactattr_'
gzip size: 3347
```

All unit tests are passing 👍 