### PR TITLE
Breaking: update TypeScript definition for Component.children

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -4,6 +4,8 @@ export as namespace preact;
 declare namespace preact {
 	type Key = string | number;
 	type Ref<T> = (instance: T) => void;
+	type ComponentChild = JSX.Element | string | number | null;
+	type ComponentChildren = ComponentChild[];
 
 	/**
 	 * @deprecated
@@ -29,7 +31,7 @@ declare namespace preact {
 	}
 
 	interface PreactDOMAttributes {
-		children?: JSX.Element[];
+		children?: ComponentChildren;
 		dangerouslySetInnerHTML?: {
 			__html: string;
 		};
@@ -50,7 +52,7 @@ declare namespace preact {
 		key?: Key | null;
 	}
 
-	type RenderableProps<P> = Readonly<P> & Readonly<{ children?: JSX.Element[] }>;
+	type RenderableProps<P> = Readonly<P> & Readonly<{ children?: ComponentChildren }>;
 
 	interface FunctionalComponent<PropsType> {
 		(props: RenderableProps<PropsType>, context?: any): VNode<any>;
@@ -94,8 +96,8 @@ declare namespace preact {
 		abstract render(props?: RenderableProps<PropsType>, state?: Readonly<StateType>, context?: any): JSX.Element | null;
 	}
 
-	function h<PropsType>(node: ComponentFactory<PropsType>, params: PropsType, ...children: (JSX.Element | JSX.Element[] | string)[]): JSX.Element;
-	function h(node: string, params: JSX.HTMLAttributes & JSX.SVGAttributes & { [propName: string]: any }, ...children: (JSX.Element | JSX.Element[] | string)[]): JSX.Element;
+	function h<PropsType>(node: ComponentFactory<PropsType>, params: PropsType, ...children: (ComponentChild | ComponentChildren)[]): JSX.Element;
+	function h(node: string, params: JSX.HTMLAttributes & JSX.SVGAttributes & { [propName: string]: any }, ...children: (ComponentChild | ComponentChildren)[]): JSX.Element;
 	function render(node: JSX.Element, parent: Element | Document, mergeWith?: Element): Element;
 	function rerender(): void;
 	function cloneElement(element: JSX.Element, props: any): JSX.Element;


### PR DESCRIPTION
- Update ComponentProps.children typing to allow string arrays and
  JSX.Element arrays of arrays. e.g., this allows strictly typed
  components to be passed a child text node such as "foo". Note that
  children are always [arrays] and this isn't a functionally breaking
  change.

- Add new ComponentChildren type which is a useful fundamental type
  union to expose.

[arrays]: https://preactjs.com/guide/differences-to-react#what-s-missing-

---

I'm not sure I've understood any of this right so don't hesitate to
close it if it looks wrong. I think this would be a potentially type
breaking change for consumers that had extended ComponentProps and
redefined children.

The use case I'm trying to solve is
`render(Foo({fooProperty: "foo", children: ["bar"]}))` where:

```tsx
import { ComponentProps, h } from "preact";

export interface Props extends ComponentProps<any> {
  fooProperty: string;
}

export function Foo({
  fooProperty,
  children
}: Props): JSX.Element {
  return (
    <div>
      <div>{fooProperty}</div>
      <div>{children}</div>
    </div>
  );
}
```