### PR TITLE
Update: add link preload "as" to HTMLAttributes type definition

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -470,6 +470,7 @@ declare namespace JSX {
 		allowFullScreen?:boolean;
 		allowTransparency?:boolean;
 		alt?:string;
+		as?:string;
 		async?:boolean;
 		autocomplete?:string;
 		autofocus?:boolean;


### PR DESCRIPTION
Link preloads support an as attribute. e.g.:
```html
  <link rel="preload" href=foo.css as: "style" />
  <link rel="preload" href=foo.js as: "script" />
```
Update the HTMLAttributes type definition to avoid workarounds like:
```html
  <link rel="preload" href=foo.css {...{ as: "style" }} />
```
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
https://w3c.github.io/preload/#as-attribute