### PR TITLE
Add typescript child type checking

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -4,8 +4,8 @@ export as namespace preact;
 declare namespace preact {
 	type Key = string | number;
 	type Ref<T> = (instance: T) => void;
-	type ComponentChild = JSX.Element | string | number | null;
-	type ComponentChildren = ComponentChild[];
+	type ComponentChild = VNode<any> | string | number | null;
+	type ComponentChildren = ComponentChild[] | ComponentChild | object | string | number | null;
 
 	/**
 	 * @deprecated
@@ -104,12 +104,12 @@ declare namespace preact {
 	function h<P>(
 		node: ComponentFactory<P>,
 		params: Attributes & P | null,
-		...children: (ComponentChild | ComponentChildren)[]
+		...children: ComponentChildren[]
 	): VNode<any>;
 	function h(
 		node: string,
 		params: JSX.HTMLAttributes & JSX.SVGAttributes & Record<string, any> | null,
-		...children: (ComponentChild | ComponentChildren)[]
+		...children: ComponentChildren[]
 	): VNode<any>;
 
 	function render(node: ComponentChild, parent: Element | Document, mergeWith?: Element): Element;
@@ -134,6 +134,10 @@ declare global {
 
 		interface ElementAttributesProperty {
 			props: any;
+		}
+
+		interface ElementChildrenAttribute {
+			children: any;
 		}
 
 		interface SVGAttributes extends HTMLAttributes {

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -57,3 +57,9 @@ describe("VNode", () => {
 		expect(comp.children[1]).to.be.a("string");
 	});
 });
+
+class TypedChildren extends Component<{children: (num: number) => string}> {
+	render() { return null }
+}
+
+const typedChild = <TypedChildren>{num => num.toFixed(2)}</TypedChildren>


### PR DESCRIPTION
Closes #1086

It fixes the original issue from #1008, it will now type check correctly

It will also allow type inference, a basic example is provided in the tests that infers the type of `num` but it will be useful for anything like developit/preact-router#269