### PR TITLE
TypeScript definitions update: allow tabIndex value to be string

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -574,7 +574,7 @@ declare namespace JSX {
 		step?:number | string;
 		style?:any;
 		summary?:string;
-		tabIndex?:number;
+		tabIndex?:number | string;
 		target?:string;
 		title?:string;
 		type?:string;


### PR DESCRIPTION
A lot of devs set tabIndex="1", this diff allows that use case in addition to
tabIndex = {1}.