### PR TITLE
WIP: Try to fix failing saucelabs connections

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -99,7 +99,7 @@ module.exports = function(config) {
 
 		sauceLabs: {
 			tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('../package.json').version),
-			startConnect: !!process.env.TRAVIS
+			startConnect: sauceLabs
 		},
 
 		customLaunchers: sauceLabs ? sauceLabsLaunchers : localLaunchers,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -97,10 +97,10 @@ module.exports = function(config) {
 		// Use only two browsers concurrently, works better with open source Sauce Labs remote testing
 		concurrency: 2,
 
-		// sauceLabs: {
-		// 	tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('./package.json').version),
-		// 	startConnect: false
-		// },
+		sauceLabs: {
+			tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('../package.json').version),
+			startConnect: !!process.env.TRAVIS
+		},
 
 		customLaunchers: sauceLabs ? sauceLabsLaunchers : localLaunchers,
 


### PR DESCRIPTION
I can't verify this, because I don't have access to saucelabs. Everything I can find via google points to a mismatch of the id of the tunnel.

Current error message on saucelabs:

```
Your test errored. No active tunnel found for identifier karma1525334797
```

@developit Can you check if this fixes it?