### PR TITLE
Don't add undefined children to props

### DIFF
--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -35,7 +35,9 @@ export function isNamedNode(node, nodeName) {
  */
 export function getNodeProps(vnode) {
 	let props = extend({}, vnode.attributes);
-	props.children = vnode.children;
+	if (vnode.children!==undefined) {
+		props.children = vnode.children;
+	}
 
 	let defaultProps = vnode.nodeName.defaultProps;
 	if (defaultProps!==undefined) {


### PR DESCRIPTION
When you use `preact-compat` or remove children from the vnode manually, children are still provided as an undefined key inside the props.

This produces a problem, when you use a library like `paypal-checkout` which is checking the props-keys against their limited props definitions.

![bildschirmfoto 2017-07-27 um 18 02 12](https://user-images.githubusercontent.com/14992140/28684656-786f4d14-7305-11e7-91da-209bf4b4b52b.png)

> Uncaught Error: [paypal-button] Invalid prop: children
>     at Component.error (index.js:343)
>     at Object.validateProps [as c] (validate.js:88)
>     at ParentComponent.setProps (index.js:358)
>     at new ParentComponent (index.js:49)
>     at Component.init (index.js:355)
>     at _class2.componentDidMount (react.js:28)
>     at flushMounts (app.js:398)
>     at diff (app.js:427)
>     at render (app.js:1059)
>     at app.js:1368
> 

So, this PR will not add children to props, if children are `undefined` inside the `vnode`. And actually nothing will change, `props.children === undefined` is still `true`.