### PR TITLE
make props required in functional component #967

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -40,7 +40,7 @@ declare namespace preact {
 	}
 
 	interface FunctionalComponent<PropsType> {
-		(props?:PropsType & ComponentProps<this>, context?:any):JSX.Element;
+		(props:PropsType & ComponentProps<this>, context?:any):JSX.Element;
 		displayName?:string;
 		defaultProps?:any;
 	}


### PR DESCRIPTION
this is a fix for #967 based on feedback that props should be required for a functional component