### PR TITLE
Use typeof to test booleaness.

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -25,7 +25,7 @@ export function h(nodeName, attributes) {
 			for (i=child.length; i--; ) stack.push(child[i]);
 		}
 		else {
-			if (child===true || child===false) child = null;
+			if (typeof child==='boolean') child = null;
 
 			if ((simple = typeof nodeName!=='function')) {
 				if (child==null) child = '';

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -66,7 +66,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 		prevSvgMode = isSvgMode;
 
 	// empty values (null, undefined, booleans) render as empty Text nodes
-	if (vnode==null || vnode===false || vnode===true) vnode = '';
+	if (vnode==null || typeof vnode==='boolean') vnode = '';
 
 
 	// Fast case: Strings & Numbers create/update Text nodes.


### PR DESCRIPTION
Using the typeof check is shorter, and in case of Chrome also faster at
this point as shown in https://esbench.com/bench/591b46f299634800a03481f8
(upstream bug to address this at http://crbug.com/v8/6403). I personally
also find the typeof version more readable, as it makes it clear what
the intent was.