### PR TITLE
Add test for rendering a component with text nodes

### DIFF
--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -208,4 +208,13 @@ describe('h(jsx)', () => {
 			.with.property('children')
 			.that.deep.equals(['onetwothree']);
 	});
+
+	it('should not merge children of components', () => {
+		let Component = ({children}) => children;
+		let r = h(Component, null, 'x', 'y');
+
+		expect(r).to.be.an('object')
+			.with.property('children')
+			.that.deep.equals(['x', 'y']);
+	});
 });


### PR DESCRIPTION
The implementation of `h` [suggests](https://git.io/vSApQ) that textual children of components should not be merged. However, there is no test coverage of this behavior. So I added some!

Is that actually the case? And if so, why are text nodes of components not merged?