### PR TITLE
Update createNode to use prevSvgMode for foreignObject

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -108,7 +108,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	// If there's no existing element or it's the wrong type, create a new one:
 	vnodeName = String(vnodeName);
 	if (!dom || !isNamedNode(dom, vnodeName)) {
-		out = createNode(vnodeName, isSvgMode);
+		out = createNode(vnodeName, vnodeName==='foreignObject' ? prevSvgMode : isSvgMode);
 
 		if (dom) {
 			// move children into the replacement node


### PR DESCRIPTION
Updating idiff createNode to use prevSvgMode instead of isSvgMode when the element is foreignObject because foreignObject is still an SVG node

https://github.com/developit/preact/issues/771