### PR TITLE
Add badge to README with Install Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 [![travis](https://travis-ci.org/developit/preact.svg?branch=master)](https://travis-ci.org/developit/preact)
 [![coveralls](https://img.shields.io/coveralls/developit/preact/master.svg)](https://coveralls.io/github/developit/preact)
 [![gzip size](http://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=gzip)](https://unpkg.com/preact/dist/preact.min.js)
+[![install size](https://packagephobia.now.sh/badge?p=preact)](https://packagephobia.now.sh/result?p=preact)
 
 Preact supports modern browsers and IE9+:
 


### PR DESCRIPTION
This badge displays the npm install size of `preact` plus it's dependencies (in this case 0 😄)