### PR TITLE
No undef childs with extended extend, POC

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -2,8 +2,11 @@
  *	@returns obj
  *	@private
  */
-export function extend(obj, props) {
-	for (let i in props) obj[i] = props[i];
+export function extend(obj, props, noOverride) {
+	for (let i in props) {
+		if (noOverride && obj[i]!==undefined) continue;
+		obj[i] = props[i];
+	}
 	return obj;
 }
 

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -34,17 +34,10 @@ export function isNamedNode(node, nodeName) {
  * @returns {Object} props
  */
 export function getNodeProps(vnode) {
-	let props = extend({}, vnode.attributes);
-	props.children = vnode.children;
+	let props = vnode.children!==undefined ? { children: vnode.children } : {};
+	props = extend(props, vnode.attributes);
 
-	let defaultProps = vnode.nodeName.defaultProps;
-	if (defaultProps!==undefined) {
-		for (let i in defaultProps) {
-			if (props[i]===undefined) {
-				props[i] = defaultProps[i];
-			}
-		}
-	}
-
-	return props;
+	return vnode.nodeName.defaultProps!==undefined
+		? extend(props, vnode.nodeName.defaultProps, true)
+		: props;
 }

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -34,10 +34,12 @@ export function isNamedNode(node, nodeName) {
  * @returns {Object} props
  */
 export function getNodeProps(vnode) {
-	let props = vnode.children!==undefined ? { children: vnode.children } : {};
+	let children = vnode.children;
+	let props = children!==undefined ? { children } : {};
 	props = extend(props, vnode.attributes);
 
-	return vnode.nodeName.defaultProps!==undefined
-		? extend(props, vnode.nodeName.defaultProps, true)
+	let defaultProps = vnode.nodeName.defaultProps;
+	return defaultProps!==undefined
+		? extend(props, defaultProps, true)
 		: props;
 }


### PR DESCRIPTION
@developit This PR is just another approach to deal with the undefined props (children) problem.
It extends the extend util to reuse it when assigning default props, because the main logic of the loop is the same, except we do not allow to override defined `obj` props.
