### PR TITLE
allow optional arguments even if not used

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -91,10 +91,10 @@ declare namespace preact {
 		context: any;
 		base?: HTMLElement;
 
-		setState<K extends keyof S>(state: Pick<S, K>, callback?: () => void): void;
-		setState<K extends keyof S>(fn: (prevState: S, props: P) => Pick<S, K>, callback?: () => void): void;
+		setState<K extends keyof S>(state: Pick<S, K>, callback?: (...args) => void): void;
+		setState<K extends keyof S>(fn: (prevState: S, props: P) => Pick<S, K>, callback?: (...args) => void): void;
 
-		forceUpdate(callback?: () => void): void;
+		forceUpdate(callback?: (...args) => void): void;
 
 		abstract render(props?: RenderableProps<P>, state?: Readonly<S>, context?: any): JSX.Element | null;
 	}


### PR DESCRIPTION
when providing a callback many people can just, rather than use an arrow function () => this.whatever(), they can provide the whole function as a callback and that may trigger TS errors since that callback can host arguments.

With this change we allow any kind of callback which IMO is more correct