### PR TITLE
Specify types directive in package.json for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/preact.esm.js",
   "dev:main": "dist/preact.dev.js",
   "minified:main": "dist/preact.min.js",
+  "types": "dist/preact.d.ts",
   "scripts": {
     "clean": "rimraf dist/ devtools.js devtools.js.map debug.js debug.js.map",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",


### PR DESCRIPTION
This allows the TS language service to automatically pull in types for Preact. This benefits non-TypeScript users as well. If you're using VSCode and just plain vanilla JS, it will pickup Preact's types automatically after installing and provide autocompletion