### PR TITLE
Changing the README to match the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img alt="Preact" title="Preact" src="https://cdn.rawgit.com/developit/b4416d5c92b743dbaec1e68bc4c27cda/raw/3235dc508f7eb834ebf48418aea212a05df13db1/preact-logo-trans.svg" width="550">
 </a>
 </p>
-<p align="center">Fast <b>3kB</b> alternative to React, with the same ES2015 API.</p>
+<p align="center">Fast <b>3kB</b> alternative to React, with the same ES6 API.</p>
 
 **All the power of Virtual DOM components, without the overhead:**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img alt="Preact" title="Preact" src="https://cdn.rawgit.com/developit/b4416d5c92b743dbaec1e68bc4c27cda/raw/3235dc508f7eb834ebf48418aea212a05df13db1/preact-logo-trans.svg" width="550">
 </a>
 </p>
-<p align="center">Fast <b>3kB</b> alternative to React, with the same ES6 API.</p>
+<p align="center">Fast <b>3kB</b> alternative to React with the same modern API.</p>
 
 **All the power of Virtual DOM components, without the overhead:**
 


### PR DESCRIPTION
##  Problem
In the website said, "Fast 3kB alternative to React, with the same ES6 API."

However, in the README said, "Fast 3kB alternative to React, with the same ES2015 API."

## Solution
Changing the README text, so it matches the website.