### PR TITLE
Add typings for some new SVG animation elements

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -799,6 +799,7 @@ declare namespace JSX {
 		//SVG
 		svg:SVGAttributes;
 		animate:SVGAttributes;
+		animateMotion:SVGAttributes;
 		circle:SVGAttributes;
 		clipPath:SVGAttributes;
 		defs:SVGAttributes;
@@ -828,6 +829,7 @@ declare namespace JSX {
 		linearGradient:SVGAttributes;
 		marker:SVGAttributes;
 		mask:SVGAttributes;
+		mpath:SVGAttributes;
 		path:SVGAttributes;
 		pattern:SVGAttributes;
 		polygon:SVGAttributes;


### PR DESCRIPTION
The current typings do not include the new `animateMotion` and `mpath` elements. See https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animateMotion for details.