### PR TITLE
fix: preact-compat unstable_renderSubtreeIntoContainer throw error 

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -248,7 +248,7 @@ function createDevToolsBridge() {
 		const prevRenderedChildren = [];
 		let instance = instanceMap.get(component);
 		if (instance) {
-			visitNonCompositeChildren(instanceMap.get(component), childInst => {
+			visitNonCompositeChildren(instance, childInst => {
 				prevRenderedChildren.push(childInst);
 			});
 		}

--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -245,15 +245,16 @@ function createDevToolsBridge() {
 
 	/** Notify devtools that a component has been updated with new props/state. */
 	const componentUpdated = component => {
-		// Must updateReactComponent first, incase unstable_renderSubtreeIntoContainer component not in instanceMap
+		const prevRenderedChildren = [];
+		let instance = instanceMap.get(component);
+		if (instance) {
+			visitNonCompositeChildren(instanceMap.get(component), childInst => {
+				prevRenderedChildren.push(childInst);
+			});
+		}
 		// Notify devtools about updates to this component and any non-composite
 		// children
-		const instance = updateReactComponent(component);
-
-		const prevRenderedChildren = [];
-		visitNonCompositeChildren(instanceMap.get(component), childInst => {
-			prevRenderedChildren.push(childInst);
-		});
+		instance = updateReactComponent(component);
 
 		Reconciler.receiveComponent(instance);
 		visitNonCompositeChildren(instance, childInst => {

--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -245,14 +245,16 @@ function createDevToolsBridge() {
 
 	/** Notify devtools that a component has been updated with new props/state. */
 	const componentUpdated = component => {
+		// Must updateReactComponent first, incase unstable_renderSubtreeIntoContainer component not in instanceMap
+		// Notify devtools about updates to this component and any non-composite
+		// children
+		const instance = updateReactComponent(component);
+
 		const prevRenderedChildren = [];
 		visitNonCompositeChildren(instanceMap.get(component), childInst => {
 			prevRenderedChildren.push(childInst);
 		});
 
-		// Notify devtools about updates to this component and any non-composite
-		// children
-		const instance = updateReactComponent(component);
 		Reconciler.receiveComponent(instance);
 		visitNonCompositeChildren(instance, childInst => {
 			if (!childInst._inDevTools) {


### PR DESCRIPTION
## Reproduce
```bash
git clone git@github.com:ant-design/ant-design-mobile.git
cd ant-design-mobile
npm install
npm start
open localhost:8002/components/input-item
// or open http://localhost:8002/components/picker
```


preact-compat unstable_renderSubtreeIntoContainer throw error when use preact/devtools

close https://github.com/ant-design/ant-design-mobile/issues/2139
  