### PR TITLE
Uglifyjs fix

### DIFF
--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,4 +1,5 @@
 /** Virtual DOM Node */
 export function VNode() {}
 
-VNode.undefined = undefined
+// For more info look at issue #1063
+VNode.undefined = undefined;

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,2 +1,4 @@
 /** Virtual DOM Node */
 export function VNode() {}
+
+VNode.undefined = undefined


### PR DESCRIPTION
Note: I'm not quite sure if Preact is the problem.

I came across a problem using [react-slick](https://github.com/akiran/react-slick) and preact. I got a `Uncaught TypeError: Cannot read property 'className' of undefined`, but the odd thing was I only got this error in production mode. So I looked into it and it turns out preact-compat wasn't mutating the `VNode`. And the reason for that was Uglifyjs was not exposing `VNode` anymore. Since `VNode` is an empty class and only used once, in the `h` function, Uglifyjs makes it inline, like `let p = new function() {}();` so preact-compat can't access it.

You can see this issue in action [here](https://github.com/ocboogie/preact-uglyjs-bug).

So my fix(hack) for this issue was setting a property on `VNode` after it was declared, this way Uglifyjs doesn't make it inline. They're very well might be a more elegant way to fix this.
