### PR TITLE
Fix wrong source mapping in tests for src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ package-lock.json
 /devtools.js.map
 /debug.js
 /debug.js.map
+
+# Editor and IDE configuration
+.vscode/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 
 script:
   - npm run build
-  - npm run test
+  - COVERAGE=true npm run test
   - COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,6 +1,6 @@
 /*eslint no-var:0, object-shorthand:0 */
 
-var coverage = String(process.env.COVERAGE)!=='false',
+var coverage = String(process.env.COVERAGE) === 'true',
 	ci = String(process.env.CI).match(/^(1|true)$/gi),
 	pullRequest = !String(process.env.TRAVIS_PULL_REQUEST).match(/^(0|false|undefined)$/gi),
 	masterBranch = String(process.env.TRAVIS_BRANCH).match(/^master$/gi),


### PR DESCRIPTION
Noticed that although breakpoints are correctly hit, the line mapping was completely off.

This is caused by additional code created by coverage reporting. Tried replacing the now deprecated `isparta-loader` with `istanbul-instrumenter-loader` to see if this fixes things, but I couldn't get the latter to work.

### Before
<img width="780" alt="screen shot 2018-03-11 at 11 51 52" src="https://user-images.githubusercontent.com/1062408/37252626-471c8c14-2524-11e8-8f28-3f7cb1a8242a.png">

### After

<img width="773" alt="screen shot 2018-03-11 at 11 53 13" src="https://user-images.githubusercontent.com/1062408/37252628-5392e060-2524-11e8-9d13-168475172245.png">


Launch settings for vscode used for the above screenshot (run `test:karma:watch` first):

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "chrome",
      "request": "attach",
      "name": "Attach Karma Chrome",
      "address": "localhost",
      "port": 9333,
      "pathMapping": {
        "/": "${workspaceRoot}",
        "/base/": "${workspaceRoot}/"
      }
    }
  ]
}
```

I do think that the debugger working by default is more useful for new contributors than coverage enabled. But this may be just my personal preference. Coverage is of course still collected on our CI. This PR only affects the local dev environment. 

### Changes:

- [x] invert `COVERAGE` feature flag to only be enabled when explicitly set to `true`. Before it was always enabled and only disabled when set to `false`
- [x] ignore common editor specific configuration (`.vscode/` + `.idea` for now)