### PR TITLE
Fix spellcheck attr not set to false

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -81,10 +81,13 @@ export function setAccessor(node, name, old, value, isSvg) {
 	}
 	else if (name!=='list' && name!=='type' && !isSvg && name in node) {
 		setProperty(node, name, value==null ? '' : value);
-		if (value==null || value===false) node.removeAttribute(name);
+		if ((value==null || value===false) && name!='spellcheck') node.removeAttribute(name);
 	}
 	else {
 		let ns = isSvg && (name !== (name = name.replace(/^xlink:?/, '')));
+		// spellcheck is treated differently than all other boolean values and
+		// should not be removed when the value is `false`. See:
+		// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-spellcheck
 		if (value==null || value===false) {
 			if (ns) node.removeAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase());
 			else node.removeAttribute(name);

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -690,7 +690,7 @@ declare global {
 			sizes?: string;
 			slot?: string;
 			span?: number;
-			spellCheck?: boolean;
+			spellcheck?: boolean;
 			src?: string;
 			srcset?: string;
 			srcDoc?: string;

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -151,6 +151,12 @@ describe('Components', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
+	// Test for #651
+	it('should set enumerable boolean attribute', () => {
+		render(<input spellcheck={false} />, scratch);
+		expect(scratch.firstChild.spellcheck).to.equal(false);
+	});
+
 	// Test for Issue #73
 	it('should remove orphaned elements replaced by Components', () => {
 		class Comp extends Component {


### PR DESCRIPTION
I'm not too keen on checking directly against the attribute name, but this seems to be the only case in the spec where the attribute should not be removed if the value is `false`.

```js
const el = document.createElement("input");

el.removeAttribute("spellCheck");
el.spellcheck // logs `true` :/

el.setAttribute("spellCheck", false);
el.spellcheck // logs `false`
```

Fixes #651.