### PR TITLE
Add support for create-react-class Components

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -83,7 +83,7 @@ function typeName(element) {
  */
 function createReactCompositeComponent(component) {
 	const _currentElement = createReactElement(component);
-	const node = component.base;
+	const node = component.base || component.rootNode;
 
 	let instance = {
 		// --- ReactDOMComponent properties


### PR DESCRIPTION
This is to handle create-react-class components such as rc-tooltip, which don't have constructors or component.base defined, causing the page to break when loading dev tools.