### PR TITLE
Move babel settings to a .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,23 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "loose": true,
+        "exclude": [
+          "transform-es2015-typeof-symbol"
+        ],
+        "targets": {
+          "browsers": [
+            "last 2 versions",
+            "IE >= 9"
+          ]
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-react-jsx"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -118,29 +118,6 @@
     "uglify-js": "^2.7.5",
     "webpack": "^2.4.1"
   },
-  "babel": {
-    "presets": [
-      [
-        "env",
-        {
-          "loose": true,
-          "exclude": [
-            "transform-es2015-typeof-symbol"
-          ],
-          "targets": {
-            "browsers": [
-              "last 2 versions",
-              "IE >= 9"
-            ]
-          }
-        }
-      ]
-    ],
-    "plugins": [
-      "transform-object-rest-spread",
-      "transform-react-jsx"
-    ]
-  },
   "greenkeeper": {
     "ignore": [
       "babel-cli",


### PR DESCRIPTION
Fixes #820 

Since the .babelrc doesn't match the package's `files` list, it won't be included in the published package. This means that users who don't exclude node_modules from transpilation will be able to use preact without it requiring them to have preact's internal babel presets and plugins installed (which isn't necessary if they're depending on the pre-transpiled version in `dist`)