### PR TITLE
Add support for getDerivedStateFromProps

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -20,13 +20,13 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 	if ((component.__ref = props.ref)) delete props.ref;
 	if ((component.__key = props.key)) delete props.key;
 
-	if (component.constructor.getDerivedStateFromProps) {
-		component.state = extend(component.state, component.constructor.getDerivedStateFromProps(props, component.state));
-	} else if (!component.base || mountAll) {
-		if (component.componentWillMount) component.componentWillMount();
-	}
-	else if (component.componentWillReceiveProps) {
-		component.componentWillReceiveProps(props, context);
+	if (typeof component.constructor.getDerivedStateFromProps === 'undefined') {
+		if (!component.base || mountAll) {
+			if (component.componentWillMount) component.componentWillMount();
+		}
+		else if (component.componentWillReceiveProps) {
+			component.componentWillReceiveProps(props, context);
+		}
 	}
 
 	if (context && context!==component.context) {
@@ -74,6 +74,11 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		initialChildComponent = component._component,
 		skip = false,
 		rendered, inst, cbase;
+
+	let getDerivedStateFromProps = component.constructor.getDerivedStateFromProps;
+	if (getDerivedStateFromProps) {
+		state = component.state = extend(state, getDerivedStateFromProps(props, state));
+	}
 
 	// if updating
 	if (isUpdate) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -75,9 +75,8 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		skip = false,
 		rendered, inst, cbase;
 
-	let getDerivedStateFromProps = component.constructor.getDerivedStateFromProps;
-	if (getDerivedStateFromProps) {
-		state = component.state = extend(state, getDerivedStateFromProps(props, state));
+	if (component.constructor.getDerivedStateFromProps) {
+		state = component.state = extend(state, component.constructor.getDerivedStateFromProps(props, state));
 	}
 
 	// if updating

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -20,7 +20,9 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 	if ((component.__ref = props.ref)) delete props.ref;
 	if ((component.__key = props.key)) delete props.key;
 
-	if (!component.base || mountAll) {
+	if (component.constructor.getDerivedStateFromProps) {
+		component.state = extend(component.state, component.constructor.getDerivedStateFromProps(props, component.state));
+	} else if (!component.base || mountAll) {
 		if (component.componentWillMount) component.componentWillMount();
 	}
 	else if (component.componentWillReceiveProps) {

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -26,10 +26,10 @@ describe('Lifecycle methods', () => {
 	describe('static getDerivedStateFromProps', () => {
 		it('should set initial state with value returned from getDerivedStateFromProps', () => {
 			class Foo extends Component {
-				static getDerivedStateFromProps(nextProps, prevState) {
+				static getDerivedStateFromProps(nextProps) {
 					return {
 						foo: nextProps.foo,
-						bar: 'bar',
+						bar: 'bar'
 					};
 				}
 				render() {
@@ -47,12 +47,12 @@ describe('Lifecycle methods', () => {
 					super(props, context);
 					this.state = {
 						foo: 'foo',
-						bar: 'bar',
+						bar: 'bar'
 					};
 				}
 				static getDerivedStateFromProps(nextProps, prevState) {
 					return {
-						foo: `not-${prevState.foo}`,
+						foo: `not-${prevState.foo}`
 					};
 				}
 				render() {
@@ -69,13 +69,13 @@ describe('Lifecycle methods', () => {
 				constructor(props, context) {
 					super(props, context);
 					this.state = {
-						value: 'initial',
+						value: 'initial'
 					};
 				}
-				static getDerivedStateFromProps(nextProps, prevState) {
+				static getDerivedStateFromProps(nextProps) {
 					if (nextProps.update) {
 						return {
-							value: 'updated',
+							value: 'updated'
 						};
 					}
 
@@ -95,13 +95,13 @@ describe('Lifecycle methods', () => {
 
 			element = render(<Foo update={false} />, scratch, element);
 			expect(element.className).to.equal('initial');
-			expect(Foo.getDerivedStateFromProps).to.have.callCount(1)
+			expect(Foo.getDerivedStateFromProps).to.have.callCount(1);
 			expect(Foo.prototype.componentDidMount).to.have.callCount(1); // verify mount occurred
 			expect(Foo.prototype.componentDidUpdate).to.have.callCount(0);
 
 			element = render(<Foo update={true} />, scratch, element);
 			expect(element.className).to.equal('updated');
-			expect(Foo.getDerivedStateFromProps).to.have.callCount(2)
+			expect(Foo.getDerivedStateFromProps).to.have.callCount(2);
 			expect(Foo.prototype.componentDidMount).to.have.callCount(1);
 			expect(Foo.prototype.componentDidUpdate).to.have.callCount(1); // verify update occurred
 		});
@@ -111,7 +111,7 @@ describe('Lifecycle methods', () => {
 				constructor(props, context) {
 					super(props, context);
 					this.state = {
-						value: 'initial',
+						value: 'initial'
 					};
 				}
 				static getDerivedStateFromProps(nextProps, prevState) {
@@ -121,7 +121,7 @@ describe('Lifecycle methods', () => {
 					}
 
 					return {
-						value: 'unexpected',
+						value: 'unexpected'
 					};
 				}
 				componentDidMount() {
@@ -150,7 +150,7 @@ describe('Lifecycle methods', () => {
 					super(props, context);
 					this.state = {
 						foo: 'foo',
-						bar: 'bar',
+						bar: 'bar'
 					};
 				}
 				static getDerivedStateFromProps() {
@@ -176,7 +176,7 @@ describe('Lifecycle methods', () => {
 					super(props, context);
 					this.state = {
 						foo: 'foo',
-						bar: 'bar',
+						bar: 'bar'
 					};
 				}
 				static getDerivedStateFromProps() {}
@@ -198,10 +198,10 @@ describe('Lifecycle methods', () => {
 			class Foo extends Component {
 				static getDerivedStateFromProps() {}
 				componentWillMount() {
-					throw new Error('componentWillMount should not be called if getDerivedStateFromProps is present.')
+					throw new Error('componentWillMount should not be called if getDerivedStateFromProps is present.');
 				}
 				componentWillReceiveProps() {
-					throw new Error('componentWillReceiveProps should not be called if getDerivedStateFromProps is present.')
+					throw new Error('componentWillReceiveProps should not be called if getDerivedStateFromProps is present.');
 				}
 				render() {
 					return <div />;

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -106,7 +106,7 @@ describe('Lifecycle methods', () => {
 			expect(Foo.prototype.componentDidUpdate).to.have.callCount(1); // verify update occurred
 		});
 
-		it('should NOT be invoked on state only updates', () => {
+		it('should update the instance\'s state with the value returned from getDerivedStateFromProps when state changes', () => {
 			class Foo extends Component {
 				constructor(props, context) {
 					super(props, context);
@@ -121,7 +121,7 @@ describe('Lifecycle methods', () => {
 					}
 
 					return {
-						value: 'unexpected'
+						value: prevState.value + ' derived'
 					};
 				}
 				componentDidMount() {
@@ -140,8 +140,8 @@ describe('Lifecycle methods', () => {
 			expect(Foo.getDerivedStateFromProps).to.have.been.calledOnce;
 
 			rerender(); // call rerender to handle cDM setState call
-			expect(element.className).to.equal('updated');
-			expect(Foo.getDerivedStateFromProps).to.have.been.calledOnce;
+			expect(element.className).to.equal('updated derived');
+			expect(Foo.getDerivedStateFromProps).to.have.been.calledTwice;
 		});
 
 		it('should NOT modify state if null is returned', () => {
@@ -197,12 +197,8 @@ describe('Lifecycle methods', () => {
 		it('should NOT invoke deprecated lifecycles (cWM/cWRP) if new static gDSFP is present', () => {
 			class Foo extends Component {
 				static getDerivedStateFromProps() {}
-				componentWillMount() {
-					throw new Error('componentWillMount should not be called if getDerivedStateFromProps is present.');
-				}
-				componentWillReceiveProps() {
-					throw new Error('componentWillReceiveProps should not be called if getDerivedStateFromProps is present.');
-				}
+				componentWillMount() {}
+				componentWillReceiveProps() {}
 				render() {
 					return <div />;
 				}

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -23,6 +23,206 @@ describe('Lifecycle methods', () => {
 	});
 
 
+	describe('static getDerivedStateFromProps', () => {
+		it('should set initial state with value returned from getDerivedStateFromProps', () => {
+			class Foo extends Component {
+				static getDerivedStateFromProps(nextProps, prevState) {
+					return {
+						foo: nextProps.foo,
+						bar: 'bar',
+					};
+				}
+				render() {
+					return <div className={`${this.state.foo} ${this.state.bar}`} />;
+				}
+			}
+
+			let element = render(<Foo foo="foo" />, scratch);
+			expect(element.className).to.be.equal('foo bar');
+		});
+
+		it('should update initial state with value returned from getDerivedStateFromProps', () => {
+			class Foo extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state = {
+						foo: 'foo',
+						bar: 'bar',
+					};
+				}
+				static getDerivedStateFromProps(nextProps, prevState) {
+					return {
+						foo: `not-${prevState.foo}`,
+					};
+				}
+				render() {
+					return <div className={`${this.state.foo} ${this.state.bar}`} />;
+				}
+			}
+
+			let element = render(<Foo />, scratch);
+			expect(element.className).to.equal('not-foo bar');
+		});
+
+		it('should update the instance\'s state with the value returned from getDerivedStateFromProps when props change', () => {
+			class Foo extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state = {
+						value: 'initial',
+					};
+				}
+				static getDerivedStateFromProps(nextProps, prevState) {
+					if (nextProps.update) {
+						return {
+							value: 'updated',
+						};
+					}
+
+					return null;
+				}
+				componentDidMount() {}
+				componentDidUpdate() {}
+				render() {
+					return <div className={this.state.value} />;
+				}
+			}
+
+			let element;
+			sinon.spy(Foo, 'getDerivedStateFromProps');
+			sinon.spy(Foo.prototype, 'componentDidMount');
+			sinon.spy(Foo.prototype, 'componentDidUpdate');
+
+			element = render(<Foo update={false} />, scratch, element);
+			expect(element.className).to.equal('initial');
+			expect(Foo.getDerivedStateFromProps).to.have.callCount(1)
+			expect(Foo.prototype.componentDidMount).to.have.callCount(1); // verify mount occurred
+			expect(Foo.prototype.componentDidUpdate).to.have.callCount(0);
+
+			element = render(<Foo update={true} />, scratch, element);
+			expect(element.className).to.equal('updated');
+			expect(Foo.getDerivedStateFromProps).to.have.callCount(2)
+			expect(Foo.prototype.componentDidMount).to.have.callCount(1);
+			expect(Foo.prototype.componentDidUpdate).to.have.callCount(1); // verify update occurred
+		});
+
+		it('should NOT be invoked on state only updates', () => {
+			class Foo extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state = {
+						value: 'initial',
+					};
+				}
+				static getDerivedStateFromProps(nextProps, prevState) {
+					// Don't change state for call that happens after the constructor
+					if (prevState.value === 'initial') {
+						return null;
+					}
+
+					return {
+						value: 'unexpected',
+					};
+				}
+				componentDidMount() {
+					this.setState({ value: 'updated' });
+				}
+				render() {
+					return <div className={this.state.value} />;
+				}
+			}
+
+			let element;
+			sinon.spy(Foo, 'getDerivedStateFromProps');
+
+			element = render(<Foo />, scratch, element);
+			expect(element.className).to.equal('initial');
+			expect(Foo.getDerivedStateFromProps).to.have.been.calledOnce;
+
+			rerender(); // call rerender to handle cDM setState call
+			expect(element.className).to.equal('updated');
+			expect(Foo.getDerivedStateFromProps).to.have.been.calledOnce;
+		});
+
+		it('should NOT modify state if null is returned', () => {
+			class Foo extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state = {
+						foo: 'foo',
+						bar: 'bar',
+					};
+				}
+				static getDerivedStateFromProps() {
+					return null;
+				}
+				render() {
+					return <div className={`${this.state.foo} ${this.state.bar}`} />;
+				}
+			}
+
+			sinon.spy(Foo, 'getDerivedStateFromProps');
+
+			let element = render(<Foo />, scratch);
+			expect(element.className).to.equal('foo bar');
+			expect(Foo.getDerivedStateFromProps).to.have.been.called;
+		});
+
+		// NOTE: Difference from React
+		// React v16.3.2 warns if undefined if returned from getDerivedStateFromProps
+		it('should NOT modify state if undefined is returned', () => {
+			class Foo extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state = {
+						foo: 'foo',
+						bar: 'bar',
+					};
+				}
+				static getDerivedStateFromProps() {}
+				render() {
+					return <div className={`${this.state.foo} ${this.state.bar}`} />;
+				}
+			}
+
+			sinon.spy(Foo, 'getDerivedStateFromProps');
+
+			let element = render(<Foo />, scratch);
+			expect(element.className).to.equal('foo bar');
+			expect(Foo.getDerivedStateFromProps).to.have.been.called;
+		});
+
+		// TODO: Consider if componentWillUpdate should still be called
+		// Likely, componentWillUpdate should not be called only if getSnapshotBeforeUpdate is implemented
+		it('should NOT invoke deprecated lifecycles (cWM/cWRP) if new static gDSFP is present', () => {
+			class Foo extends Component {
+				static getDerivedStateFromProps() {}
+				componentWillMount() {
+					throw new Error('componentWillMount should not be called if getDerivedStateFromProps is present.')
+				}
+				componentWillReceiveProps() {
+					throw new Error('componentWillReceiveProps should not be called if getDerivedStateFromProps is present.')
+				}
+				render() {
+					return <div />;
+				}
+			}
+
+			sinon.spy(Foo, 'getDerivedStateFromProps');
+			sinon.spy(Foo.prototype, 'componentWillMount');
+			sinon.spy(Foo.prototype, 'componentWillReceiveProps');
+
+			render(<Foo />, scratch);
+			expect(Foo.getDerivedStateFromProps).to.have.been.called;
+			expect(Foo.prototype.componentWillMount).to.not.have.been.called;
+			expect(Foo.prototype.componentWillReceiveProps).to.not.have.been.called;
+		});
+
+		// TODO: Investigate this test:
+		// [should not override state with stale values if prevState is spread within getDerivedStateFromProps](https://github.com/facebook/react/blob/25dda90c1ecb0c662ab06e2c80c1ee31e0ae9d36/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js#L1035)
+	});
+
+
 	describe('#componentWillUpdate', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {


### PR DESCRIPTION
Add support for the getDerivedStateFromProps lifecycle method.

Where componentWillMount or componentWillReceiveProps would've previously been called, Preact now invokes getDerivedStateFromProps on the component's constructor. The result of getDerivedStateFromProps is then immediately merged into the component's current state for use by the next lifecycle methods (primarily shouldComponentUpdate, render, and componentDidUpdate).

Sizes (bytes gzipped)
Before: 3443

~~After: 3477~~
~~Change: +34~~

commit 4150a25
After: 3480
Change: +37

Some differences from React
1. React warns if getDerivedStateFromProps is defined on Functional Components ([source](https://github.com/facebook/react/blob/25dda90c1ecb0c662ab06e2c80c1ee31e0ae9d36/packages/react-dom/src/__tests__/ReactStatelessComponent-test.js#L101)).
2. React warns if getDerivedStateFromProps is defined but state is not initialized ([source](https://github.com/facebook/react/blob/25dda90c1ecb0c662ab06e2c80c1ee31e0ae9d36/packages/react/src/__tests__/ReactES6Class-test.js#L174)). Preact always initializes state to an empty object ([source](https://github.com/developit/preact/blob/46c76c3c95c19ba1c2aba4d2862ed74c30d84e88/src/component.js#L33)) so this isn't necessary.
3. React warns if getDerivedStateFromProps returns undefined ([source](https://github.com/facebook/react/blob/25dda90c1ecb0c662ab06e2c80c1ee31e0ae9d36/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js#L174)). This PR allows undefined to be returned.

See comments for more discussion.

Updated sizes.