### PR TITLE
Remove object-notation for class/className from TS typings

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -518,8 +518,8 @@ declare global {
 			charSet?: string;
 			challenge?: string;
 			checked?: boolean;
-			class?: string | { [key: string]: boolean };
-			className?: string | { [key: string]: boolean };
+			class?: string;
+			className?: string;
 			cols?: number;
 			colSpan?: number;
 			content?: string;


### PR DESCRIPTION
That feature was removed in 8.0.0