### PR TITLE
Fixing master build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,7 @@ addons:
 script:
   - npm run build
   - COVERAGE=true ALLOW_SAUCELABS=false npm run test
-  - COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
+  - if [ "$TRAVIS_NODE_VERSION" = "8" ]; then
+    COVERAGE=false FLAKEY=false PERFORMANCE=false ALLOW_SAUCELABS=true npm run test:karma;
+    fi
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ addons:
 
 script:
   - npm run build
-  - COVERAGE=true npm run test
+  - COVERAGE=true ALLOW_SAUCELABS=false npm run test
   - COVERAGE=false FLAKEY=false PERFORMANCE=false npm run test:karma
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
 install:
   - npm install
 
+addons:
+  sauce_connect: true
+
 script:
   - npm run build
   - COVERAGE=true npm run test

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,10 +1,10 @@
 /*eslint no-var:0, object-shorthand:0 */
 
 var coverage = String(process.env.COVERAGE) === 'true',
-	ci = String(process.env.CI).match(/^(1|true)$/gi),
+	allowSauce = !String(process.env.ALLOW_SAUCELABS).match(/^(0|false|undefined)$/gi),
 	pullRequest = !String(process.env.TRAVIS_PULL_REQUEST).match(/^(0|false|undefined)$/gi),
 	masterBranch = String(process.env.TRAVIS_BRANCH).match(/^master$/gi),
-	sauceLabs = ci && !pullRequest && masterBranch,
+	sauceLabs = allowSauce && !pullRequest && masterBranch,
 	performance = !coverage && String(process.env.PERFORMANCE)!=='false',
 	webpack = require('webpack');
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -32,8 +32,8 @@ var sauceLabsLaunchers = {
 	sl_ie_11: {
 		base: 'SauceLabs',
 		browserName: 'internet explorer',
-		version: '11.103',
-		platform: 'Windows 10'
+		version: '11.0',
+		platform: 'Windows 7'
 	}
 };
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -85,10 +85,15 @@ module.exports = function(config) {
 		// Use only two browsers concurrently, works better with open source Sauce Labs remote testing
 		concurrency: 2,
 
-		// sauceLabs: {
-		// 	tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('./package.json').version),
-		// 	startConnect: false
-		// },
+		captureTimeout: 0,
+
+		sauceLabs: {
+			build: 'CI #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')',
+			tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || ('local'+require('../package.json').version),
+			connectLocationForSERelay: 'localhost',
+			connectPortForSERelay: 4445,
+			startConnect: false
+		},
 
 		customLaunchers: sauceLabs ? sauceLabsLaunchers : localLaunchers,
 


### PR DESCRIPTION
This PR relates to #1038.

Basically what we are doing here is switching to IE11 on Windows 7, which oddly greens the problematic empty node test that is currently not passing on IE11 Windows 10 on Sauce Labs for no apparent reason.

Locally all IE11 versions work, Windows 10 included. It must be some env bug in Sauce Labs.

This PR also changes the way we connect to Sauce Labs, now leveraging the tunnel created by Travis Sauce Connect addon. Now sending all the relevant info (tunneldentifier, buildNumber, etc). This should fix the errors we saw on #1089.

The base code of this PR was tested in `sauce-test` branch, logs from Travis (https://travis-ci.org/developit/preact/builds) and Sauce Labs (https://saucelabs.com/u/preact) from those tests appear OK.

Finally, this PR prepares the ground for #1124, which aims to test multiple node versions on Travis.

Please let me know if this looks good 😄 