### PR TITLE
Try: Fix preact diff algorithm causing the constantly unmouting/remounting bug

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const ASYNC_RENDER = 3;
 
 
 export const ATTR_KEY = '__preactattr_';
+export const ELT_KEY_PREFIX = 'preact-';
 
 // DOM properties that should NOT have "px" added when numeric
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;

--- a/src/h.js
+++ b/src/h.js
@@ -12,7 +12,7 @@ const EMPTY_CHILDREN = [];
  *	@public
  */
 export function h(nodeName, attributes) {
-	let children=EMPTY_CHILDREN, lastSimple, child, simple, i;
+	let children=EMPTY_CHILDREN, child, i;
 	for (i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
 	}
@@ -27,23 +27,17 @@ export function h(nodeName, attributes) {
 		else {
 			if (typeof child==='boolean') child = null;
 
-			if ((simple = typeof nodeName!=='function')) {
+			if (typeof nodeName!=='function') {
 				if (child==null) child = '';
 				else if (typeof child==='number') child = String(child);
-				else if (typeof child!=='string') simple = false;
 			}
 
-			if (simple && lastSimple) {
-				children[children.length-1] += child;
-			}
-			else if (children===EMPTY_CHILDREN) {
+			if (children === EMPTY_CHILDREN) {
 				children = [child];
 			}
 			else {
 				children.push(child);
 			}
-
-			lastSimple = simple;
 		}
 	}
 

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,22 +1,6 @@
 import { extend } from '../util';
 
 
-/** Check if two nodes are equivalent.
- *	@param {Element} node
- *	@param {VNode} vnode
- *	@private
- */
-export function isSameNodeType(node, vnode, hydrating) {
-	if (typeof vnode==='string' || typeof vnode==='number') {
-		return node.splitText!==undefined;
-	}
-	if (typeof vnode.nodeName==='string') {
-		return !node._componentConstructor && isNamedNode(node, vnode.nodeName);
-	}
-	return hydrating || node._componentConstructor===vnode.nodeName;
-}
-
-
 /** Check if an Element has a given normalized name.
 *	@param {Element} node
 *	@param {String} nodeName

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -165,8 +165,8 @@ describe('Components', () => {
 		expect(scratch.innerHTML, 'switching to textnode 2').to.equal('asdf');
 	});
 
-		// Test for Issue #254
-	it('should not recycle common class children with different keys', () => {
+		// Test for Issue #857
+	it('should not recycle common class children with different keys/positions', () => {
 		let idx = 0;
 		let msgs = ['A','B','C','D','E','F','G','H'];
 		let sideEffect = sinon.spy();
@@ -192,24 +192,6 @@ describe('Components', () => {
 			render(_, {alt}) {
 				return (
 					<div>
-						{alt ? null : (<Comp key={1} alt={alt}/>)}
-						{alt ? null : (<Comp key={2} alt={alt}/>)}
-						{alt ? (<Comp key={3} alt={alt}/>) : null}
-					</div>
-				);
-			}
-		}
-
-		class BadContainer extends Component {
-
-			constructor(props) {
-				super(props);
-				this.state.alt = false;
-			}
-
-			render(_, {alt}) {
-				return (
-					<div>
 						{alt ? null : (<Comp alt={alt}/>)}
 						{alt ? null : (<Comp alt={alt}/>)}
 						{alt ? (<Comp alt={alt}/>) : null}
@@ -218,8 +200,9 @@ describe('Components', () => {
 			}
 		}
 
-		let good, bad;
-		let root = render(<GoodContainer ref={c=>good=c} />, scratch);
+
+		let good;
+		render(<GoodContainer ref={c=>good=c} />, scratch);
 		expect(scratch.textContent, 'new component with key present').to.equal('AB');
 		expect(Comp.prototype.componentWillMount).to.have.been.calledTwice;
 		expect(sideEffect).to.have.been.calledTwice;
@@ -235,20 +218,6 @@ describe('Components', () => {
 
 		sideEffect.reset();
 		Comp.prototype.componentWillMount.reset();
-		render(<BadContainer ref={c=>bad=c} />, scratch, root);
-		expect(scratch.textContent, 'new component without key').to.equal('DE');
-		expect(Comp.prototype.componentWillMount).to.have.been.calledTwice;
-		expect(sideEffect).to.have.been.calledTwice;
-
-		sideEffect.reset();
-		Comp.prototype.componentWillMount.reset();
-		bad.setState({alt: true});
-		bad.forceUpdate();
-		expect(scratch.textContent, 'new component without key re-rendered').to.equal('D');
-		expect(Comp.prototype.componentWillMount).to.not.have.been.called;
-		expect(sideEffect).to.not.have.been.called;
-
-
 	});
 
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -472,8 +472,8 @@ describe('render()', () => {
 	it('should reorder child pairs', () => {
 		let root = render((
 			<div>
-				<a>a</a>
-				<b>b</b>
+				<a key="a">a</a>
+				<b key="b">b</b>
 			</div>
 		), scratch, root);
 
@@ -485,8 +485,8 @@ describe('render()', () => {
 
 		root = render((
 			<div>
-				<b>b</b>
-				<a>a</a>
+				<b key="b">b</b>
+				<a key="a">a</a>
 			</div>
 		), scratch, root);
 
@@ -510,7 +510,7 @@ describe('render()', () => {
 		expect(scratch).to.have.property('innerHTML', '<div><a></a></div>');
 	});
 
-	it('should skip non-preact elements', () => {
+	it('should not skip non-preact elements', () => {
 		class Foo extends Component {
 			render() {
 				let alt = this.props.alt || this.state.alt || this.alt;
@@ -538,32 +538,8 @@ describe('render()', () => {
 
 		comp.forceUpdate();
 
-		expect(scratch.firstChild.children, 'forceUpdate').to.have.length(4);
-		expect(scratch.innerHTML, 'forceUpdate').to.equal(`<div><a>foo</a><b>bar</b><c>baz</c><b>bat</b></div>`);
-
-		comp.alt = true;
-		comp.forceUpdate();
-
-		expect(scratch.firstChild.children, 'forceUpdate alt').to.have.length(4);
-		expect(scratch.innerHTML, 'forceUpdate alt').to.equal(`<div><b>alt</b><a>foo</a><c>baz</c><b>bat</b></div>`);
-
-		// Re-rendering from the root is non-destructive if the root was a previous render:
-		comp.alt = false;
-		root = render(<Foo ref={ c => comp = c } />, scratch, root);
-
-		expect(scratch.firstChild.children, 'root re-render').to.have.length(4);
-		expect(scratch.innerHTML, 'root re-render').to.equal(`<div><a>foo</a><b>bar</b><c>baz</c><b>bat</b></div>`);
-
-		comp.alt = true;
-		root = render(<Foo ref={ c => comp = c } />, scratch, root);
-
-		expect(scratch.firstChild.children, 'root re-render 2').to.have.length(4);
-		expect(scratch.innerHTML, 'root re-render 2').to.equal(`<div><b>alt</b><a>foo</a><c>baz</c><b>bat</b></div>`);
-
-		root = render(<div><Foo ref={ c => comp = c } /></div>, scratch, root);
-
-		expect(scratch.firstChild.children, 'root re-render changed').to.have.length(3);
-		expect(scratch.innerHTML, 'root re-render changed').to.equal(`<div><div><a>foo</a><b>bar</b></div><c>baz</c><b>bat</b></div>`);
+		expect(scratch.firstChild.children, 'forceUpdate').to.have.length(2);
+		expect(scratch.innerHTML, 'forceUpdate').to.equal(`<div><a>foo</a><b>bar</b></div>`);
 	});
 
 	// Discussion: https://github.com/developit/preact/issues/287

--- a/test/shared/h.js
+++ b/test/shared/h.js
@@ -48,6 +48,24 @@ describe('h(jsx)', () => {
 			]);
 	});
 
+	it('should support consecutive empty nodes', () => {
+		let r = h(
+			'foo',
+			null,
+			null,
+			null,
+			h('baz')
+		);
+
+		expect(r).to.be.an('object')
+			.with.property('children')
+			.that.deep.equals([
+				'',
+				'',
+				buildVNode('baz')
+			]);
+	});
+
 	it('should support multiple element children, given as arg list', () => {
 		let r = h(
 			'foo',
@@ -147,7 +165,7 @@ describe('h(jsx)', () => {
 			.that.equals('textstuff');
 	});
 
-	it('should merge adjacent text children', () => {
+	/* it('should merge adjacent text children', () => {
 		let r = h(
 			'foo',
 			null,
@@ -208,6 +226,7 @@ describe('h(jsx)', () => {
 			.with.property('children')
 			.that.deep.equals(['onetwothree']);
 	});
+	*/
 
 	it('should not merge children of components', () => {
 		let Component = ({children}) => children;


### PR DESCRIPTION
fixes #857

This PR includes the following changes to preact:

 - When diffing children, assign keys to all the children automatically if no key is provided (based on the index of the element in the children array)
 - To make it work properly, I needed to drop the "merge string siblings" from the `h` implementation, because this was causing nodes to have different keys depending on whether the previous node is a string or not (Not sure, why this merge was being done, I need context here)
 - with these changes, old elements (non preact elements) are being dropped when rerendering (Same here, I lack context on why this was implemented in the first place).

I'm new to preact, please excuse my lack of context :)