### PR TITLE
Improve JSDoc comments

### DIFF
--- a/config/eslint-config.js
+++ b/config/eslint-config.js
@@ -23,7 +23,7 @@ module.exports = {
 	rules: {
 		'react/jsx-uses-react': 2,
 		'react/jsx-uses-vars': 2,
-		'no-unused-vars': [1, { varsIgnorePattern: '^h$' }],
+		'no-unused-vars': [1, { varsIgnorePattern: '(^h$|^VNode$)' }],
 		'no-cond-assign': 1,
 		'no-empty': 0,
 		'no-console': 1,

--- a/config/eslint-config.js
+++ b/config/eslint-config.js
@@ -23,7 +23,7 @@ module.exports = {
 	rules: {
 		'react/jsx-uses-react': 2,
 		'react/jsx-uses-vars': 2,
-		'no-unused-vars': [1, { varsIgnorePattern: '(^h$|^VNode$)' }],
+		'no-unused-vars': [1, { varsIgnorePattern: '^h$' }],
 		'no-cond-assign': 1,
 		'no-empty': 0,
 		'no-console': 1,

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "sinon": "^4.4.2",
     "sinon-chai": "^3.0.0",
-    "typescript": "^2.8.1",
+    "typescript": "^2.9.0-dev.20180509",
     "uglify-js": "^2.7.5",
     "webpack": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "sinon": "^4.4.2",
     "sinon-chai": "^3.0.0",
-    "typescript": "^2.9.0-dev.20180509",
+    "typescript": "^2.9.0-rc",
     "uglify-js": "^2.7.5",
     "webpack": "^4.3.0"
   },

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,11 +1,12 @@
 import { extend } from './util';
 import { h } from './h';
+import { VNode } from './vnode';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
- * @param {import('./vnode').VNode} vnode The virtual DOM element to clone
+ * @param {VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {Array<import('./vnode').VNode>} [rest] Any additional arguments will be used as replacement children.
+ * @param {Array<VNode>} [rest] Any additional arguments will be used as replacement children.
  */
 export function cloneElement(vnode, props) {
 	return h(

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -6,7 +6,7 @@ import { VNode } from './vnode';
  * Clones the given VNode, optionally adding attributes/props and replacing its
  * children.
  * @param {VNode} vnode The virtual DOM element to clone
- * @param {Object} props Attributes/props to add when cloning
+ * @param {object} props Attributes/props to add when cloning
  * @param {Array<VNode>} [rest] Any additional arguments will be used as replacement
  *  children.
  */

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,13 +1,12 @@
 import { extend } from './util';
 import { h } from './h';
-import { VNode } from './vnode';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its
  * children.
- * @param {VNode} vnode The virtual DOM element to clone
+ * @param {import('./vnode').VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {Array<VNode>} [rest] Any additional arguments will be used as replacement
+ * @param {Array<import('./vnode').VNode>} [rest] Any additional arguments will be used as replacement
  *  children.
  */
 export function cloneElement(vnode, props) {

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,15 +1,11 @@
-/**
- * @typedef {import('./vnode').VNode} VNode
- */
-
 import { extend } from './util';
 import { h } from './h';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
- * @param {VNode} vnode The virtual DOM element to clone
+ * @param {import('./vnode').VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {VNode[]} [rest] Any additional arguments will be used as replacement children.
+ * @param {Array<import('./vnode').VNode>} [rest] Any additional arguments will be used as replacement children.
  */
 export function cloneElement(vnode, props) {
 	return h(

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -7,9 +7,9 @@ import { h } from './h';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
- * @param {VNode} vnode		The virtual DOM element to clone
- * @param {Object} props	Attributes/props to add when cloning
- * @param {VNode[]} [rest]	Any additional arguments will be used as replacement children.
+ * @param {VNode} vnode The virtual DOM element to clone
+ * @param {object} props Attributes/props to add when cloning
+ * @param {VNode[]} [rest] Any additional arguments will be used as replacement children.
  */
 export function cloneElement(vnode, props) {
 	return h(

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('./vnode').VNode} VNode
+ */
+
 import { extend } from './util';
 import { h } from './h';
 
@@ -5,7 +9,7 @@ import { h } from './h';
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
  * @param {VNode} vnode		The virtual DOM element to clone
  * @param {Object} props	Attributes/props to add when cloning
- * @param {VNode} rest		Any additional arguments will be used as replacement children.
+ * @param {VNode[]} [rest]	Any additional arguments will be used as replacement children.
  */
 export function cloneElement(vnode, props) {
 	return h(

--- a/src/component.js
+++ b/src/component.js
@@ -6,7 +6,7 @@ import { enqueueRender } from './render-queue';
 /** Base Component class.
  *	Provides `setState()` and `forceUpdate()`, which trigger rendering.
  *	@public
- *
+ *  @typedef {Object} Component
  *	@example
  *	class MyFoo extends Component {
  *		render(props, state) {
@@ -37,12 +37,12 @@ export function Component(props, context) {
 extend(Component.prototype, {
 
 	/** Returns a `boolean` indicating if the component should re-render when receiving the given `props` and `state`.
+	 *	@name shouldComponentUpdate
+	 *	@function
 	 *	@param {object} nextProps
 	 *	@param {object} nextState
 	 *	@param {object} nextContext
 	 *	@returns {Boolean} should the component re-render
-	 *	@name shouldComponentUpdate
-	 *	@function
 	 */
 
 

--- a/src/component.js
+++ b/src/component.js
@@ -44,7 +44,7 @@ extend(Component.prototype, {
 	/**
 	 * Update component state by copying properties from `state` to `this.state`.
 	 * @param {object} state A hash of state properties to update with new values
-	 * @param {function} callback A function to be called once component state is updated
+	 * @param {() => void} callback A function to be called once component state is updated
 	 */
 	setState(state, callback) {
 		let s = this.state;
@@ -57,7 +57,7 @@ extend(Component.prototype, {
 
 	/**
 	 * Immediately perform a synchronous re-render of the component.
-	 * @param {function} callback A function to be called after component is re-rendered.
+	 * @param {() => void} callback A function to be called after component is re-rendered.
 	 * @private
 	 */
 	forceUpdate(callback) {

--- a/src/component.js
+++ b/src/component.js
@@ -75,8 +75,8 @@ extend(Component.prototype, {
 	 * @param {object} props Props (eg: JSX attributes) received from parent
 	 * 	element/component
 	 * @param {object} state The component's current state
-	 * @param {object} context Context object (if a parent component has provided
-	 * 	context)
+	 * @param {object} context Context object, as returned by the nearest
+	 *  ancestor's `getChildContext()`
 	 * @returns {import('./vnode').VNode | void}
 	 */
 	render() {}

--- a/src/component.js
+++ b/src/component.js
@@ -42,7 +42,7 @@ export function Component(props, context) {
 extend(Component.prototype, {
 
 	/**
-	 * Update component state by copying properties from `state` to `this.state`.
+	 * Update component state and schedule a re-render.
 	 * @param {object} state A hash of state properties to update with new values
 	 * @param {() => void} callback A function to be called once component state is updated
 	 */
@@ -71,7 +71,7 @@ extend(Component.prototype, {
 	 * Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
 	 * @param {object} props Props (eg: JSX attributes) received from parent element/component
 	 * @param {object} state The component's current state
-	 * @param {object} context Context object (if a parent component has provided context)
+	 * @param {object} context Context object, as returned by the nearest  ancestor's `getChildContext()`
 	 * @returns {import('./vnode').VNode | void}
 	 */
 	render() {}

--- a/src/component.js
+++ b/src/component.js
@@ -1,34 +1,43 @@
+/**
+ * @typedef {import('./vnode').VNode} VNode
+ */
+
 import { FORCE_RENDER } from './constants';
 import { extend } from './util';
 import { renderComponent } from './vdom/component';
 import { enqueueRender } from './render-queue';
 
-/** Base Component class.
- *	Provides `setState()` and `forceUpdate()`, which trigger rendering.
- *	@public
- *	@typedef {object} Component
- *	@example
- *	class MyFoo extends Component {
- *		render(props, state) {
- *			return <div />;
- *		}
- *	}
+/**
+ * Base Component class. Provides `setState()` and `forceUpdate()`, which trigger rendering
+ * @typedef {object} Component
+ * @param {object} props The initial component props
+ * @param {object} context The initial context from parent components' getChildContext
+ * @public
+ * @example
+ * class MyFoo extends Component {
+ * 		render(props, state) {
+ * 			return <div />;
+ * 		}
+ * }
  */
 export function Component(props, context) {
 	this._dirty = true;
 
-	/** @public
-	 *	@type {object}
+	/**
+	 * @public
+	 * @type {object}
 	 */
 	this.context = context;
 
-	/** @public
-	 *	@type {object}
+	/**
+	 * @public
+	 * @type {object}
 	 */
 	this.props = props;
 
-	/** @public
-	 *	@type {object}
+	/**
+	 * @public
+	 * @type {object}
 	 */
 	this.state = this.state || {};
 }
@@ -36,19 +45,10 @@ export function Component(props, context) {
 
 extend(Component.prototype, {
 
-	/** Returns a `boolean` indicating if the component should re-render when receiving the given `props` and `state`.
-	 *	@name shouldComponentUpdate
-	 *	@function
-	 *	@param {object} nextProps
-	 *	@param {object} nextState
-	 *	@param {object} nextContext
-	 *	@returns {Boolean} should the component re-render
-	 */
-
-
-	/** Update component state by copying properties from `state` to `this.state`.
-	 *	@param {object} state		A hash of state properties to update with new values
-	 *	@param {function} callback	A function to be called once component state is updated
+	/**
+	 * Update component state by copying properties from `state` to `this.state`.
+	 * @param {object} state A hash of state properties to update with new values
+	 * @param {function} callback A function to be called once component state is updated
 	 */
 	setState(state, callback) {
 		let s = this.state;
@@ -59,9 +59,10 @@ extend(Component.prototype, {
 	},
 
 
-	/** Immediately perform a synchronous re-render of the component.
-	 *	@param {function} callback		A function to be called after component is re-rendered.
-	 *	@private
+	/**
+	 * Immediately perform a synchronous re-render of the component.
+	 * @param {function} callback A function to be called after component is re-rendered.
+	 * @private
 	 */
 	forceUpdate(callback) {
 		if (callback) (this._renderCallbacks = (this._renderCallbacks || [])).push(callback);
@@ -69,12 +70,13 @@ extend(Component.prototype, {
 	},
 
 
-	/** Accepts `props` and `state`, and returns a new Virtual DOM tree to build.
-	 *	Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
-	 *	@param {object} props		Props (eg: JSX attributes) received from parent element/component
-	 *	@param {object} state		The component's current state
-	 *	@param {object} context		Context object (if a parent component has provided context)
-	 *	@returns VNode
+	/**
+	 * Accepts `props` and `state`, and returns a new Virtual DOM tree to build.
+	 * Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
+	 * @param {object} props Props (eg: JSX attributes) received from parent element/component
+	 * @param {object} state The component's current state
+	 * @param {object} context Context object (if a parent component has provided context)
+	 * @returns {VNode | void}
 	 */
 	render() {}
 

--- a/src/component.js
+++ b/src/component.js
@@ -1,7 +1,3 @@
-/**
- * @typedef {import('./vnode').VNode} VNode
- */
-
 import { FORCE_RENDER } from './constants';
 import { extend } from './util';
 import { renderComponent } from './vdom/component';
@@ -76,7 +72,7 @@ extend(Component.prototype, {
 	 * @param {object} props Props (eg: JSX attributes) received from parent element/component
 	 * @param {object} state The component's current state
 	 * @param {object} context Context object (if a parent component has provided context)
-	 * @returns {VNode | void}
+	 * @returns {import('./vnode').VNode | void}
 	 */
 	render() {}
 

--- a/src/component.js
+++ b/src/component.js
@@ -6,7 +6,7 @@ import { enqueueRender } from './render-queue';
 /** Base Component class.
  *	Provides `setState()` and `forceUpdate()`, which trigger rendering.
  *	@public
- *  @typedef {Object} Component
+ *	@typedef {object} Component
  *	@example
  *	class MyFoo extends Component {
  *		render(props, state) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,13 +1,17 @@
 // render modes
 
+/** Do not recursively re-render a component */
 export const NO_RENDER = 0;
+/** Recursively re-render a component and it's children */
 export const SYNC_RENDER = 1;
+/** Force a re-render of a component */
 export const FORCE_RENDER = 2;
+/** Asynchronously queue re-renders of a component and it's children */
 export const ASYNC_RENDER = 3;
 
 
 export const ATTR_KEY = '__preactattr_';
 
-// DOM properties that should NOT have "px" added when numeric
+/** DOM properties that should NOT have "px" added when numeric */
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,10 @@
 // render modes
 
-/** Do not recursively re-render a component */
+/** Do not re-render a component */
 export const NO_RENDER = 0;
-/** Recursively re-render a component and it's children */
+/** Synchronously re-render a component and its children */
 export const SYNC_RENDER = 1;
-/** Force a re-render of a component */
+/** Synchronously re-render a component, even if its lifecycle methods attempt to prevent it. */
 export const FORCE_RENDER = 2;
 /** Queue asynchronous re-render of a component and it's children */
 export const ASYNC_RENDER = 3;

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ export const NO_RENDER = 0;
 export const SYNC_RENDER = 1;
 /** Force a re-render of a component */
 export const FORCE_RENDER = 2;
-/** Asynchronously queue re-renders of a component and it's children */
+/** Queue asynchronous re-render of a component and it's children */
 export const ASYNC_RENDER = 3;
 
 

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -2,7 +2,20 @@ import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
 /**
- * @typedef {Element & ElementCSSInlineStyle} PreactElement
+ * @typedef {(e: Event) => void} EventListner
+ * @typedef {{ [eventType: string]: EventListener}} EventListenerMap
+ */
+
+/**
+ * @typedef PreactHtmlProperties
+ * @property {string} [normalizedNodeName]
+ * @property {EventListenerMap} [_listeners]
+ * @property {import('../component').Component} [_component]
+ * @property {Function} [_componentConstructor]
+ */
+
+/**
+ * @typedef {Element & ElementCSSInlineStyle & PreactHtmlProperties} PreactElement
  */
 
 /**
@@ -12,6 +25,7 @@ import options from '../options';
  * @returns {PreactElement} node
  */
 export function createNode(nodeName, isSvg) {
+	/** @type {PreactElement} */
 	let node = isSvg ? document.createElementNS('http://www.w3.org/2000/svg', nodeName) : document.createElement(nodeName);
 	node.normalizedNodeName = nodeName;
 	return node;

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -2,10 +2,11 @@ import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
 
-/** Create an element with the given nodeName.
- *	@param {String} nodeName
- *	@param {Boolean} [isSvg=false]	If `true`, creates an element within the SVG namespace.
- *	@returns {Element} node
+/**
+ * Create an element with the given nodeName.
+ * @param {String} nodeName
+ * @param {Boolean} [isSvg=false] If `true`, creates an element within the SVG namespace.
+ * @returns {Element} node
  */
 export function createNode(nodeName, isSvg) {
 	let node = isSvg ? document.createElementNS('http://www.w3.org/2000/svg', nodeName) : document.createElement(nodeName);
@@ -14,8 +15,9 @@ export function createNode(nodeName, isSvg) {
 }
 
 
-/** Remove a child node from its parent if attached.
- *	@param {Node} node		The node to remove
+/**
+ * Remove a child node from its parent if attached.
+ * @param {Node} node The node to remove
  */
 export function removeNode(node) {
 	let parentNode = node.parentNode;
@@ -23,14 +25,15 @@ export function removeNode(node) {
 }
 
 
-/** Set a named attribute on the given Node, with special behavior for some names and event handlers.
- *	If `value` is `null`, the attribute/handler will be removed.
- *	@param {HTMLElement | SVGElement} node	An element to mutate
- *	@param {string} name	The name/key to set, such as an event or attribute name
- *	@param {any} old	The last value that was set for this name/node pair
- *	@param {any} value	An attribute value, such as a function to be used as an event handler
- *	@param {Boolean} isSvg	Are we currently diffing inside an svg?
- *	@private
+/**
+ * Set a named attribute on the given Node, with special behavior for some names and event handlers.
+ * If `value` is `null`, the attribute/handler will be removed.
+ * @param {HTMLElement | SVGElement} node An element to mutate
+ * @param {string} name The name/key to set, such as an event or attribute name
+ * @param {any} old The last value that was set for this name/node pair
+ * @param {any} value An attribute value, such as a function to be used as an event handler
+ * @param {Boolean} isSvg Are we currently diffing inside an svg?
+ * @private
  */
 export function setAccessor(node, name, old, value, isSvg) {
 	if (name==='className') name = 'class';
@@ -91,8 +94,12 @@ export function setAccessor(node, name, old, value, isSvg) {
 }
 
 
-/** Attempt to set a DOM property to the given value.
- *	IE & FF throw for certain property-value combinations.
+/**
+ * Attempt to set a DOM property to the given value.
+ * IE & FF throw for certain property-value combinations.
+ * @param {Node} node The node to set a property on
+ * @param {string} name The name of the property to set
+ * @param {any} value The value to set
  */
 function setProperty(node, name, value) {
 	try {
@@ -101,9 +108,10 @@ function setProperty(node, name, value) {
 }
 
 
-/** Proxy an event to hooked event handlers
- *  @param {Event} e The event object from the browser
- *	@private
+/**
+ * Proxy an event to hooked event handlers
+ * @param {Event} e The event object from the browser
+ * @private
  */
 function eventProxy(e) {
 	return this._listeners[e.type](options.event && options.event(e) || e);

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -8,7 +8,7 @@ import options from '../options';
 
 /**
  * A mapping of event types to event listeners
- * @typedef {{ [eventType: string]: EventListener}} EventListenerMap
+ * @typedef {Object.<string, EventListener>} EventListenerMap
  */
 
 /**
@@ -17,7 +17,7 @@ import options from '../options';
  * @property {string} [normalizedNodeName] A normalized node name to use in diffing
  * @property {EventListenerMap} [_listeners] A map of event listeners added by components to this DOM node
  * @property {import('../component').Component} [_component] The component that rendered this DOM node
- * @property {Function} [_componentConstructor] The constructor of the component that rendered this DOM node
+ * @property {function} [_componentConstructor] The constructor of the component that rendered this DOM node
  */
 
 /**
@@ -56,8 +56,8 @@ export function removeNode(node) {
  * removed.
  * @param {PreactElement} node An element to mutate
  * @param {string} name The name/key to set, such as an event or attribute name
- * @param {any} old The last value that was set for this name/node pair
- * @param {any} value An attribute value, such as a function to be used as an
+ * @param {*} old The last value that was set for this name/node pair
+ * @param {*} value An attribute value, such as a function to be used as an
  *  event handler
  * @param {boolean} isSvg Are we currently diffing inside an svg?
  * @private
@@ -126,7 +126,7 @@ export function setAccessor(node, name, old, value, isSvg) {
  * IE & FF throw for certain property-value combinations.
  * @param {Node} node The node to set a property on
  * @param {string} name The name of the property to set
- * @param {any} value The value to set
+ * @param {*} value The value to set
  */
 function setProperty(node, name, value) {
 	try {

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -1,12 +1,15 @@
 import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
+/**
+ * @typedef {Element & ElementCSSInlineStyle} PreactElement
+ */
 
 /**
  * Create an element with the given nodeName.
  * @param {String} nodeName
  * @param {boolean} [isSvg=false] If `true`, creates an element within the SVG namespace.
- * @returns {Element} node
+ * @returns {PreactElement} node
  */
 export function createNode(nodeName, isSvg) {
 	let node = isSvg ? document.createElementNS('http://www.w3.org/2000/svg', nodeName) : document.createElement(nodeName);
@@ -28,7 +31,7 @@ export function removeNode(node) {
 /**
  * Set a named attribute on the given Node, with special behavior for some names and event handlers.
  * If `value` is `null`, the attribute/handler will be removed.
- * @param {HTMLElement | SVGElement} node An element to mutate
+ * @param {PreactElement} node An element to mutate
  * @param {string} name The name/key to set, such as an event or attribute name
  * @param {any} old The last value that was set for this name/node pair
  * @param {any} value An attribute value, such as a function to be used as an event handler

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -25,7 +25,7 @@ export function removeNode(node) {
 
 /** Set a named attribute on the given Node, with special behavior for some names and event handlers.
  *	If `value` is `null`, the attribute/handler will be removed.
- *	@param {Element} node	An element to mutate
+ *	@param {HTMLElement | SVGElement} node	An element to mutate
  *	@param {string} name	The name/key to set, such as an event or attribute name
  *	@param {any} old	The last value that was set for this name/node pair
  *	@param {any} value	An attribute value, such as a function to be used as an event handler
@@ -102,6 +102,7 @@ function setProperty(node, name, value) {
 
 
 /** Proxy an event to hooked event handlers
+ *  @param {Event} e The event object from the browser
  *	@private
  */
 function eventProxy(e) {

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -2,27 +2,34 @@ import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
 /**
+ * A DOM event listener
  * @typedef {(e: Event) => void} EventListner
+ */
+
+/**
+ * A mapping of event types to event listeners
  * @typedef {{ [eventType: string]: EventListener}} EventListenerMap
  */
 
 /**
- * @typedef PreactHtmlProperties
- * @property {string} [normalizedNodeName]
- * @property {EventListenerMap} [_listeners]
- * @property {import('../component').Component} [_component]
- * @property {Function} [_componentConstructor]
+ * Properties Preact adds to elements it creates
+ * @typedef PreactElementExtensions
+ * @property {string} [normalizedNodeName] A normalized node name to use in diffing
+ * @property {EventListenerMap} [_listeners] A map of event listeners added by components to this DOM node
+ * @property {import('../component').Component} [_component] The component that rendered this DOM node
+ * @property {Function} [_componentConstructor] The constructor of the component that rendered this DOM node
  */
 
 /**
- * @typedef {Element & ElementCSSInlineStyle & PreactHtmlProperties} PreactElement
+ * A DOM element that has been extended with Preact properties
+ * @typedef {Element & ElementCSSInlineStyle & PreactElementExtensions} PreactElement
  */
 
 /**
  * Create an element with the given nodeName.
- * @param {String} nodeName
+ * @param {string} nodeName The DOM node to create
  * @param {boolean} [isSvg=false] If `true`, creates an element within the SVG namespace.
- * @returns {PreactElement} node
+ * @returns {PreactElement} The created DOM node
  */
 export function createNode(nodeName, isSvg) {
 	/** @type {PreactElement} */

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -5,7 +5,7 @@ import options from '../options';
 /**
  * Create an element with the given nodeName.
  * @param {String} nodeName
- * @param {Boolean} [isSvg=false] If `true`, creates an element within the SVG namespace.
+ * @param {boolean} [isSvg=false] If `true`, creates an element within the SVG namespace.
  * @returns {Element} node
  */
 export function createNode(nodeName, isSvg) {
@@ -32,7 +32,7 @@ export function removeNode(node) {
  * @param {string} name The name/key to set, such as an event or attribute name
  * @param {any} old The last value that was set for this name/node pair
  * @param {any} value An attribute value, such as a function to be used as an event handler
- * @param {Boolean} isSvg Are we currently diffing inside an svg?
+ * @param {boolean} isSvg Are we currently diffing inside an svg?
  * @private
  */
 export function setAccessor(node, name, old, value, isSvg) {

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -15,7 +15,7 @@ export function createNode(nodeName, isSvg) {
 
 
 /** Remove a child node from its parent if attached.
- *	@param {Element} node		The node to remove
+ *	@param {Node} node		The node to remove
  */
 export function removeNode(node) {
 	let parentNode = node.parentNode;

--- a/src/h.js
+++ b/src/h.js
@@ -30,7 +30,7 @@ const EMPTY_CHILDREN = [];
  *
  * `h('div', { id: 'foo', name : 'bar' }, 'Hello!');`
  *
- * @param {string | Function} nodeName An element name. Ex: `div`, `a`, `span`, etc.
+ * @param {string | function} nodeName An element name. Ex: `div`, `a`, `span`, etc.
  * @param {object | null} attributes Any attributes/props to set on the created element.
  * @param {VNode[]} [rest] Additional arguments are taken to be children to
  *  append. Can be infinitely nested Arrays.

--- a/src/h.js
+++ b/src/h.js
@@ -29,7 +29,7 @@ const EMPTY_CHILDREN = [];
  * `h('div', { id: 'foo', name : 'bar' }, 'Hello!');`
  *
  * @param {string | Function} nodeName An element name. Ex: `div`, `a`, `span`, etc.
- * @param {object} attributes Any attributes/props to set on the created element.
+ * @param {object | null} attributes Any attributes/props to set on the created element.
  * @param {VNode[]} [rest] Additional arguments are taken to be children to append. Can be infinitely nested Arrays.
  *
  * @public

--- a/src/h.js
+++ b/src/h.js
@@ -1,6 +1,7 @@
 import { VNode } from './vnode';
 import options from './options';
 
+
 const stack = [];
 
 const EMPTY_CHILDREN = [];

--- a/src/h.js
+++ b/src/h.js
@@ -1,7 +1,6 @@
 import { VNode } from './vnode';
 import options from './options';
 
-
 const stack = [];
 
 const EMPTY_CHILDREN = [];
@@ -28,9 +27,9 @@ const EMPTY_CHILDREN = [];
  *
  * `h('div', { id: 'foo', name : 'bar' }, 'Hello!');`
  *
- * @param {string | Function} nodeName	An element name. Ex: `div`, `a`, `span`, etc.
- * @param {Object} attributes Any attributes/props to set on the created element.
- * @param {Array<VNode>} [rest]	Additional arguments are taken to be children to append. Can be infinitely nested Arrays.
+ * @param {string | Function} nodeName An element name. Ex: `div`, `a`, `span`, etc.
+ * @param {object} attributes Any attributes/props to set on the created element.
+ * @param {VNode[]} [rest] Additional arguments are taken to be children to append. Can be infinitely nested Arrays.
  *
  * @public
  */

--- a/src/h.js
+++ b/src/h.js
@@ -28,9 +28,9 @@ const EMPTY_CHILDREN = [];
  *
  * `h('div', { id: 'foo', name : 'bar' }, 'Hello!');`
  *
- * @param {string} nodeName	An element name. Ex: `div`, `a`, `span`, etc.
- * @param {Object} attributes	Any attributes/props to set on the created element.
- * @param rest			Additional arguments are taken to be children to append. Can be infinitely nested Arrays.
+ * @param {string | Function} nodeName	An element name. Ex: `div`, `a`, `span`, etc.
+ * @param {Object} attributes Any attributes/props to set on the created element.
+ * @param {Array<VNode>} [rest]	Additional arguments are taken to be children to append. Can be infinitely nested Arrays.
  *
  * @public
  */

--- a/src/options.js
+++ b/src/options.js
@@ -7,7 +7,7 @@
  * Global options
  * @public
  * @typedef Options
- * @property {Boolean} [syncComponentUpdates] If `true`, `prop` changes trigger synchronous component updates. Defaults to true.
+ * @property {boolean} [syncComponentUpdates] If `true`, `prop` changes trigger synchronous component updates. Defaults to true.
  * @property {(vnode: VNode) => void} [vnode] Processes all created VNodes.
  * @property {(component: Component) => void} [afterMount] Hook invoked after a component is mounted.
  * @property {(component: Component) => void} [afterUpdate] Hook invoked after the DOM is updated with a component's latest render.

--- a/src/options.js
+++ b/src/options.js
@@ -3,16 +3,17 @@
  * @typedef {import('./vnode').VNode} VNode
  */
 
-/** Global options
- *  @public
- *  @typedef Options
- *  @property {Boolean} [syncComponentUpdates] If `true`, `prop` changes trigger synchronous component updates. Defaults to true.
- *  @property {(vnode: VNode) => void} [vnode] Processes all created VNodes.
- *  @property {(component: Component) => void} [afterMount] Hook invoked after a component is mounted.
- *  @property {(component: Component) => void} [afterUpdate] Hook invoked after the DOM is updated with a component's latest render.
- *  @property {(component: Component) => void} [beforeUnmount] Hook invoked immediately before a component is unmounted.
- *  @property {(rerender: Function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
- *  @property {(event: Event) => Event | void} [event] Hook invoked before any Preact event listeners. The return value (if any) replaces the native browser event given to event listeners
+/**
+ * Global options
+ * @public
+ * @typedef Options
+ * @property {Boolean} [syncComponentUpdates] If `true`, `prop` changes trigger synchronous component updates. Defaults to true.
+ * @property {(vnode: VNode) => void} [vnode] Processes all created VNodes.
+ * @property {(component: Component) => void} [afterMount] Hook invoked after a component is mounted.
+ * @property {(component: Component) => void} [afterUpdate] Hook invoked after the DOM is updated with a component's latest render.
+ * @property {(component: Component) => void} [beforeUnmount] Hook invoked immediately before a component is unmounted.
+ * @property {(rerender: Function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
+ * @property {(event: Event) => Event | void} [event] Hook invoked before any Preact event listeners. The return value (if any) replaces the native browser event given to event listeners
  */
 
 /** @type {Options}  */

--- a/src/options.js
+++ b/src/options.js
@@ -1,27 +1,21 @@
-/** Global options
- *	@public
- *	@namespace options {Object}
+/**
+ * @typedef {import('./component').Component} Component
+ * @typedef {import('./vnode').VNode} VNode
  */
-export default {
 
-	/** If `true`, `prop` changes trigger synchronous component updates.
-	 *	@name syncComponentUpdates
-	 *	@type Boolean
-	 *	@default true
-	 */
-	//syncComponentUpdates: true,
+/** Global options
+ *  @public
+ *  @typedef Options
+ *  @property {Boolean} [syncComponentUpdates] If `true`, `prop` changes trigger synchronous component updates. Defaults to true.
+ *  @property {(vnode: VNode) => void} [vnode] Processes all created VNodes.
+ *  @property {(component: Component) => void} [afterMount] Hook invoked after a component is mounted.
+ *  @property {(component: Component) => void} [afterUpdate] Hook invoked after the DOM is updated with a component's latest render.
+ *  @property {(component: Component) => void} [beforeUnmount] Hook invoked immediately before a component is unmounted.
+ *  @property {(rerender: Function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
+ *  @property {(event: Event) => Event | void} [event] Hook invoked before any Preact event listeners. The return value (if any) replaces the native browser event given to event listeners
+ */
 
-	/** Processes all created VNodes.
-	 *	@param {VNode} vnode	A newly-created VNode to normalize/process
-	 */
-	//vnode(vnode) { }
+/** @type {Options}  */
+const options = {};
 
-	/** Hook invoked after a component is mounted. */
-	// afterMount(component) { }
-
-	/** Hook invoked after the DOM is updated with a component's latest render. */
-	// afterUpdate(component) { }
-
-	/** Hook invoked immediately before a component is unmounted. */
-	// beforeUnmount(component) { }
-};
+export default options;

--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@
  * @property {(component: Component) => void} [afterMount] Hook invoked after a component is mounted.
  * @property {(component: Component) => void} [afterUpdate] Hook invoked after the DOM is updated with a component's latest render.
  * @property {(component: Component) => void} [beforeUnmount] Hook invoked immediately before a component is unmounted.
- * @property {(rerender: Function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
+ * @property {(rerender: function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
  * @property {(event: Event) => Event | void} [event] Hook invoked before any Preact event listeners. The return value (if any) replaces the native browser event given to event listeners
  */
 

--- a/src/render-queue.js
+++ b/src/render-queue.js
@@ -1,18 +1,16 @@
-/** @typedef {import('./component').Component} Component */
-
 import options from './options';
 import { defer } from './util';
 import { renderComponent } from './vdom/component';
 
 /**
  * Managed queue of dirty components to be re-rendered
- * @type {Component[]}
+ * @type {Array<import('./component').Component>}
  */
 let items = [];
 
 /**
  * Enqueue a rerender of a component
- * @param {Component} component The component to rerender
+ * @param {import('./component').Component} component The component to rerender
  */
 export function enqueueRender(component) {
 	if (!component._dirty && (component._dirty = true) && items.push(component)==1) {

--- a/src/render-queue.js
+++ b/src/render-queue.js
@@ -1,17 +1,24 @@
+/** @typedef {import('./component').Component} Component */
+
 import options from './options';
 import { defer } from './util';
 import { renderComponent } from './vdom/component';
 
-/** Managed queue of dirty components to be re-rendered */
-
+/** Managed queue of dirty components to be re-rendered
+ *  @type {Component[]}
+ */
 let items = [];
 
+/** Enqueue a rerender of a component
+ *  @param {Component} component The component to rerender
+ */
 export function enqueueRender(component) {
 	if (!component._dirty && (component._dirty = true) && items.push(component)==1) {
 		(options.debounceRendering || defer)(rerender);
 	}
 }
 
+/** Rerender all enqueued dirty components */
 export function rerender() {
 	let p, list = items;
 	items = [];

--- a/src/render-queue.js
+++ b/src/render-queue.js
@@ -4,13 +4,15 @@ import options from './options';
 import { defer } from './util';
 import { renderComponent } from './vdom/component';
 
-/** Managed queue of dirty components to be re-rendered
- *  @type {Component[]}
+/**
+ * Managed queue of dirty components to be re-rendered
+ * @type {Component[]}
  */
 let items = [];
 
-/** Enqueue a rerender of a component
- *  @param {Component} component The component to rerender
+/**
+ * Enqueue a rerender of a component
+ * @param {Component} component The component to rerender
  */
 export function enqueueRender(component) {
 	if (!component._dirty && (component._dirty = true) && items.push(component)==1) {

--- a/src/render.js
+++ b/src/render.js
@@ -2,9 +2,9 @@ import { diff } from './vdom/diff';
 
 /**
  * Render JSX into a `parent` Element.
- * @param {import('./vnode').VNode} vnode		A (JSX) VNode to render
- * @param {Element} parent		DOM element to render into
- * @param {Element} [merge]	Attempt to re-use an existing DOM tree rooted at `merge`
+ * @param {import('./vnode').VNode} vnode A (JSX) VNode to render
+ * @param {Element} parent DOM element to render into
+ * @param {Element} [merge] Attempt to re-use an existing DOM tree rooted at `merge`
  * @public
  *
  * @example

--- a/src/render.js
+++ b/src/render.js
@@ -1,15 +1,10 @@
-/**
- * @typedef {import('./vnode').VNode} VNode
- * @typedef {import('./dom').PreactElement} PreactElement
- */
-
 import { diff } from './vdom/diff';
 
 /**
  * Render JSX into a `parent` Element.
- * @param {VNode} vnode A (JSX) VNode to render
- * @param {PreactElement} parent DOM element to render into
- * @param {PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at `merge`
+ * @param {import('./vnode').VNode} vnode A (JSX) VNode to render
+ * @param {import('./dom').PreactElement} parent DOM element to render into
+ * @param {import('./dom').PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at `merge`
  * @public
  *
  * @example

--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,7 @@
 import { diff } from './vdom/diff';
 
 /** Render JSX into a `parent` Element.
- *	@param {VNode} vnode		A (JSX) VNode to render
+ *	@param {import('./vnode').VNode} vnode		A (JSX) VNode to render
  *	@param {Element} parent		DOM element to render into
  *	@param {Element} [merge]	Attempt to re-use an existing DOM tree rooted at `merge`
  *	@public

--- a/src/render.js
+++ b/src/render.js
@@ -1,10 +1,15 @@
+/**
+ * @typedef {import('./vnode').VNode} VNode
+ * @typedef {import('./dom').PreactElement} PreactElement
+ */
+
 import { diff } from './vdom/diff';
 
 /**
  * Render JSX into a `parent` Element.
- * @param {import('./vnode').VNode} vnode A (JSX) VNode to render
- * @param {Element} parent DOM element to render into
- * @param {Element} [merge] Attempt to re-use an existing DOM tree rooted at `merge`
+ * @param {VNode} vnode A (JSX) VNode to render
+ * @param {PreactElement} parent DOM element to render into
+ * @param {PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at `merge`
  * @public
  *
  * @example

--- a/src/render.js
+++ b/src/render.js
@@ -1,19 +1,20 @@
 import { diff } from './vdom/diff';
 
-/** Render JSX into a `parent` Element.
- *	@param {import('./vnode').VNode} vnode		A (JSX) VNode to render
- *	@param {Element} parent		DOM element to render into
- *	@param {Element} [merge]	Attempt to re-use an existing DOM tree rooted at `merge`
- *	@public
+/**
+ * Render JSX into a `parent` Element.
+ * @param {import('./vnode').VNode} vnode		A (JSX) VNode to render
+ * @param {Element} parent		DOM element to render into
+ * @param {Element} [merge]	Attempt to re-use an existing DOM tree rooted at `merge`
+ * @public
  *
- *	@example
- *	// render a div into <body>:
- *	render(<div id="hello">hello!</div>, document.body);
+ * @example
+ * // render a div into <body>:
+ * render(<div id="hello">hello!</div>, document.body);
  *
- *	@example
- *	// render a "Thing" component into #foo:
- *	const Thing = ({ name }) => <span>{ name }</span>;
- *	render(<Thing name="one" />, document.querySelector('#foo'));
+ * @example
+ * // render a "Thing" component into #foo:
+ * const Thing = ({ name }) => <span>{ name }</span>;
+ * render(<Thing name="one" />, document.querySelector('#foo'));
  */
 export function render(vnode, parent, merge) {
 	return diff(merge, vnode, {}, false, parent, false);

--- a/src/util.js
+++ b/src/util.js
@@ -14,7 +14,6 @@ export function extend(obj, props) {
  * Call a function asynchronously, as soon as possible. Makes
  * use of HTML Promise to schedule the callback if available,
  * otherwise falling back to `setTimeout` (mainly for IE<11).
- *
  * @type {(callback: Function) => void}
  */
 export const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;

--- a/src/util.js
+++ b/src/util.js
@@ -14,6 +14,6 @@ export function extend(obj, props) {
  * Call a function asynchronously, as soon as possible. Makes
  * use of HTML Promise to schedule the callback if available,
  * otherwise falling back to `setTimeout` (mainly for IE<11).
- * @type {(callback: Function) => void}
+ * @type {(callback: function) => void}
  */
 export const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;

--- a/src/util.js
+++ b/src/util.js
@@ -2,7 +2,7 @@
  * Copy all properties from `props` onto `obj`.
  * @param {object} obj Object onto which properties should be copied.
  * @param {object} props Object from which to copy properties.
- * @returns {object} obj
+ * @returns {object}
  * @private
  */
 export function extend(obj, props) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,9 @@
 /**
- *  Copy all properties from `props` onto `obj`.
- *  @param {Object} obj		Object onto which properties should be copied.
- *  @param {Object} props	Object from which to copy properties.
- *  @returns obj
- *  @private
+ * Copy all properties from `props` onto `obj`.
+ * @param {object} obj Object onto which properties should be copied.
+ * @param {object} props Object from which to copy properties.
+ * @returns {object} obj
+ * @private
  */
 export function extend(obj, props) {
 	for (let i in props) obj[i] = props[i];
@@ -15,6 +15,6 @@ export function extend(obj, props) {
  * use of HTML Promise to schedule the callback if available,
  * otherwise falling back to `setTimeout` (mainly for IE<11).
  *
- * @param {Function} callback
+ * @type {(callback: Function) => void}
  */
 export const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -1,20 +1,30 @@
 import { Component } from '../component';
 
-/** Retains a pool of Components for re-use, keyed on component name.
- *	Note: since component names are not unique or even necessarily available, these are primarily a form of sharding.
- *	@private
+/**
+ * Retains a pool of Components for re-use, keyed on component name.
+ * Note: since component names are not unique or even necessarily available, these are primarily a form of sharding.
+ * @type {Record<string, Component[]>}
+ * @private
  */
 const components = {};
 
 
-/** Reclaim a component for later re-use by the recycler. */
+/**
+ * Reclaim a component for later re-use by the recycler.
+ * @param {Component} component The component to collect
+ */
 export function collectComponent(component) {
 	let name = component.constructor.name;
 	(components[name] || (components[name] = [])).push(component);
 }
 
 
-/** Create a component. Normalizes differences between PFC's and classful Components. */
+/**
+ * Create a component. Normalizes differences between PFC's and classful Components.
+ * @param {ComponentConstructor} Ctor The constructor of the component to create
+ * @param {any} props The initial props of the component
+ * @param {any} context The initial context of the component
+ */
 export function createComponent(Ctor, props, context) {
 	let list = components[Ctor.name],
 		inst;

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -21,9 +21,9 @@ export function collectComponent(component) {
 
 /**
  * Create a component. Normalizes differences between PFC's and classful Components.
- * @param {ComponentConstructor} Ctor The constructor of the component to create
- * @param {any} props The initial props of the component
- * @param {any} context The initial context of the component
+ * @param {Function} Ctor The constructor of the component to create
+ * @param {object} props The initial props of the component
+ * @param {object} context The initial context of the component
  */
 export function createComponent(Ctor, props, context) {
 	let list = components[Ctor.name],

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -24,6 +24,7 @@ export function collectComponent(component) {
  * @param {Function} Ctor The constructor of the component to create
  * @param {object} props The initial props of the component
  * @param {object} context The initial context of the component
+ * @returns {import('../component').Component}
  */
 export function createComponent(Ctor, props, context) {
 	let list = components[Ctor.name],

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -4,7 +4,7 @@ import { Component } from '../component';
  * Retains a pool of Components for re-use, keyed on component name.
  * Note: since component names are not unique or even necessarily available,
  * these are primarily a form of sharding.
- * @type {Record<string, Component[]>}
+ * @type {Object.<string, Component[]>}
  * @private
  */
 const components = {};
@@ -23,7 +23,7 @@ export function collectComponent(component) {
 /**
  * Create a component. Normalizes differences between PFC's and classful
  * Components.
- * @param {Function} Ctor The constructor of the component to create
+ * @param {function} Ctor The constructor of the component to create
  * @param {object} props The initial props of the component
  * @param {object} context The initial context of the component
  * @returns {import('../component').Component}

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -1,9 +1,3 @@
-/**
- * @typedef {import('../component').Component} Component
- * @typedef {import('../vnode').VNode} VNode
- * @typedef {import('../dom').PreactElement} PreactElement
- */
-
 import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER, ATTR_KEY } from '../constants';
 import options from '../options';
 import { extend } from '../util';
@@ -15,7 +9,7 @@ import { removeNode } from '../dom/index';
 
 /**
  * Set a component's `props` and possibly re-render the component
- * @param {Component} component The Component to set props on
+ * @param {import('../component').Component} component The Component to set props on
  * @param {object} props The new props
  * @param {number} opts Render options - specifies how to re-render the component
  * @param {object} context The new context
@@ -61,7 +55,7 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 
 /**
  * Render a Component, triggering necessary lifecycle events and taking High-Order Components into account.
- * @param {Component} component The component to render
+ * @param {import('../component').Component} component The component to render
  * @param {number} [opts] A number indicating the kind of render to execute (e.g. sync, async, force)
  * @param {boolean} [mountAll] Whether or not to immediately mount all components
  * @param {boolean} [isChild] ?
@@ -205,11 +199,11 @@ export function renderComponent(component, opts, mountAll, isChild) {
 
 /**
  * Apply the Component referenced by a VNode to the DOM.
- * @param {PreactElement} dom The DOM node to mutate
- * @param {VNode} vnode A Component-reference VNode
+ * @param {import('../dom').PreactElement} dom The DOM node to mutate
+ * @param {import('../vnode').VNode} vnode A Component-reference VNode
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
- * @returns {PreactElement} The created/mutated element
+ * @returns {import('../dom').PreactElement} The created/mutated element
  * @private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {
@@ -255,7 +249,7 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 
 /**
  * Remove a component from the DOM and recycle it.
- * @param {Component} component The Component instance to unmount
+ * @param {import('../component').Component} component The Component instance to unmount
  * @private
  */
 export function unmountComponent(component) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -8,10 +8,11 @@ import { createComponent, collectComponent } from './component-recycler';
 import { removeNode } from '../dom/index';
 
 /** Set a component's `props` (generally derived from JSX attributes).
+ *  @param {Component} component
  *	@param {Object} props
- *	@param {Object} [opts]
- *	@param {boolean} [opts.renderSync=false]	If `true` and {@link options.syncComponentUpdates} is `true`, triggers synchronous rendering.
- *	@param {boolean} [opts.render=true]			If `false`, no render will be triggered.
+ *	@param {number} [opts] A number indicating which kind of render is running (e.g. sync, async, force). See ../constants.js for available renders
+ *  @param {Object} [context]
+ *  @param {boolean} [mountAll]
  */
 export function setComponentProps(component, props, opts, context, mountAll) {
 	if (component._disable) return;
@@ -52,9 +53,10 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 
 
 /** Render a Component, triggering necessary lifecycle events and taking High-Order Components into account.
- *	@param {Component} component
- *	@param {Object} [opts]
- *	@param {boolean} [opts.build=false]		If `true`, component will build and store a DOM node if not already associated with one.
+ *	@param {Component} component  The component to render
+ *	@param {number} [opts]        A number indicating which kind of render is running (e.g. sync, async, force). See ../constants.js for available renders
+ *  @param {boolean} [mountAll]
+ *  @param {boolean} [isChild]
  *	@private
  */
 export function renderComponent(component, opts, mountAll, isChild) {
@@ -196,7 +198,9 @@ export function renderComponent(component, opts, mountAll, isChild) {
 /** Apply the Component referenced by a VNode to the DOM.
  *	@param {Element} dom	The DOM node to mutate
  *	@param {VNode} vnode	A Component-referencing VNode
- *	@returns {Element} dom	The created/mutated element
+ *  @param {Object} [context]
+ *  @param {boolean} [mountAll]
+ *	@returns {Element} The created/mutated element
  *	@private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -11,11 +11,11 @@ import { removeNode } from '../dom/index';
  * Set a component's `props` and possibly re-render the component
  * @param {import('../component').Component} component The Component to set props on
  * @param {object} props The new props
- * @param {number} opts Render options - specifies how to re-render the component
+ * @param {number} renderMode Render options - specifies how to re-render the component
  * @param {object} context The new context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  */
-export function setComponentProps(component, props, opts, context, mountAll) {
+export function setComponentProps(component, props, renderMode, context, mountAll) {
 	if (component._disable) return;
 	component._disable = true;
 
@@ -41,8 +41,8 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 
 	component._disable = false;
 
-	if (opts!==NO_RENDER) {
-		if (opts===SYNC_RENDER || options.syncComponentUpdates!==false || !component.base) {
+	if (renderMode!==NO_RENDER) {
+		if (renderMode===SYNC_RENDER || options.syncComponentUpdates!==false || !component.base) {
 			renderComponent(component, SYNC_RENDER, mountAll);
 		}
 		else {
@@ -59,12 +59,12 @@ export function setComponentProps(component, props, opts, context, mountAll) {
  * Render a Component, triggering necessary lifecycle events and taking
  * High-Order Components into account.
  * @param {import('../component').Component} component The component to render
- * @param {number} [opts] render mode, see constants.js for available options.
+ * @param {number} [renderMode] render mode, see constants.js for available options.
  * @param {boolean} [mountAll] Whether or not to immediately mount all components
  * @param {boolean} [isChild] ?
  * @private
  */
-export function renderComponent(component, opts, mountAll, isChild) {
+export function renderComponent(component, renderMode, mountAll, isChild) {
 	if (component._disable) return;
 
 	let props = component.props,
@@ -89,7 +89,7 @@ export function renderComponent(component, opts, mountAll, isChild) {
 		component.props = previousProps;
 		component.state = previousState;
 		component.context = previousContext;
-		if (opts!==FORCE_RENDER
+		if (renderMode!==FORCE_RENDER
 			&& component.shouldComponentUpdate
 			&& component.shouldComponentUpdate(props, state, context) === false) {
 			skip = true;
@@ -146,7 +146,7 @@ export function renderComponent(component, opts, mountAll, isChild) {
 				cbase = component._component = null;
 			}
 
-			if (initialBase || opts===SYNC_RENDER) {
+			if (initialBase || renderMode===SYNC_RENDER) {
 				if (cbase) cbase._component = null;
 				base = diff(cbase, rendered, context, mountAll || !isUpdate, initialBase && initialBase.parentNode, true);
 			}

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('../component').Component} Component
+ * @typedef {import('../vnode').VNode} VNode
+ */
+
 import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER, ATTR_KEY } from '../constants';
 import options from '../options';
 import { extend } from '../util';

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('../component').Component} Component
  * @typedef {import('../vnode').VNode} VNode
+ * @typedef {import('../dom').PreactElement} PreactElement
  */
 
 import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER, ATTR_KEY } from '../constants';
@@ -204,11 +205,11 @@ export function renderComponent(component, opts, mountAll, isChild) {
 
 /**
  * Apply the Component referenced by a VNode to the DOM.
- * @param {Element} dom The DOM node to mutate
+ * @param {PreactElement} dom The DOM node to mutate
  * @param {VNode} vnode A Component-reference VNode
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
- * @returns {Element} The created/mutated element
+ * @returns {PreactElement} The created/mutated element
  * @private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -12,12 +12,13 @@ import { diff, mounts, diffLevel, flushMounts, recollectNodeTree, removeChildren
 import { createComponent, collectComponent } from './component-recycler';
 import { removeNode } from '../dom/index';
 
-/** Set a component's `props` (generally derived from JSX attributes).
- *  @param {Component} component
- *	@param {Object} props
- *	@param {number} [opts] A number indicating which kind of render is running (e.g. sync, async, force). See ../constants.js for available renders
- *  @param {Object} [context]
- *  @param {boolean} [mountAll]
+/**
+ * Set a component's `props` and possibly re-render the component
+ * @param {Component} component The Component to set props on
+ * @param {object} props The new props
+ * @param {number} opts Render options - specifies how to re-render the component
+ * @param {object} context The new context
+ * @param {boolean} mountAll Whether or not to immediately mount all components
  */
 export function setComponentProps(component, props, opts, context, mountAll) {
 	if (component._disable) return;
@@ -57,12 +58,13 @@ export function setComponentProps(component, props, opts, context, mountAll) {
 
 
 
-/** Render a Component, triggering necessary lifecycle events and taking High-Order Components into account.
- *	@param {Component} component  The component to render
- *	@param {number} [opts]        A number indicating which kind of render is running (e.g. sync, async, force). See ../constants.js for available renders
- *  @param {boolean} [mountAll]
- *  @param {boolean} [isChild]
- *	@private
+/**
+ * Render a Component, triggering necessary lifecycle events and taking High-Order Components into account.
+ * @param {Component} component The component to render
+ * @param {number} [opts] A number indicating the kind of render to execute (e.g. sync, async, force)
+ * @param {boolean} [mountAll] Whether or not to immediately mount all components
+ * @param {boolean} [isChild] ?
+ * @private
  */
 export function renderComponent(component, opts, mountAll, isChild) {
 	if (component._disable) return;
@@ -200,13 +202,14 @@ export function renderComponent(component, opts, mountAll, isChild) {
 
 
 
-/** Apply the Component referenced by a VNode to the DOM.
- *	@param {Element} dom	The DOM node to mutate
- *	@param {VNode} vnode	A Component-referencing VNode
- *  @param {Object} [context]
- *  @param {boolean} [mountAll]
- *	@returns {Element} The created/mutated element
- *	@private
+/**
+ * Apply the Component referenced by a VNode to the DOM.
+ * @param {Element} dom The DOM node to mutate
+ * @param {VNode} vnode A Component-reference VNode
+ * @param {object} context The current context
+ * @param {boolean} mountAll Whether or not to immediately mount all components
+ * @returns {Element} The created/mutated element
+ * @private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 	let c = dom && dom._component,
@@ -249,9 +252,10 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 
 
 
-/** Remove a component from the DOM and recycle it.
- *	@param {Component} component	The Component instance to unmount
- *	@private
+/**
+ * Remove a component from the DOM and recycle it.
+ * @param {Component} component The Component instance to unmount
+ * @private
  */
 export function unmountComponent(component) {
 	if (options.beforeUnmount) options.beforeUnmount(component);

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('../vnode').VNode} VNode
+ * @typedef {import('../component').Component} Component
+ */
+
 import { ATTR_KEY } from '../constants';
 import { isSameNodeType, isNamedNode } from './index';
 import { buildComponentFromVNode } from './component';
@@ -31,11 +36,15 @@ export function flushMounts() {
 }
 
 
-/** Apply differences in a given vnode (and it's deep children) to a real DOM Node.
- *	@param {Element} [dom=null]		A DOM node to mutate into the shape of the `vnode`
- *	@param {VNode} vnode			A VNode (with descendants forming a tree) representing the desired DOM structure
- *	@returns {Element} dom			The created/mutated element
- *	@private
+/**
+ * Apply differences in a given vnode (and it's deep children) to a real DOM Node.
+ * @param {Element} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
+ * @param {object} context The current context
+ * @param {boolean} mountAll Whether or not to immediately mount all components
+ * @param {Element} parent ?
+ * @param {boolean} componentRoot ?
+ * @private
  */
 export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 	// diffLevel having been 0 here indicates initial entry into the diff (not a subdiff)
@@ -63,7 +72,15 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 }
 
 
-/** Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing. */
+/**
+ * Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing.
+ * @param {Element} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
+ * @param {object} context The current context
+ * @param {boolean} mountAll Whether or not to immediately mount all components
+ * @param {boolean} [componentRoot] ?
+ * @private
+ */
 function idiff(dom, vnode, context, mountAll, componentRoot) {
 	let out = dom,
 		prevSvgMode = isSvgMode;

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -289,7 +289,8 @@ export function recollectNodeTree(node, unmountOnly) {
 }
 
 
-/** Recollect/unmount all children.
+/**
+ * Recollect/unmount all children.
  *	- we use .lastChild here because it causes less reflow than .firstChild
  *	- it's also cheaper than accessing the .childNodes Live NodeList
  */

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -6,7 +6,10 @@ import { unmountComponent } from './component';
 import options from '../options';
 import { removeNode } from '../dom/index';
 
-/** Queue of components that have been mounted and are awaiting componentDidMount */
+/**
+ * Queue of components that have been mounted and are awaiting componentDidMount
+ * @type {Component[]}
+ */
 export const mounts = [];
 
 /** Diff recursion count, used to track the end of the diff cycle. */
@@ -155,12 +158,13 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 }
 
 
-/** Apply child and attribute changes between a VNode and a DOM Node to the DOM.
- *	@param {Element} dom			Element whose children should be compared & mutated
- *	@param {Array} vchildren		Array of VNodes to compare to `dom.childNodes`
- *	@param {Object} context			Implicitly descendant context object (from most recent `getChildContext()`)
- *	@param {Boolean} mountAll
- *	@param {Boolean} isHydrating	If `true`, consumes externally created elements similar to hydration
+/**
+ * Apply child and attribute changes between a VNode and a DOM Node to the DOM.
+ * @param {Element} dom Element whose children should be compared & mutated
+ * @param {VNode[]} vchildren Array of VNodes to compare to `dom.childNodes`
+ * @param {object} context Implicitly descendant context object (from most recent `getChildContext()`)
+ * @param {boolean} mountAll Whether or not to immediately mount all components
+ * @param {boolean} isHydrating if `true`, consumes externally created elements similar to hydration
  */
 function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 	let originalChildren = dom.childNodes,
@@ -248,9 +252,10 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 
 
-/** Recursively recycle (or just unmount) a node and its descendants.
- *	@param {Node} node						DOM node to start unmount/removal from
- *	@param {Boolean} [unmountOnly=false]	If `true`, only triggers unmount lifecycle, skips removal
+/**
+ * Recursively recycle (or just unmount) a node and its descendants.
+ * @param {Node} node DOM node to start unmount/removal from
+ * @param {boolean} [unmountOnly=false] If `true`, only triggers unmount lifecycle, skips removal
  */
 export function recollectNodeTree(node, unmountOnly) {
 	let component = node._component;
@@ -286,10 +291,11 @@ export function removeChildren(node) {
 }
 
 
-/** Apply differences in attributes from a VNode to the given DOM Element.
- *	@param {Element} dom		Element with attributes to diff `attrs` against
- *	@param {Object} attrs		The desired end-state key-value attribute pairs
- *	@param {Object} old			Current/previous attributes (from previous VNode or element's prop cache)
+/**
+ * Apply differences in attributes from a VNode to the given DOM Element.
+ * @param {Element} dom Element with attributes to diff `attrs` against
+ * @param {object} attrs The desired end-state key-value attribute pairs
+ * @param {object} old Current/previous attributes (from previous VNode or element's prop cache)
  */
 function diffAttributes(dom, attrs, old) {
 	let name;

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('../vnode').VNode} VNode
  * @typedef {import('../component').Component} Component
+ * @typedef {import('../dom').PreactElement} PreactElement
  */
 
 import { ATTR_KEY } from '../constants';
@@ -38,7 +39,7 @@ export function flushMounts() {
 
 /**
  * Apply differences in a given vnode (and it's deep children) to a real DOM Node.
- * @param {Element} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
  * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
@@ -74,7 +75,7 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 
 /**
  * Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing.
- * @param {Element} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
  * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
@@ -177,7 +178,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 /**
  * Apply child and attribute changes between a VNode and a DOM Node to the DOM.
- * @param {Element} dom Element whose children should be compared & mutated
+ * @param {PreactElement} dom Element whose children should be compared & mutated
  * @param {VNode[]} vchildren Array of VNodes to compare to `dom.childNodes`
  * @param {object} context Implicitly descendant context object (from most recent `getChildContext()`)
  * @param {boolean} mountAll Whether or not to immediately mount all components
@@ -271,7 +272,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 /**
  * Recursively recycle (or just unmount) a node and its descendants.
- * @param {Node} node DOM node to start unmount/removal from
+ * @param {PreactElement} node DOM node to start unmount/removal from
  * @param {boolean} [unmountOnly=false] If `true`, only triggers unmount lifecycle, skips removal
  */
 export function recollectNodeTree(node, unmountOnly) {
@@ -310,7 +311,7 @@ export function removeChildren(node) {
 
 /**
  * Apply differences in attributes from a VNode to the given DOM Element.
- * @param {Element} dom Element with attributes to diff `attrs` against
+ * @param {PreactElement} dom Element with attributes to diff `attrs` against
  * @param {object} attrs The desired end-state key-value attribute pairs
  * @param {object} old Current/previous attributes (from previous VNode or element's prop cache)
  */

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -270,7 +270,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 /**
  * Recursively recycle (or just unmount) a node and its descendants.
- * @param {import('../dom').PreactElement} node DOM node to start 
+ * @param {import('../dom').PreactElement} node DOM node to start
  *  unmount/removal from
  * @param {boolean} [unmountOnly=false] If `true`, only triggers unmount
  *  lifecycle, skips removal

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,9 +1,3 @@
-/**
- * @typedef {import('../vnode').VNode} VNode
- * @typedef {import('../component').Component} Component
- * @typedef {import('../dom').PreactElement} PreactElement
- */
-
 import { ATTR_KEY } from '../constants';
 import { isSameNodeType, isNamedNode } from './index';
 import { buildComponentFromVNode } from './component';
@@ -14,7 +8,7 @@ import { removeNode } from '../dom/index';
 
 /**
  * Queue of components that have been mounted and are awaiting componentDidMount
- * @type {Component[]}
+ * @type {Array<import('../component').Component>}
  */
 export const mounts = [];
 
@@ -39,8 +33,8 @@ export function flushMounts() {
 
 /**
  * Apply differences in a given vnode (and it's deep children) to a real DOM Node.
- * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
- * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
+ * @param {import('../dom').PreactElement} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @param {Element} parent ?
@@ -75,8 +69,8 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 
 /**
  * Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing.
- * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
- * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
+ * @param {import('../dom').PreactElement} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @param {boolean} [componentRoot] ?
@@ -178,8 +172,8 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 /**
  * Apply child and attribute changes between a VNode and a DOM Node to the DOM.
- * @param {PreactElement} dom Element whose children should be compared & mutated
- * @param {VNode[]} vchildren Array of VNodes to compare to `dom.childNodes`
+ * @param {import('../dom').PreactElement} dom Element whose children should be compared & mutated
+ * @param {Array<import('../vnode').VNode>} vchildren Array of VNodes to compare to `dom.childNodes`
  * @param {object} context Implicitly descendant context object (from most recent `getChildContext()`)
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @param {boolean} isHydrating if `true`, consumes externally created elements similar to hydration
@@ -272,7 +266,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 /**
  * Recursively recycle (or just unmount) a node and its descendants.
- * @param {PreactElement} node DOM node to start unmount/removal from
+ * @param {import('../dom').PreactElement} node DOM node to start unmount/removal from
  * @param {boolean} [unmountOnly=false] If `true`, only triggers unmount lifecycle, skips removal
  */
 export function recollectNodeTree(node, unmountOnly) {
@@ -311,7 +305,7 @@ export function removeChildren(node) {
 
 /**
  * Apply differences in attributes from a VNode to the given DOM Element.
- * @param {PreactElement} dom Element with attributes to diff `attrs` against
+ * @param {import('../dom').PreactElement} dom Element with attributes to diff `attrs` against
  * @param {object} attrs The desired end-state key-value attribute pairs
  * @param {object} old Current/previous attributes (from previous VNode or element's prop cache)
  */

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -3,10 +3,9 @@ import { extend } from '../util';
 
 /**
  * Check if two nodes are equivalent.
- *
- * @param {Node} node			DOM Node to compare
- * @param {VNode} vnode			Virtual DOM node to compare
- * @param {boolean} [hydrating=false]	If true, ignores component constructors when comparing.
+ * @param {Node} node DOM Node to compare
+ * @param {VNode} vnode Virtual DOM node to compare
+ * @param {boolean} [hydrating=false] If true, ignores component constructors when comparing.
  * @private
  */
 export function isSameNodeType(node, vnode, hydrating) {
@@ -22,9 +21,8 @@ export function isSameNodeType(node, vnode, hydrating) {
 
 /**
  * Check if an Element has a given nodeName, case-insensitively.
- *
- * @param {Element} node	A DOM Element to inspect the name of.
- * @param {String} nodeName	Unnormalized name to compare against.
+ * @param {Element} node A DOM Element to inspect the name of.
+ * @param {string} nodeName Unnormalized name to compare against.
  */
 export function isNamedNode(node, nodeName) {
 	return node.normalizedNodeName===nodeName || node.nodeName.toLowerCase()===nodeName.toLowerCase();
@@ -35,9 +33,8 @@ export function isNamedNode(node, nodeName) {
  * Reconstruct Component-style `props` from a VNode.
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
- *
- * @param {VNode} vnode
- * @returns {Object} props
+ * @param {VNode} vnode The VNode to get props for
+ * @returns {Object} The props to use for this VNode
  */
 export function getNodeProps(vnode) {
 	let props = extend({}, vnode.attributes);

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,15 +1,10 @@
-/**
- * @typedef {import('../vnode').VNode} VNode
- * @typedef {import('../dom').PreactElement} PreactElement
- */
-
 import { extend } from '../util';
 
 
 /**
  * Check if two nodes are equivalent.
- * @param {PreactElement} node DOM Node to compare
- * @param {VNode} vnode Virtual DOM node to compare
+ * @param {import('../dom').PreactElement} node DOM Node to compare
+ * @param {import('../vnode').VNode} vnode Virtual DOM node to compare
  * @param {boolean} [hydrating=false] If true, ignores component constructors when comparing.
  * @private
  */
@@ -26,7 +21,7 @@ export function isSameNodeType(node, vnode, hydrating) {
 
 /**
  * Check if an Element has a given nodeName, case-insensitively.
- * @param {PreactElement} node A DOM Element to inspect the name of.
+ * @param {import('../dom').PreactElement} node A DOM Element to inspect the name of.
  * @param {string} nodeName Unnormalized name to compare against.
  */
 export function isNamedNode(node, nodeName) {
@@ -38,7 +33,7 @@ export function isNamedNode(node, nodeName) {
  * Reconstruct Component-style `props` from a VNode.
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
- * @param {VNode} vnode The VNode to get props for
+ * @param {import('../vnode').VNode} vnode The VNode to get props for
  * @returns {object} The props to use for this VNode
  */
 export function getNodeProps(vnode) {

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import('../vnode').VNode} VNode
+ * @typedef {import('../dom').PreactElement} PreactElement
  */
 
 import { extend } from '../util';
@@ -7,7 +8,7 @@ import { extend } from '../util';
 
 /**
  * Check if two nodes are equivalent.
- * @param {Element} node DOM Node to compare
+ * @param {PreactElement} node DOM Node to compare
  * @param {VNode} vnode Virtual DOM node to compare
  * @param {boolean} [hydrating=false] If true, ignores component constructors when comparing.
  * @private
@@ -25,7 +26,7 @@ export function isSameNodeType(node, vnode, hydrating) {
 
 /**
  * Check if an Element has a given nodeName, case-insensitively.
- * @param {Element} node A DOM Element to inspect the name of.
+ * @param {PreactElement} node A DOM Element to inspect the name of.
  * @param {string} nodeName Unnormalized name to compare against.
  */
 export function isNamedNode(node, nodeName) {

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,9 +1,13 @@
+/**
+ * @typedef {import('../vnode').VNode} VNode
+ */
+
 import { extend } from '../util';
 
 
 /**
  * Check if two nodes are equivalent.
- * @param {Node} node DOM Node to compare
+ * @param {Element} node DOM Node to compare
  * @param {VNode} vnode Virtual DOM node to compare
  * @param {boolean} [hydrating=false] If true, ignores component constructors when comparing.
  * @private
@@ -34,7 +38,7 @@ export function isNamedNode(node, nodeName) {
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
  * @param {VNode} vnode The VNode to get props for
- * @returns {Object} The props to use for this VNode
+ * @returns {object} The props to use for this VNode
  */
 export function getNodeProps(vnode) {
 	let props = extend({}, vnode.attributes);

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,2 +1,10 @@
+/**
+ * @typedef VNode
+ * @property {string | Function} nodeName
+ * @property {Array<VNode | string>} children
+ * @property {any} attributes
+ * @property {string | number | undefined} key
+ */
+
 /** Virtual DOM Node */
 export function VNode() {}

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,10 +1,9 @@
 /**
+ * Virtual DOM Node
  * @typedef VNode
  * @property {string | Function} nodeName
  * @property {Array<VNode | string>} children
- * @property {any} attributes
+ * @property {object} attributes
  * @property {string | number | undefined} key
  */
-
-/** Virtual DOM Node */
 export function VNode() {}

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -3,7 +3,7 @@
  * @typedef VNode
  * @property {string | Function} nodeName
  * @property {Array<VNode | string>} children
- * @property {object} attributes
  * @property {string | number | undefined} key
+ * @property {object} attributes
  */
 export function VNode() {}

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,7 +1,7 @@
 /**
  * Virtual DOM Node
  * @typedef VNode
- * @property {string | Function} nodeName The string of the DOM node to create or Component constructor to render
+ * @property {string | function} nodeName The string of the DOM node to create or Component constructor to render
  * @property {Array<VNode | string>} children The children of node
  * @property {string | number | undefined} key The key used to identify this VNode in a list
  * @property {object} attributes The properties of this VNode

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,9 +1,9 @@
 /**
  * Virtual DOM Node
  * @typedef VNode
- * @property {string | Function} nodeName
- * @property {Array<VNode | string>} children
- * @property {string | number | undefined} key
- * @property {object} attributes
+ * @property {string | Function} nodeName The string of the DOM node to create or Component constructor to render
+ * @property {Array<VNode | string>} children The children of node
+ * @property {string | number | undefined} key The key used to identify this VNode in a list
+ * @property {object} attributes The properties of this VNode
  */
 export function VNode() {}


### PR DESCRIPTION
Update Preact's JSDoc comments to better reflect the current code and improve editor experience (if using editor with TypeScript support/extension). I make use of `@typedef`s to define a couple of key complex types used by Preact. Each complex type is described below.

## Complex Types

**Options**: Documents all the public options a consumer of Preact can define

**VNode**: Documents the properties of a Preact Virtual DOM Node

**PreactElement**: Documents all of the properties Preact adds to the DOM elements it creates

## What about Component?

I haven't exhaustively documented Component in this PR because that is a much more complex type to document in JSDoc and I'm considering doing it in its own PR to discuss different ways of how to accomplish it. I've started experimenting with how to do this in my [update-jsdoc-component-doc branch](https://github.com/andrewiggins/preact/blob/update-jsdoc-component-doc/src/component.js) if you are curious.

## Other Notes

These JSDoc comments rely on a new feature in Typescript 2.9, "[allow `import(...)-ing` types at any location](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#allow-import-ing-types-at-any-location)". I use this feature to import `@typedef`s across files. The next version of VSCode should include TS 2.9 by default so these comments will work by default in that version. If you'd like to check out the TS 2.9 experience now, check out this branch and set the VSCode workspace setting `typescript.tsdk` to `node_modules\\typescript\\lib`.

This PR does not eliminate all errors that appear in the editor. In order to do that Preact would likely need to embrace full TypeScript or Flow syntaxes to utilize the entirety of features those languages offer. It might be possible to remove all errors using only JSDoc syntax however I'd like to explore that possibility in a separate PR as it might require an additional significant amount of changes.

I've rewritten many JSDoc comments to the default style that VSCode uses when you add new JSDoc comments.

Fixes #1106 