### PR TITLE
Remove IE9 and IE10 from remote testing

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -34,18 +34,6 @@ var sauceLabsLaunchers = {
 		browserName: 'internet explorer',
 		version: '11.103',
 		platform: 'Windows 10'
-	},
-	sl_ie_10: {
-		base: 'SauceLabs',
-		browserName: 'internet explorer',
-		version: '10.0',
-		platform: 'Windows 7'
-	},
-	sl_ie_9: {
-		base: 'SauceLabs',
-		browserName: 'internet explorer',
-		version: '9.0',
-		platform: 'Windows 7'
 	}
 };
 


### PR DESCRIPTION
As `mocha` is now on version 5 we should remove IE9 and IE10 from Sauce Labs testing as @marvinhagemeister pointed out.

The Travis build is erroring now because of this.

This PR fixes precisely that.