### PR TITLE
Provide default type for VNode generic parameter

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -45,7 +45,7 @@ declare namespace preact {
 	 * of child {VNode}s and a key. The key is used by preact for
 	 * internal purposes.
 	 */
-	interface VNode<P> {
+	interface VNode<P = any> {
 		nodeName: ComponentFactory<P> | string;
 		attributes: P;
 		children: Array<VNode<any> | string>;


### PR DESCRIPTION
Make the VNode generic parameter optional by providing a default type for it.

Adding a generic parameter to the VNode interface breaks the types of many preact libraries that reference or extend VNode. Until many of these libraries update their types to provide a value for the VNode type parameter, I suggest we make it optional. Making it optional unblocks Preact TypeScript users to adopt 8.2.8+ without having to wait for all other libraries to catch up.

Addresses #1081