### PR TITLE
Add library size check in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-eslint": "^6.1.0",
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.24",
-    "bundlesize": "^0.5.5",
+    "bundlesize": "^0.5.6",
     "chai": "^3.4.1",
     "copyfiles": "^1.0.0",
     "core-js": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-eslint": "^6.1.0",
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.24",
-    "bundlesize": "^0.5.6",
+    "bundlesize": "^0.5.7",
     "chai": "^3.4.1",
     "copyfiles": "^1.0.0",
     "core-js": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "minify": "uglifyjs dist/preact.js -c collapse_vars,evaluate,screw_ie8,unsafe,loops=false,keep_fargs=false,pure_getters,unused,dead_code -m -o dist/preact.min.js -p relative --in-source-map dist/preact.js.map --source-map dist/preact.min.js.map",
     "strip": "jscodeshift --run-in-band -s -t config/codemod-strip-tdz.js dist/preact.dev.js && jscodeshift --run-in-band -s -t config/codemod-const.js dist/preact.dev.js",
     "size": "node -e \"process.stdout.write('gzip size: ')\" && gzip-size dist/preact.min.js",
-    "test": "npm-run-all lint --parallel test:mocha test:karma test:ts",
+    "test": "npm-run-all lint --parallel test:mocha test:karma test:ts test:size",
     "test:ts": "tsc -p test/ts/",
     "test:mocha": "mocha --recursive --compilers js:babel/register test/shared test/node",
     "test:karma": "karma start test/karma.conf.js --single-run",
     "test:mocha:watch": "npm run test:mocha -- --watch",
     "test:karma:watch": "npm run test:karma -- no-single-run",
+    "test:size": "bundlesize",
     "lint": "eslint debug devtools src test",
     "prepublish": "npm run build",
     "smart-release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish",
@@ -72,6 +73,7 @@
     "babel-eslint": "^6.1.0",
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.24",
+    "bundlesize": "^0.5.5",
     "chai": "^3.4.1",
     "copyfiles": "^1.0.0",
     "core-js": "^2.4.1",
@@ -120,5 +122,11 @@
       "babel-runtime",
       "jscodeshift"
     ]
-  }
+  },
+  "bundlesize": [
+    {
+      "path": "./dist/preact.min.js",
+      "threshold": "4Kb"
+    }
+  ]
 }


### PR DESCRIPTION
This will help in **keeping** preact tiny.

It's basically,

this in the terminal: 

```
 PASS  ./dist/preact.min.js: 3.37kB < threshold 4kB gzip
```

and this in the pull request: 

<img src="https://raw.githubusercontent.com/siddharthkp/bundlesize/master/art/status.png" width="500px"/>

1. Setting the file and threshold:

    The config sits inside `package.json`, the threshold is set to 4kB right now.
You can add multiple files here. ([docs](https://github.com/siddharthkp/bundlesize/blob/master/README.md#configuration))

2. Authorize bundlesize:

    `bundlesize` needs access to github API with scope `repo:status`, You can follow the [steps here](https://github.com/siddharthkp/bundlesize/blob/master/README.md#build-status)

Happy to hear your feedback 😄 