### PR TITLE
[WIP] New context API

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -14,7 +14,7 @@ export function createContext(key) {
 	function Provider(props, context) {
 		Component.call(this, props, context);
 
-		c = [];
+		this.c = [];
 	}
 
 	extendComponent(Provider.prototype, {
@@ -29,7 +29,7 @@ export function createContext(key) {
 
 		componentWillReceiveProps(nextProps) {
 			if (!Object.is(this.props.value, nextProps.value)) {
-				c.forEach(subscriber => {
+				this.c.forEach(subscriber => {
 					subscriber(nextProps.value);
 				});
 			}

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -1,0 +1,64 @@
+import { Component } from "./component";
+import { extendComponent } from "./util";
+
+/**
+ *
+ * @param {string} key
+ */
+export function createContext(key) {
+	/** Provider Component class.
+	 *	prop `value` is provided to every corresponding `Consumer` component.
+	 *	@public
+	 *
+	 */
+	function Provider(props, context) {
+		Component.call(this, props, context);
+
+		c = [];
+	}
+
+	extendComponent(Provider.prototype, {
+		s(subscriber) {
+			this.c.push(subscriber);
+			subscriber(this.props.value);
+		},
+
+		getChildContext() {
+			return { [key]: this.s };
+		},
+
+		componentWillReceiveProps(nextProps) {
+			if (!Object.is(this.props.value, nextProps.value)) {
+				c.forEach(subscriber => {
+					subscriber(nextProps.value);
+				});
+			}
+		},
+
+		render() {
+			return this.props.children;
+		}
+	});
+
+  /**  Consumer Component class.
+	 *	`children` must be a function that accepts the value from the `Consumer`'s
+	 		corresponding `Provider` component.
+	 *	@public
+	 *
+	 */
+	function Consumer(props, context) {
+		Component.call(this, props, context);
+
+		context[key](value => {
+			this.setState({ value });
+		});
+	}
+
+	extendComponent(Consumer.prototype, {
+		render() {
+			return this.props.children(this.state.value);
+		}
+	});
+
+	return { Provider, Consumer };
+}

--- a/src/preact.js
+++ b/src/preact.js
@@ -1,6 +1,7 @@
 import { h, h as createElement } from './h';
 import { cloneElement } from './clone-element';
 import { Component } from './component';
+import { createContext } from './create-context';
 import { render } from './render';
 import { rerender } from './render-queue';
 import options from './options';
@@ -10,6 +11,7 @@ export default {
 	createElement,
 	cloneElement,
 	Component,
+	createContext,
 	render,
 	rerender,
 	options
@@ -20,6 +22,7 @@ export {
 	createElement,
 	cloneElement,
 	Component,
+	createContext,
 	render,
 	rerender,
 	options

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+import {Component} from './component';
+
 /**
  *  Copy all properties from `props` onto `obj`.
  *  @param {Object} obj		Object onto which properties should be copied.
@@ -18,3 +20,16 @@ export function extend(obj, props) {
  * @param {Function} callback
  */
 export const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;
+
+/**
+ * Extend an object from `Component`.
+ * @param {Object} obj    Object onto `Component` should be applied to.
+ * @param {Object} props	Object from which to copy properties.
+ * @private
+ */
+export function extendComponent(obj, props) {
+	obj = Object.create(Component.prototype);
+	obj.constructor = Component;
+	extend(obj, props);
+}
+


### PR DESCRIPTION
This PR is an implementation of React's proposed new context API for Preact. This implementation is built on top of the existing context API. React's corresponding PR is https://github.com/facebook/react/pull/11818 and the RFC is https://github.com/reactjs/rfcs/pull/2.

These are the following tasks and considerations I've identified that will need to be accomplished before merging.

- [ ] Add tests. I'm planning for now on recreating the existing context based tests, but using the new API.
- [ ] TypeScript definitions.
- [ ] Flow definitions.
- [ ] Devtools support warning on rendering a `Provider` without any `Consumer`'s.
- [ ] Code documentation improvements.
- [x] Wait for https://github.com/reactjs/rfcs/pull/2 to be approved.
- [ ] Examine size reduction opportunities. Currently this adds 200 bytes to the (min + gzip) size.
- [ ] Consider refactoring to remove the old context API and only support this new API. This would be inline with Preact traditionally only supporting the most modern parts of React's API. Currently it appears that Facebook may deprecate and remove old context at some future point.
