### PR TITLE
make the preact as same as react in shouldComponentUpdate return value

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -80,7 +80,7 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		component.context = previousContext;
 		if (opts!==FORCE_RENDER
 			&& component.shouldComponentUpdate
-			&& component.shouldComponentUpdate(props, state, context) === false) {
+			&& !component.shouldComponentUpdate(props, state, context)) {
 			skip = true;
 		}
 		else if (component.componentWillUpdate) {


### PR DESCRIPTION
Hey, l found there is some difference between `React` and `Preact` about `shouldComponentUpdate`.
if you return a value like `''`,`0`,`false`,`NaN`,`undefined` in `React` , they all skip render. but only `false` skip render in `Preact`.