### PR TITLE
Fix attributes diff on DOM node

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Preact supports modern browsers and IE9+:
 - [**Color Picker**](https://colors.now.sh) _([Github Project](https://github.com/lukeed/colors-app))_ :art:
 - [**Rainbow Explorer**](https://use-the-platform.com/rainbow-explorer/) _([Github Project](https://github.com/vaneenige/rainbow-explorer/))_ :rainbow:
 - [**Offline Gallery**](https://use-the-platform.com/offline-gallery/) _([Github Project](https://github.com/vaneenige/offline-gallery/))_ :balloon:
+- [**Periodic Weather**](https://use-the-platform.com/periodic-weather/) _([Github Project](https://github.com/vaneenige/periodic-weather/))_ :sunny:
 
 ## Libraries & Add-ons
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -121,8 +121,16 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 
 	let fc = out.firstChild,
-		props = out[ATTR_KEY] || (out[ATTR_KEY] = {}),
+		props,
 		vchildren = vnode.children;
+
+	if (out[ATTR_KEY]) {
+		props = out[ATTR_KEY];
+	}
+	else {
+		props = out[ATTR_KEY] = {};
+		for (let a=out.attributes, i=a.length; i--; ) props[a[i].name] = a[i].value;
+	}
 
 	// Optimization: fast-path for elements containing a single TextNode:
 	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc.splitText!==undefined && fc.nextSibling==null) {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -406,7 +406,7 @@ describe('render()', () => {
 		expect(scratch.innerHTML, 're-set').to.equal('<div>'+html+'</div>');
 	});
 
-	it( 'should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
+	it('should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
 		class Thing extends Component {
 			constructor(props, context) {
 				super(props, context);
@@ -494,6 +494,20 @@ describe('render()', () => {
 		expect(scratch.firstChild.lastChild).to.have.property('nodeName', 'A');
 		expect(scratch.firstChild.firstChild).to.equal(b);
 		expect(scratch.firstChild.lastChild).to.equal(a);
+	});
+
+	it('should not merge attributes with node created by the DOM', () => {
+		const html = (htmlString) => {
+			const div = document.createElement('div');
+			div.innerHTML = htmlString;
+			return div.firstChild;
+		};
+
+		const DOMElement = html`<div><a foo="bar"></a></div>`;
+		const preactElement = <div><a></a></div>;
+
+		render(preactElement, scratch, DOMElement);
+		expect(scratch).to.have.property('innerHTML', '<div><a></a></div>');
 	});
 
 	it('should skip non-preact elements', () => {


### PR DESCRIPTION
### Expected behaviour 

Diff should remove attributes when they are no longer present in the next html state (see [unit test](https://github.com/developit/preact/compare/master...dmail-fork:master?expand=1#diff-a1195645838de4f080fcb358b5132a4cR499))

### Actual behaviour

It behaves as expected when the merged node is created using `h`.
It preserves removed attributes when the merged node comes from the DOM.

### Possible solutions

- I suggest to approve this pull request :)