### PR TITLE
Update types to use autoFocus instead of autofocus

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -471,7 +471,7 @@ declare namespace JSX {
 		alt?:string;
 		async?:boolean;
 		autocomplete?:string;
-		autofocus?:boolean;
+		autoFocus?:boolean;
 		autoPlay?:boolean;
 		capture?:boolean;
 		cellPadding?:number | string;


### PR DESCRIPTION
React uses `autoFocus` and that's what seems to work most reliably in preact as well, so I think this type may just be wrong.