### PR TITLE
Release 8.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact",
-  "version": "8.2.8",
+  "version": "8.2.9",
   "description": "Fast 3kb React alternative with the same modern API. Components & Virtual DOM.",
   "main": "dist/preact.js",
   "jsnext:main": "dist/preact.esm.js",


### PR DESCRIPTION
Draft for release announcement:

```md
This release fixes an issue with our minifacation pipeline, which
incorrectly mangled export declarations.

* Don't mangle module exports #1077, thanks @marvinhagemeister
* [ts] Add missing `ref` and `key` attribute #1051, thanks @andrewiggins
* [ts] Add default parameter for Generic argument of `VNode` #1082, thanks @andrewiggins
* [ts] Remove devtools module declaraction #1083, thanks @andrewiggins
```

Fixes #1075 