### PR TITLE
super important PR

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -617,7 +617,7 @@ declare global {
 			title?: string;
 			type?: string;
 			useMap?: string;
-			value?: string | string[];
+			value?: string | string[] | number;
 			width?: number | string;
 			wmode?: string;
 			wrap?: string;


### PR DESCRIPTION
We should allow any serializable value to be asigned to `value` html prop 

fix:
```
whatever is not assignable to type 'HTMLAttributes'. Types of property 'value' are incompatible. Type 'number' is not assignable to type 'string | string[]'.	
```