### PR TITLE
Optimize defer

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,4 +10,5 @@ export function extend(obj, props) {
 /** Call a function asynchronously, as soon as possible.
  *	@param {Function} callback
  */
-export const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;
+let promise;
+export const defer = (promise = typeof Promise === 'function' ? Promise.resolve() : undefined) ? promise.then.bind(promise) : setTimeout;


### PR DESCRIPTION
Optimize `defer` function by removing unnecessary duplicate call of `Promise.resolve`.

According to https://jsperf.com/preact-defer-perf, it's almost twice as fast.