### PR TITLE
Revert "Set component instance constructor to make it work nicely with react-hot-loader"

### DIFF
--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -25,11 +25,10 @@ export function createComponent(Ctor, props, context) {
 	}
 	else {
 		inst = new Component(props, context);
+		inst.constructor = Ctor;
 		inst.render = doRender;
 	}
 
-	// Always redefine the constructor to make it play nice with react-hot-loader proxies
-	inst.constructor = Ctor;
 
 	if (list) {
 		for (let i=list.length; i--; ) {


### PR DESCRIPTION
Reverts developit/preact#1016

Turns out that this leads to a decrease in performance by around ~10-15%. Hopefully we'll find a better fix. See the discussion on the original PR