### PR TITLE
Add back missing attributes types to RenderableProps

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -10,16 +10,18 @@ declare namespace preact {
 	/**
 	 * @deprecated
 	 *
-	 * Use Attributes instead
+	 * Use Attributes instead. This type must remain an interface to not break
+	 * other libraries' types (e.g. preact-router)
 	 */
-	type ComponentProps = Attributes;
+	interface ComponentProps extends Attributes {}
 
 	/**
 	 * @deprecated
 	 *
-	 * Use ClassAttributes instead
+	 * Use ClassAttributes instead. This type must remain an interface to not break
+	 * other libraries' types (e.g. preact-router)
 	 */
-	type PreactHTMLAttributes = ClassAttributes<any>;
+	interface PreactHTMLAttributes extends ClassAttributes<any> {}
 
 	interface Attributes {
 		key?: string | number | any;
@@ -52,7 +54,8 @@ declare namespace preact {
 		key?: Key | null;
 	}
 
-	type RenderableProps<P> = Readonly<P> & Readonly<{ children?: ComponentChildren }>;
+	type RenderableProps<P> = Readonly<P> & Readonly<Attributes> & Readonly<{ children?: ComponentChildren }>;
+	type ClassRenderableProps<P> = RenderableProps<P> & Readonly<ClassAttributes<any>>;
 
 	interface FunctionalComponent<P = {}> {
 		(props: RenderableProps<P>, context?: any): VNode<any> | null;
@@ -87,7 +90,7 @@ declare namespace preact {
 		static defaultProps?: any;
 
 		state: Readonly<S>;
-		props: RenderableProps<P>;
+		props: ClassRenderableProps<P>;
 		context: any;
 		base?: HTMLElement;
 
@@ -96,7 +99,7 @@ declare namespace preact {
 
 		forceUpdate(callback?: () => void): void;
 
-		abstract render(props?: RenderableProps<P>, state?: Readonly<S>, context?: any): JSX.Element | null;
+		abstract render(props?: ClassRenderableProps<P>, state?: Readonly<S>, context?: any): JSX.Element | null;
 	}
 
 	function h<P>(

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -10,18 +10,16 @@ declare namespace preact {
 	/**
 	 * @deprecated
 	 *
-	 * Use Attributes instead. This type must remain an interface to not break
-	 * other libraries' types (e.g. preact-router)
+	 * Use Attributes instead.
 	 */
-	interface ComponentProps extends Attributes {}
+	type ComponentProps = Attributes;
 
 	/**
 	 * @deprecated
 	 *
-	 * Use ClassAttributes instead. This type must remain an interface to not break
-	 * other libraries' types (e.g. preact-router)
+	 * Use ClassAttributes instead.
 	 */
-	interface PreactHTMLAttributes extends ClassAttributes<any> {}
+	type PreactHTMLAttributes = ClassAttributes<any>;
 
 	interface Attributes {
 		key?: string | number | any;
@@ -54,7 +52,7 @@ declare namespace preact {
 		key?: Key | null;
 	}
 
-	type RenderableProps<P> = Readonly<P> & Readonly<Attributes> & Readonly<{ children?: ComponentChildren }>;
+	type RenderableProps<P> = Readonly<P & Attributes & { children?: ComponentChildren }>;
 	type ClassRenderableProps<P> = RenderableProps<P> & Readonly<ClassAttributes<any>>;
 
 	interface FunctionalComponent<P = {}> {

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -52,8 +52,9 @@ declare namespace preact {
 		key?: Key | null;
 	}
 
-	type RenderableProps<P> = Readonly<P & Attributes & { children?: ComponentChildren }>;
-	type ClassRenderableProps<P> = RenderableProps<P> & Readonly<ClassAttributes<any>>;
+	type RenderableProps<P, RefType = any> = Readonly<
+		P & Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }
+	>;
 
 	interface FunctionalComponent<P = {}> {
 		(props: RenderableProps<P>, context?: any): VNode<any> | null;
@@ -88,7 +89,7 @@ declare namespace preact {
 		static defaultProps?: any;
 
 		state: Readonly<S>;
-		props: ClassRenderableProps<P>;
+		props: RenderableProps<P>;
 		context: any;
 		base?: HTMLElement;
 
@@ -97,7 +98,7 @@ declare namespace preact {
 
 		forceUpdate(callback?: () => void): void;
 
-		abstract render(props?: ClassRenderableProps<P>, state?: Readonly<S>, context?: any): JSX.Element | null;
+		abstract render(props?: RenderableProps<P>, state?: Readonly<S>, context?: any): JSX.Element | null;
 	}
 
 	function h<P>(

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -10,14 +10,14 @@ declare namespace preact {
 	/**
 	 * @deprecated
 	 *
-	 * Use Attributes instead.
+	 * Use Attributes instead
 	 */
 	type ComponentProps = Attributes;
 
 	/**
 	 * @deprecated
 	 *
-	 * Use ClassAttributes instead.
+	 * Use ClassAttributes instead
 	 */
 	type PreactHTMLAttributes = ClassAttributes<any>;
 

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -1,4 +1,4 @@
-import { h, render, Component, ComponentProps, FunctionalComponent } from "../../src/preact";
+import { h, render, Component, ComponentProps, FunctionalComponent, AnyComponent } from "../../src/preact";
 
 interface DummyProps {
 	initialInput: string;
@@ -16,12 +16,16 @@ class DummyComponent extends Component<DummyProps, DummyState> {
 		}
 	}
 
+	private setRef = (el: AnyComponent<any>) => {
+		console.log(el);
+	}
+
 	render({ initialInput }: DummyProps, { input }: DummyState) {
 		return (
 			<div>
 				<DummerComponent initialInput={initialInput} input={input} />
 				{/* Can specify all Preact attributes on a typed FunctionalComponent */}
-				<ComponentWithChildren initialInput={initialInput} input={input} key="1" />
+				<ComponentWithChildren initialInput={initialInput} input={input} key="1" ref={this.setRef} />
 			</div>
 		);
 	}
@@ -75,7 +79,7 @@ class ComponentUsingRef extends Component<any, any> {
 				<span ref={this.setRef}>{el}</span>
 			)}
 
-			{/* Can specify Preact attributes on class component */}
+			{/* Can specify Preact attributes on a component */}
 			<DummyComponent initialInput="1" key="1" ref={this.setRef} />
 		</div>
 	}

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -17,7 +17,13 @@ class DummyComponent extends Component<DummyProps, DummyState> {
 	}
 
 	render({ initialInput }: DummyProps, { input }: DummyState) {
-		return <DummerComponent initialInput={initialInput} input={input} />
+		return (
+			<div>
+				<DummerComponent initialInput={initialInput} input={input} />
+				{/* Can specify all Preact attributes on a typed FunctionalComponent */}
+				<ComponentWithChildren initialInput={initialInput} input={input} key="1" jsx={true} />
+			</div>
+		);
 	}
 }
 
@@ -29,7 +35,7 @@ function DummerComponent({ input, initialInput }: DummerComponentProps) {
 	return <div>Input: {input}, initial: {initialInput}</div>;
 }
 
-render(h(DummerComponent, { initialInput: "The input", input: "New input" }), document);
+render(h(DummerComponent, { initialInput: "The input", input: "New input", key: "1", jsx: false }), document);
 
 // Accessing children
 const ComponentWithChildren: FunctionalComponent<DummerComponentProps> = (
@@ -68,6 +74,9 @@ class ComponentUsingRef extends Component<any, any> {
 			{this.array.map(el =>
 				<span ref={this.setRef}>{el}</span>
 			)}
+
+			{/* Can specify Preact attributes on class component */}
+			<DummyComponent initialInput="1" key="1" jsx={true} ref={this.setRef} />
 		</div>
 	}
 

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -21,7 +21,7 @@ class DummyComponent extends Component<DummyProps, DummyState> {
 			<div>
 				<DummerComponent initialInput={initialInput} input={input} />
 				{/* Can specify all Preact attributes on a typed FunctionalComponent */}
-				<ComponentWithChildren initialInput={initialInput} input={input} key="1" jsx={true} />
+				<ComponentWithChildren initialInput={initialInput} input={input} key="1" />
 			</div>
 		);
 	}
@@ -35,7 +35,7 @@ function DummerComponent({ input, initialInput }: DummerComponentProps) {
 	return <div>Input: {input}, initial: {initialInput}</div>;
 }
 
-render(h(DummerComponent, { initialInput: "The input", input: "New input", key: "1", jsx: false }), document);
+render(h(DummerComponent, { initialInput: "The input", input: "New input", key: "1"}), document);
 
 // Accessing children
 const ComponentWithChildren: FunctionalComponent<DummerComponentProps> = (
@@ -76,7 +76,7 @@ class ComponentUsingRef extends Component<any, any> {
 			)}
 
 			{/* Can specify Preact attributes on class component */}
-			<DummyComponent initialInput="1" key="1" jsx={true} ref={this.setRef} />
+			<DummyComponent initialInput="1" key="1" ref={this.setRef} />
 		</div>
 	}
 


### PR DESCRIPTION
The existing types don't allow a component to add Preact common props that any component can specify (e.g. `key`). I've updated the types to add back these common props to `RenderableProps`.

I also changed some types from `type` to `interface` to allow other libraries to extend them with their own common props (e.g. preact-router adds `path`).

See the tests I added for an example of the code that previously didn't work.