### PR TITLE
Fix preact/debug accessing attributes that don't have toString

### DIFF
--- a/debug/index.js
+++ b/debug/index.js
@@ -70,17 +70,17 @@ if (process.env.NODE_ENV === 'development') {
 
 		if (attributes) {
 			props = Object.keys(attributes).map(attr => {
-        const attrValue = attributes[attr];
-        let attrValueString;
-        
-        // If it is an object but doesn't have toString(), use Object.toString
-        if (Object(attrValue) === attrValue && !attrValue.toString) {
-          attrValueString =  Object.prototype.toString.call(attrValue)
-        } else {
-          attrValueString = attrValue + '';
-        }
-        
-        return `${attr}=${JSON.stringify(attrValueString)}`;
+				const attrValue = attributes[attr];
+				let attrValueString;
+
+				// If it is an object but doesn't have toString(), use Object.toString
+				if (Object(attrValue) === attrValue && !attrValue.toString) {
+				  attrValueString =  Object.prototype.toString.call(attrValue)
+				} else {
+				  attrValueString = attrValue + '';
+				}
+
+				return `${attr}=${JSON.stringify(attrValueString)}`;
 			});
 		}
 

--- a/debug/index.js
+++ b/debug/index.js
@@ -70,7 +70,7 @@ if (process.env.NODE_ENV === 'development') {
 
 		if (attributes) {
 			props = Object.keys(attributes).map(attr => {
-				return `${attr}=${JSON.stringify(attributes[attr] + '')}`;
+				return `${attr}=${JSON.stringify(Object.prototype.toString.call(attributes[attr]))}`;
 			});
 		}
 

--- a/debug/index.js
+++ b/debug/index.js
@@ -70,7 +70,17 @@ if (process.env.NODE_ENV === 'development') {
 
 		if (attributes) {
 			props = Object.keys(attributes).map(attr => {
-				return `${attr}=${JSON.stringify(Object.prototype.toString.call(attributes[attr]))}`;
+        const attrValue = attributes[attr];
+        let attrValueString;
+        
+        // If it is an object but doesn't have toString(), use Object.toString
+        if (Object(attrValue) === attrValue && !attrValue.toString) {
+          attrValueString =  Object.prototype.toString.call(attrValue)
+        } else {
+          attrValueString = attrValue + '';
+        }
+        
+        return `${attr}=${JSON.stringify(attrValueString)}`;
 			});
 		}
 

--- a/debug/index.js
+++ b/debug/index.js
@@ -75,7 +75,7 @@ if (process.env.NODE_ENV === 'development') {
 
 				// If it is an object but doesn't have toString(), use Object.toString
 				if (Object(attrValue) === attrValue && !attrValue.toString) {
-				  attrValueString =  Object.prototype.toString.call(attrValue)
+				  attrValueString = Object.prototype.toString.call(attrValue);
 				} else {
 				  attrValueString = attrValue + '';
 				}


### PR DESCRIPTION
In some rare cases (e.g. `Object.create(null)`), a prop value doesn't have the `toString()` function, and thus cannot be cast to a string, throwing `TypeError: Cannot convert object to primitive value`. This should fix that.