### PR TITLE
Make render node arg nullable

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -98,7 +98,7 @@ declare namespace preact {
 
 	function h<PropsType>(node: ComponentFactory<PropsType>, params: PropsType, ...children: (ComponentChild | ComponentChildren)[]): JSX.Element;
 	function h(node: string, params: JSX.HTMLAttributes & JSX.SVGAttributes & { [propName: string]: any }, ...children: (ComponentChild | ComponentChildren)[]): JSX.Element;
-	function render(node: JSX.Element, parent: Element | Document, mergeWith?: Element): Element;
+	function render(node: ComponentChild, parent: Element | Document, mergeWith?: Element): Element;
 	function rerender(): void;
 	function cloneElement(element: JSX.Element, props: any): JSX.Element;
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -37,6 +37,14 @@ describe('render()', () => {
 		scratch = null;
 	});
 
+	it('should render a empty text node', () => {
+		render(null, scratch);
+		let c = scratch.childNodes;
+		expect(c).to.have.length(1);
+		expect(c).to.have.deep.property('0.data', '');
+		expect(c).to.have.deep.property('0.nodeName', '#text');
+	});
+
 	it('should create empty nodes (<* />)', () => {
 		render(<div />, scratch);
 		expect(scratch.childNodes)


### PR DESCRIPTION
Fixes #996 

- [x] test that passing in `null` will render an empty text node

Hopefully my first contribution! :) 