### PR TITLE
[945] Update boolean attributes to be empty value for consistency

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -248,7 +248,7 @@ function createDevToolsBridge() {
 		const prevRenderedChildren = [];
 		let instance = instanceMap.get(component);
 		if (instance) {
-			visitNonCompositeChildren(instanceMap.get(component), childInst => {
+			visitNonCompositeChildren(instance, childInst => {
 				prevRenderedChildren.push(childInst);
 			});
 		}

--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -245,15 +245,16 @@ function createDevToolsBridge() {
 
 	/** Notify devtools that a component has been updated with new props/state. */
 	const componentUpdated = component => {
-		// Must updateReactComponent first, incase unstable_renderSubtreeIntoContainer component not in instanceMap
+		const prevRenderedChildren = [];
+		let instance = instanceMap.get(component);
+		if (instance) {
+			visitNonCompositeChildren(instanceMap.get(component), childInst => {
+				prevRenderedChildren.push(childInst);
+			});
+		}
 		// Notify devtools about updates to this component and any non-composite
 		// children
-		const instance = updateReactComponent(component);
-
-		const prevRenderedChildren = [];
-		visitNonCompositeChildren(instanceMap.get(component), childInst => {
-			prevRenderedChildren.push(childInst);
-		});
+		instance = updateReactComponent(component);
 
 		Reconciler.receiveComponent(instance);
 		visitNonCompositeChildren(instance, childInst => {

--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -245,14 +245,16 @@ function createDevToolsBridge() {
 
 	/** Notify devtools that a component has been updated with new props/state. */
 	const componentUpdated = component => {
+		// Must updateReactComponent first, incase unstable_renderSubtreeIntoContainer component not in instanceMap
+		// Notify devtools about updates to this component and any non-composite
+		// children
+		const instance = updateReactComponent(component);
+
 		const prevRenderedChildren = [];
 		visitNonCompositeChildren(instanceMap.get(component), childInst => {
 			prevRenderedChildren.push(childInst);
 		});
 
-		// Notify devtools about updates to this component and any non-composite
-		// children
-		const instance = updateReactComponent(component);
 		Reconciler.receiveComponent(instance);
 		visitNonCompositeChildren(instance, childInst => {
 			if (!childInst._inDevTools) {

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -85,6 +85,7 @@ export function setAccessor(node, name, old, value, isSvg) {
 		}
 		else if (typeof value!=='function') {
 			if (ns) node.setAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase(), value);
+			else if (value===true) node.setAttribute(name, "");
 			else node.setAttribute(name, value);
 		}
 	}

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -485,8 +485,7 @@ describe('Components', () => {
 			rerender();
 
 			expect(Inner.prototype.componentWillUnmount).to.have.been.calledOnce;
-
-			expect(scratch.innerHTML).to.equal('<div is-alt="true"></div>');
+			expect(scratch.innerHTML).to.equal('<div is-alt=""></div>');
 
 			// update & flush
 			alt = false;


### PR DESCRIPTION
## Change boolean attributes to have empty value

In response to #945 
I added an explicit check in case the value === "true" which simply sets attribute to "" which is inline with web standard in moz docs: https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute

> Boolean attributes are considered to be true if they're present on the element at all, regardless of their actual value; as a rule, you should specify the empty string ("") in value (some people use the attribute's name; this works but is non-standard). See the example below for a practical demonstration.

I also updated the test to make sure it renders empt value instead of ="true"