### PR TITLE
Load vnode.nodeName only once.

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -94,18 +94,20 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 
 	// If the VNode represents a Component, perform a component diff:
-	if (typeof vnode.nodeName==='function') {
+	let vnodeName = vnode.nodeName;
+	if (typeof vnodeName==='function') {
 		return buildComponentFromVNode(dom, vnode, context, mountAll);
 	}
 
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
-	isSvgMode = vnode.nodeName==='svg' ? true : vnode.nodeName==='foreignObject' ? false : isSvgMode;
+	isSvgMode = vnodeName==='svg' ? true : vnodeName==='foreignObject' ? false : isSvgMode;
 
 
 	// If there's no existing element or it's the wrong type, create a new one:
-	if (!dom || !isNamedNode(dom, String(vnode.nodeName))) {
-		out = createNode(String(vnode.nodeName), isSvgMode);
+	vnodeName = String(vnodeName);
+	if (!dom || !isNamedNode(dom, vnodeName)) {
+		out = createNode(vnodeName, isSvgMode);
 
 		if (dom) {
 			// move children into the replacement node


### PR DESCRIPTION
Since idiff is invoked on all kinds of virtual nodes, the property
access vnode.nodeName is usually megamorphic in any realistic workload,
so it's better for the JS engine to load the property only once.

Also apply the String constructor only once to the vnode.nodeName,
because the String constructor can have arbitrary side-effects (since it
can call out to Symbol.toPrimitive, valueOf or toString), and thus
requires magic on the engines' side to optimize this away, which doesn't
always kick in (and is costly).