### PR TITLE
Fix(TS): Declare preact/debug module

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -97,6 +97,10 @@ declare module "preact/devtools" {
 	// when imported.
 }
 
+declare module "preact/debug" {
+	// Empty. This module initializes checks inside development
+}
+
 declare namespace JSX {
 
 	/**


### PR DESCRIPTION
Hey!

Example of usage:

![image](https://user-images.githubusercontent.com/572096/36629551-644008e2-199a-11e8-9c70-3f5a8ebc29fa.png)

Actual error (before fix):

```
src/components/app.tsx(10,12): error TS7016: Could not find a declaration file for module 'preact/debug'. '/Users/ovr/projects/startup/notify/frontend/node_modules/preact/debug.js' implicitly has an 'any' type.
  Try `npm install @types/preact` if it exists or add a new declaration (.d.ts) file containing `declare module 'preact';`
```

Expected:

works :)

Thanks