### PR TITLE
Remove devtools module declaraction

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -124,11 +124,6 @@ declare namespace preact {
 	};
 }
 
-declare module "preact/devtools" {
-	// Empty. This module initializes the React Developer Tools integration
-	// when imported.
-}
-
 declare global {
 	namespace JSX {
 		interface Element extends preact.VNode<any> {


### PR DESCRIPTION
I haven't found a way to avoid getting the following error from the `preact/devtools` declaration in this file:
```
error TS2665: Invalid module name in augmentation. Module 'preact/devtools' resolves to an untyped module at 'node_modules/preact/devtools.js', which cannot be augmented.
```

I don't believe this declaration is really necessary though. Neither devtools.js nor debug.js have any exports so using syntax such as `import * as something from 'preact/debug';` wouldn't be correct usage. TypeScript only needs the module to be declared if you try to import something from it. Since the correct usage of these modules is `import 'preact/debug';` or `require('preact/debug');`, we don't need to declare definitions for these modules. TypeScript handles `import 'preact/debug';` and `require('preact/debug');` fine without any definitions.

P.S. it appears that error is because it isn't declared within a global scope (see Microsoft/TypeScript#9748). However wrapping this declaration in a `declare global` leads to others errors. Instead of chasing that rabbit hole, I thought it made more sense to just remove it, given the rationale above.

Thoughts?