### PR TITLE
Add preact stylesheet addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Preact supports modern browsers and IE9+:
 - :shaved_ice: [**preact-codemod**](https://github.com/vutran/preact-codemod): Transform your React code to Preact.
 - :construction_worker: [**preact-helmet**](https://github.com/download/preact-helmet): A document head manager for Preact
 - :necktie: [**preact-delegate**](https://github.com/NekR/preact-delegate): Delegate DOM events
+- :art: [**preact-stylesheet-decorator**](https://github.com/k1r0s/preact-stylesheet-decorator): Add Scoped Stylesheets to your Preact Components
 
 #### UI Component Libraries
 


### PR DESCRIPTION
Hi @developit . I think this package will help Preact developers. Its simple, you don't need to learn anything, just plug and code plain CSS. Can be extended by a css preprocesor easily since decorator spects just a css string. 

Thanks in advantage