### PR TITLE
Typescript: Change HTMLAttribute [value] typing to allow numbers

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -581,7 +581,7 @@ declare namespace JSX {
 		title?:string;
 		type?:string;
 		useMap?:string;
-		value?:string | string[];
+		value?:string | string[] | number;
 		width?:number | string;
 		wmode?:string;
 		wrap?:string;


### PR DESCRIPTION
With the current Typescript declaration in Preact, using `<input value={1} />` is not allowed because `value` is defined as `string | string[]`. React's typings [allows numbers](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ecabf5526f47412ddd1bf93b06a0ee4eceea5b00/types/react/index.d.ts#L2597).