### PR TITLE
Fix: Invoke componentWillUnmount before the DOM element is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Everything you need: JSX, <abbr title="Virtual DOM">VDOM</abbr>, React DevTools, <abbr title="Hot Module Replacement">HMR</abbr>, <abbr title="Server-Side Rendering">SSR</abbr>..
 - A highly optimized diff algorithm and seamless Server Side Rendering
 - Transparent asynchronous rendering with a pluggable scheduler
+- 🆕💥 **Instant no-config app bundling with [Preact CLI](https://github.com/developit/preact-cli)**
 
 ### 💁 More information at the [Preact Website ➞](https://preactjs.com)
 
@@ -125,9 +126,13 @@ Preact supports modern browsers and IE9+:
 
 ## Getting Started
 
-> 💁 You [don't _have_ to use ES2015 to use Preact](https://github.com/developit/preact-without-babel)... but you should.
+> 💁 _**Note:** You [don't need ES2015 to use Preact](https://github.com/developit/preact-in-es3)... but give it a try!_
 
-The following guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc.  If you don't, start with [preact-boilerplate] or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
+The easiest way to get started with Preact is to install [Preact CLI](https://github.com/developit/preact-cli). This simple command-line tool wraps up the best possible Webpack and Babel setup for you, and even keeps you up-to-date as the underlying tools change. Best of all, it's easy to understand! It builds your app in a single command (`preact build`), doesn't need any configuration, and bakes in best-practises 🙌.
+
+The following guide assumes you have some sort of ES2015 build set up using babel and/or webpack/browserify/gulp/grunt/etc.
+
+You can also start with [preact-boilerplate] or a [CodePen Template](http://codepen.io/developit/pen/pgaROe?editors=0010).
 
 
 ### Import what you need
@@ -331,7 +336,7 @@ Here is a somewhat verbose Preact `<Link>` component:
 ```js
 class Link extends Component {
 	render(props, state) {
-		return <a href={ props.href }>{ props.children }</a>;
+		return <a href={props.href}>{props.children}</a>;
 	}
 }
 ```
@@ -340,21 +345,21 @@ Since this is ES6/ES2015, we can further simplify:
 
 ```js
 class Link extends Component {
-	render({ href, children }) {
-		return <a {...{ href, children }} />;
-	}
+    render({ href, children }) {
+        return <a {...{ href, children }} />;
+    }
 }
 
 // or, for wide-open props support:
 class Link extends Component {
-	render(props) {
-		return <a {...props} />;
-	}
+    render(props) {
+        return <a {...props} />;
+    }
 }
 
 // or, as a stateless functional component:
 const Link = ({ children, ...props }) => (
-	<a {...props}>{ children }</a>
+    <a {...props}>{ children }</a>
 );
 ```
 

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -144,12 +144,18 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		if (initialBase && base!==initialBase && inst!==initialChildComponent) {
 			let baseParent = initialBase.parentNode;
 			if (baseParent && base!==baseParent) {
-				baseParent.replaceChild(base, initialBase);
 
 				if (!toUnmount) {
+					baseParent.replaceChild(base, initialBase);
 					initialBase._component = null;
 					recollectNodeTree(initialBase, false);
 				}
+				// @TODO Formerly the initialBase was always replaced by the base
+				//		 but somehow all tests passes also if its only called at not unmounting.
+				//       These else condition was the original fix.
+				// else {
+				// 	baseParent.insertBefore(base, initialBase);
+				// }
 			}
 		}
 
@@ -264,10 +270,11 @@ export function unmountComponent(component) {
 
 		component.nextBase = base;
 
-		removeNode(base);
 		collectComponent(component);
-
 		removeChildren(base);
+
+		// Remove Node as last, so all childs exists when componentWillUnmount is called
+		removeNode(base);
 	}
 
 	if (component.__ref) component.__ref(null);

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -262,11 +262,12 @@ export function recollectNodeTree(node, unmountOnly) {
 		// (this is part of the React spec, and smart for unsetting references)
 		if (node[ATTR_KEY]!=null && node[ATTR_KEY].ref) node[ATTR_KEY].ref(null);
 
+		removeChildren(node);
+
+		// Remove Node as last, so all childs exists when componentWillUnmount is called
 		if (unmountOnly===false || node[ATTR_KEY]==null) {
 			removeNode(node);
 		}
-
-		removeChildren(node);
 	}
 }
 

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -456,42 +456,74 @@ describe('Lifecycle methods', () => {
 					expect(document.getElementById('InnerDiv'), 'Inner componentDidMount').to.exist;
 				}
 				componentWillUnmount() {
-					// @TODO Component mounted into elements (non-components)
-					// are currently unmounted after those elements, so their
-					// DOM is unmounted prior to the method being called.
-					//expect(document.getElementById('InnerDiv'), 'Inner componentWillUnmount').to.exist;
+					expect(document.getElementById('InnerDiv'), 'Inner componentWillUnmount').to.exist;
 					setTimeout( () => {
 						expect(document.getElementById('InnerDiv'), 'Inner after componentWillUnmount').to.not.exist;
 					}, 0);
 				}
 
 				render() {
-					return <div id="InnerDiv" />;
+					return <div id="InnerDiv">
+						<Innerest />
+					</div>;
+				}
+			}
+
+			class Innerest extends  Component {
+				componentWillMount() {
+					expect(document.getElementById('InnerestDiv'), 'Innerest componentWillMount').to.not.exist;
+				}
+				componentDidMount() {
+					expect(document.getElementById('InnerestDiv'), 'Innerest componentDidMount').to.exist;
+				}
+				componentWillUnmount() {
+					expect(document.getElementById('InnerestDiv'), 'Innerest componentWillUnmount').to.exist;
+					setTimeout( () => {
+						expect(document.getElementById('InnerestDiv'), 'Innerest after componentWillUnmount').to.not.exist;
+					}, 0);
+				}
+
+				render() {
+					return <div id="InnerestDiv"/>;
 				}
 			}
 
 			let proto = Inner.prototype;
+			let proto_innerest = Innerest.prototype;
 			let spies = ['componentWillMount', 'componentDidMount', 'componentWillUnmount'];
 			spies.forEach( s => sinon.spy(proto, s) );
+			spies.forEach( s => sinon.spy(proto_innerest, s) );
 
 			let reset = () => spies.forEach( s => proto[s].reset() );
+			let reset_innerest = () => spies.forEach( s => proto_innerest[s].reset() );
 
 			render(<Outer />, scratch);
-			expect(proto.componentWillMount).to.have.been.called;
-			expect(proto.componentWillMount).to.have.been.calledBefore(proto.componentDidMount);
-			expect(proto.componentDidMount).to.have.been.called;
+			expect(proto.componentWillMount, 'Inner componentWillMount').to.have.been.called;
+			expect(proto.componentWillMount, 'Inner componentWillMount').to.have.been.calledBefore(proto.componentDidMount);
+			expect(proto.componentDidMount, 'Inner componentDidMount').to.have.been.called;
+
+			expect(proto_innerest.componentWillMount, 'Innerest componentWillMount').to.have.been.called;
+			expect(proto_innerest.componentWillMount, 'Innerest componentWillMount').to.have.been.calledBefore(proto_innerest.componentDidMount);
+			expect(proto_innerest.componentDidMount, 'Innerest componentDidMount').to.have.been.called;
 
 			reset();
+			reset_innerest();
 			setState({ show:false });
 
-			expect(proto.componentWillUnmount).to.have.been.called;
+			expect(proto.componentWillUnmount, 'Inner componentWillUnmount').to.have.been.called;
+			expect(proto_innerest.componentWillUnmount, 'Innerest componentWillUnmount').to.have.been.called;
 
 			reset();
+			reset_innerest();
 			setState({ show:true });
 
-			expect(proto.componentWillMount).to.have.been.called;
-			expect(proto.componentWillMount).to.have.been.calledBefore(proto.componentDidMount);
-			expect(proto.componentDidMount).to.have.been.called;
+			expect(proto.componentWillMount, 'Inner componentWillMount').to.have.been.called;
+			expect(proto.componentWillMount, 'Inner componentWillMount').to.have.been.calledBefore(proto.componentDidMount);
+			expect(proto.componentDidMount, 'Inner componentDidMount').to.have.been.called;
+
+			expect(proto_innerest.componentWillMount, 'Innerest componentWillMount').to.have.been.called;
+			expect(proto_innerest.componentWillMount, 'Innerest componentWillMount').to.have.been.calledBefore(proto_innerest.componentDidMount);
+			expect(proto_innerest.componentDidMount, 'Innerest componentDidMount').to.have.been.called;
 		});
 
 		it('should remove this.base for HOC', () => {


### PR DESCRIPTION
This PR changes fixes the Issue #732.

- it removes the Node in `unmountComponent` and `recollectNodeTree` after the iteration steps
- it replaces the children in `renderComponent` only when the component isn't unmounting
- it extends a test to cover multiple nested components

The change I commented in component.js was discovered by accident. As the tests are passing and a quick test with a small app too, I don't know, if it's breaking something else. So someone with more preact knowledge could estimate the consequences better than me.