### PR TITLE
Add option to support NativeScript event handling

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -63,8 +63,11 @@ export function setAccessor(node, name, old, value, isSvg) {
 		if (value) node.innerHTML = value.__html || '';
 	}
 	else if (name[0]=='o' && name[1]=='n') {
-		let useCapture = name !== (name=name.replace(/Capture$/, ''));
-		name = name.toLowerCase().substring(2);
+		// In NativeScript the third addEventListener Parameter is a self reference https://docs.nativescript.org/api-reference/classes/_data_observable_.observable#addeventlistener
+		let useCapture = options.nativeScript ? node : name !== (name=name.replace(/Capture$/, ''));
+		// in NativeScript Events are case sensitive hence we only lowercase the first character of the eventName
+		// (e.g. onTextChanged would become textchanged but needs to be textChanged)
+		name = options.nativeScript ? name.substring(2, 3).toLowerCase() + name.substring(3) : name.toLowerCase().substring(2);
 		if (value) {
 			if (!old) node.addEventListener(name, eventProxy, useCapture);
 		}
@@ -105,5 +108,6 @@ function setProperty(node, name, value) {
  *	@private
  */
 function eventProxy(e) {
-	return this._listeners[e.type](options.event && options.event(e) || e);
+	const type = options.nativeScript ? e.eventName : e.type;
+	return this._listeners[type](options.event && options.event(e) || e);
 }

--- a/src/options.js
+++ b/src/options.js
@@ -24,4 +24,11 @@ export default {
 
 	/** Hook invoked immediately before a component is unmounted. */
 	// beforeUnmount(component) { }
+
+	/** If `true`, preact will use NativeScript API for add and removeEventListener
+	 *	@name nativeScript
+	 *	@type Boolean
+	 *	@default false
+	 */
+	//nativeScript: false,
 };

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -82,6 +82,7 @@ declare namespace preact {
 
 	var options:{
 		syncComponentUpdates?:boolean;
+		nativeScript?:boolean;
 		debounceRendering?:(render:() => void) => void;
 		vnode?:(vnode:VNode) => void;
 		event?:(event:Event) => Event;

--- a/test/browser/nativeScript.js
+++ b/test/browser/nativeScript.js
@@ -1,5 +1,3 @@
-/* global DISABLE_FLAKEY */
-
 import { h, render, options } from '../../src/preact';
 /** @jsx h */
 

--- a/test/browser/nativeScript.js
+++ b/test/browser/nativeScript.js
@@ -1,0 +1,100 @@
+/* global DISABLE_FLAKEY */
+
+import { h, render, options } from '../../src/preact';
+/** @jsx h */
+
+describe('nativeScript option', () => {
+	let scratch;
+
+	before( () => {
+		options.nativeScript = true;
+		scratch = document.createElement('div');
+		(document.body || document.documentElement).appendChild(scratch);
+	});
+
+	beforeEach( () => {
+		scratch.innerHTML = '';
+	});
+
+	after( () => {
+		scratch.parentNode.removeChild(scratch);
+		scratch = null;
+		options.nativeScript = false;
+	});
+
+	it('should only register on* functions as handlers', () => {
+		let textChanged = () => {}, onTextChanged = () => {};
+		let proto = document.createElement('div').constructor.prototype;
+
+		sinon.spy(proto, 'addEventListener');
+
+		render(<div textChanged={ textChanged } onTextChanged={ onTextChanged } />, scratch);
+
+		expect(scratch.childNodes[0]).to.have.deep.property('attributes.length', 0);
+
+		expect(proto.addEventListener).to.have.been.calledOnce
+			.and.to.have.been.calledWithExactly('textChanged', sinon.match.func, scratch.childNodes[0]);
+
+		proto.addEventListener.restore();
+	});
+
+	it('should add and remove event handlers', () => {
+		let click = sinon.spy(),
+			mousedown = sinon.spy();
+
+		let proto = document.createElement('div').constructor.prototype;
+		sinon.spy(proto, 'addEventListener');
+		sinon.spy(proto, 'removeEventListener');
+
+		function fireEvent(on, type) {
+			let e = document.createEvent('Event');
+			e.initEvent(type, true, true);
+			e.eventName = type;
+			on.dispatchEvent(e);
+		}
+
+		render(<div onTap={ () => click(1) } onTextChanged={ mousedown } />, scratch);
+
+		expect(proto.addEventListener).to.have.been.calledTwice
+			.and.to.have.been.calledWith('tap')
+			.and.calledWith('textChanged');
+
+		fireEvent(scratch.childNodes[0], 'tap');
+		expect(click).to.have.been.calledOnce
+			.and.calledWith(1);
+
+		proto.addEventListener.reset();
+		click.reset();
+
+		render(<div onTap={ () => click(2) } />, scratch, scratch.firstChild);
+
+		expect(proto.addEventListener).not.to.have.been.called;
+
+		expect(proto.removeEventListener)
+			.to.have.been.calledOnce
+			.and.calledWith('textChanged');
+
+		fireEvent(scratch.childNodes[0], 'tap');
+		expect(click).to.have.been.calledOnce
+			.and.to.have.been.calledWith(2);
+
+		fireEvent(scratch.childNodes[0], 'textChanged');
+		expect(mousedown).not.to.have.been.called;
+
+		proto.removeEventListener.reset();
+		click.reset();
+		mousedown.reset();
+
+		render(<div />, scratch, scratch.firstChild);
+
+		expect(proto.removeEventListener)
+			.to.have.been.calledOnce
+			.and.calledWith('tap');
+
+		fireEvent(scratch.childNodes[0], 'tap');
+		expect(click).not.to.have.been.called;
+
+		proto.addEventListener.restore();
+		proto.removeEventListener.restore();
+	});
+});


### PR DESCRIPTION
In the exploration of using [preact with nativescript](https://github.com/Hizoul/preact-to-nativescript) I had to [adjust eventHandling](https://github.com/staydecent/nativescript-preact/issues/4#issuecomment-355989276) to get events working.

In this pull request I added a boolean called `nativeScript` in the `options`. I also added a test to cover the correct behaviour if said option is truthy.

I am unsure wether:
1. platform specific code like this should even be in preact
2.  this way to solve this is mergeworthy but it seemed like the most uninitrusive solution for exisiting behaviour to me