### PR TITLE
Fix npm script deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:karma:watch": "npm run test:karma -- no-single-run",
     "test:size": "bundlesize",
     "lint": "eslint debug devtools src test",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "smart-release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish",
     "release": "cross-env npm run smart-release",
     "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mLove Preact? You can now donate to our open collective:\\u001b[22m\\u001b[39m\\n > \\u001b[34mhttps://opencollective.com/preact/donate\\u001b[0m')\""


### PR DESCRIPTION
With https://github.com/developit/preact/pull/1023 we are using a newer release of npm which prefers `prepublishOnly` instead of `prepublish`. This PR corrects that.

Original console output:

```bash
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```