### PR TITLE
Fix issue of unmounting component which only renders `null`

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -65,8 +65,19 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	let out = dom,
 		prevSvgMode = isSvgMode;
 
-	// empty values (null, undefined, booleans) render as empty Text nodes
-	if (vnode==null || typeof vnode==='boolean') vnode = '';
+	// empty values (null, undefined, booleans) render as comment nodes
+	if (vnode==null || typeof vnode==='boolean') {
+		const comment = ' preact empty ';
+		if (!dom || dom.nodeName !== '#comment' || dom.textContent !== comment) {
+			out = document.createComment(comment);
+			if (dom) {
+				if (dom.parentNode) dom.parentNode.replaceChild(out, dom);
+				recollectNodeTree(dom, true);
+			}
+		}
+		out[ATTR_KEY] = true;
+		return out;
+	}
 
 
 	// Fast case: Strings & Numbers create/update Text nodes.

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -251,6 +251,24 @@ describe('Components', () => {
 
 	});
 
+	it('should trigger componentWillUnmount when unmounting component that renders null', () => {
+		const componentWillUnmount = sinon.spy(() => { });
+		class Comp extends Component {
+			componentWillUnmount() {
+				componentWillUnmount();
+			}
+			render() {
+				return null;
+			}
+		}
+		const Parent = ({ show }) => <div>{show && <Comp />}</div>;
+		render(<Parent show />, scratch);
+		expect(scratch.lastChild.innerHTML).to.equal('<!-- preact empty -->');
+		render(<Parent show={false} />, scratch, scratch.lastChild);
+
+		expect(componentWillUnmount).to.have.been.calledOnce;
+		expect(scratch.lastChild.innerHTML).to.equal('');
+	});
 
 
 	describe('props.children', () => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -91,22 +91,22 @@ describe('render()', () => {
 
 	it('should not render null', () => {
 		render(null, scratch);
-		expect(scratch.innerHTML).to.equal('');
+		expect(scratch.innerHTML).to.equal('<!-- preact empty -->');
 	});
 
 	it('should not render undefined', () => {
 		render(undefined, scratch);
-		expect(scratch.innerHTML).to.equal('');
+		expect(scratch.innerHTML).to.equal('<!-- preact empty -->');
 	});
 
 	it('should not render boolean true', () => {
 		render(true, scratch);
-		expect(scratch.innerHTML).to.equal('');
+		expect(scratch.innerHTML).to.equal('<!-- preact empty -->');
 	});
 
 	it('should not render boolean false', () => {
 		render(false, scratch);
-		expect(scratch.innerHTML).to.equal('');
+		expect(scratch.innerHTML).to.equal('<!-- preact empty -->');
 	});
 
 	it('should render NaN as text content', () => {


### PR DESCRIPTION
Using current implementation, when component renders `null`, it will be actually rendered as an empty text node. However, if that component is the only child inside a parent component, when removed, `componentWillUnmount` will not be triggered. (See unit test for details)
The reason is that children with falsy value will be treated as empty string when VNode is created, and that is the same as how component returns null is treated.
Using comment node instead of empty text node will fix this.

All tests passed, but I am not sure if the implementation is good. Any suggestion is very welcome.