### PR TITLE
extend() uses Object.assign() 

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -3,8 +3,7 @@
  *	@private
  */
 export function extend(obj, props) {
-	for (let i in props) obj[i] = props[i];
-	return obj;
+	return Object.assign(obj, props);
 }
 
 /** Call a function asynchronously, as soon as possible.


### PR DESCRIPTION
Instead of manually doing the loop, use the widely support Object.assign
Ref: http://kangax.github.io/compat-table/es6/#test-Object_static_methods_Object.assign