### PR TITLE
Upgrade travis to use node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "6"
+  - "8"
 
 cache:
   directories:
@@ -23,15 +23,3 @@ script:
   - npm run test
   - BROWSER=true COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info
-
-# Necessary to compile native modules for io.js v3 or Node.js v4
-env:
-  - CXX=g++-4.8
-
-# Necessary to compile native modules for io.js v3 or Node.js v4
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8


### PR DESCRIPTION
This PR builds and test preact with `node 8` which should make the CI run a tiny bit faster.

Changes:
- [x] Upgrade node to 8 (latest LTS release)
- [x] Remove custom g++ dependencies, they were only needed for older node versions