### PR TITLE
Fix: AnyComponent type to allow parameterized class usage

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -42,8 +42,8 @@ declare namespace preact {
 		new (props?:PropsType, context?: any):Component<PropsType, StateType>;
 	}
 
-    // Type alias for a component considered generally, whether stateless or stateful.
-	type AnyComponent<PropsType, StateType> = FunctionalComponent<PropsType> | typeof Component;
+	// Type alias for a component considered generally, whether stateless or stateful.
+	type AnyComponent<PropsType, StateType> = FunctionalComponent<PropsType> | ComponentConstructor<PropsType, StateType>;
 
 	abstract class Component<PropsType, StateType> {
 		constructor(props?:PropsType, context?:any);


### PR DESCRIPTION
Update the AnyComponent type to allow references to parameterized
classes:

```ts
  const Foo: AnyComponent<undefined, undefined> = class extends PreactComponent<
    undefined,
    undefined
  > {
    render() { return null; }
  };
```

Previously, this usage failed:
```
  error TS2322: Type 'typeof Foo' is not assignable to type 'AnyComponent<undefined, undefined>'.
    Type 'typeof Foo' is not assignable to type 'FunctionalComponent<undefined>'.
      Type 'typeof Foo' provides no match for the signature '(props?: (undefined & ComponentProps<FunctionalComponent<undefined>>) | undefined, context?: any): Element'.
```
https://github.com/developit/preact-router/blob/c2c4693/src/index.d.ts#L51-L53
https://phabricator.wikimedia.org/source/marvin/browse/master/src/common/components/preact-utils.ts;c79bc0be45e404ba2a38697b17b16f8e61548651$8-10