### PR TITLE
Inline setProperty function

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -80,7 +80,11 @@ export function setAccessor(node, name, old, value, isSvg) {
 		(node._listeners || (node._listeners = {}))[name] = value;
 	}
 	else if (name!=='list' && name!=='type' && !isSvg && name in node) {
-		setProperty(node, name, value==null ? '' : value);
+		// Attempt to set a DOM property to the given value.
+		// IE & FF throw for certain property-value combinations.
+		try {
+			node[name] = value==null ? '' : value;
+		} catch (e) { }
 		if ((value==null || value===false) && name!='spellcheck') node.removeAttribute(name);
 	}
 	else {
@@ -97,17 +101,6 @@ export function setAccessor(node, name, old, value, isSvg) {
 			else node.setAttribute(name, value);
 		}
 	}
-}
-
-
-/**
- * Attempt to set a DOM property to the given value.
- * IE & FF throw for certain property-value combinations.
- */
-function setProperty(node, name, value) {
-	try {
-		node[name] = value;
-	} catch (e) { }
 }
 
 


### PR DESCRIPTION
Inlining the setProperty function (which is only used once) saves 7 bytes. Thought I could try to pay back some of the bytes of new features that have gone into Preact recently.