### PR TITLE
Remove whitelist for css properties

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,3 @@ export const ASYNC_RENDER = 3;
 
 
 export const ATTR_KEY = '__preactattr_';
-
-// DOM properties that should NOT have "px" added when numeric
-export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
-

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -1,4 +1,3 @@
-import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
 
@@ -55,7 +54,7 @@ export function setAccessor(node, name, old, value, isSvg) {
 				for (let i in old) if (!(i in value)) node.style[i] = '';
 			}
 			for (let i in value) {
-				node.style[i] = typeof value[i]==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (value[i]+'px') : value[i];
+				node.style[i] = value[i];
 			}
 		}
 	}

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -359,8 +359,8 @@ describe('render()', () => {
 				background: 'rgb(255, 100, 0)',
 				backgroundPosition: '10px 10px',
 				'background-size': 'cover',
-				padding: 5,
-				top: 100,
+				padding: '5px',
+				top: '100px',
 				left: '100%'
 			}}>
 				test


### PR DESCRIPTION
This PR reduces the bundle size (`3443 -> 3377 bytes`).

Was looking around for possible reductions in size and noticed, that we automatically append `px` for numeric values for properties of the `style`-attribute. But adding the `px` suffix is not correct for every numeric value in css, which is why a small regex whitelist is in our code.

The reason we have this is because of react. See https://reactjs.org/docs/dom-elements.html . I think it would be better for us if we'd move this to `preact-compat`. In every react or preact-based codebase that I've worked on, the developers chose to specify the suffix themselves and weren't even aware that both libs shipped with that feature. Even with that knowledge they preferred the explicitness of specifying the suffix themselves.

Example:

```jsx
const n = 100;

// Before: preact will add the 'px' suffix
const foo = <div style={{ top: n }} />;

// After: devs must add explicit suffix
const bar = <div style={{ top: n + 'px' }} />;
```

My experience may be subject to sample bias, that's why I'd love to here other opinions on this first before moving this out of core to `preact-compat`.