### PR TITLE
Implicitly set keys for components created using JSX

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -37,7 +37,19 @@ const EMPTY_CHILDREN = [];
 export function h(nodeName, attributes) {
 	let children=EMPTY_CHILDREN, lastSimple, child, simple, i;
 	for (i=arguments.length; i-- > 2; ) {
-		stack.push(arguments[i]);
+		child = arguments[i];
+		if ((child instanceof VNode) && (child.key==null)) {
+			const key = `preact-${arguments.length - i}`
+			child.key = key;
+			if (child.attributes) {
+				child.attributes.key = key
+			} else {
+				child.attributes = {
+					key: key
+				}
+			}
+		}
+		stack.push(child);
 	}
 	if (attributes && attributes.children!=null) {
 		if (!stack.length) stack.push(attributes.children);


### PR DESCRIPTION
To fix: https://github.com/developit/preact/issues/857
This is minimal POC of assigning implicit keys when you know the order of the arguments is going to be the same.
There is still a lot to do:
- [ ] Fix breaking tests
- [ ] Add new tests
- [ ] Don't create attributes object only for key
- [ ] Avoid using `key` and use `__key`
- [ ] As might be a breaking change, hide behind a flag.

Fixes @youknowriad's demo https://codesandbox.io/s/w2wxzr0q2k
Let me know if this approach is explorable or completely absurd / unfeasible. I'll start working on the above points accordingly.

CC: @yaodingyd, @developit 