### PR TITLE
fix #1052: removing multiply keyed children results in unnecessary DOM events

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -191,7 +191,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 		len = originalChildren.length,
 		childrenLen = 0,
 		vlen = vchildren ? vchildren.length : 0,
-		j, c, f, vchild, child;
+		j, c, f, l, vchild, child;
 
 	// Build up a map of keyed children and an Array of unkeyed children:
 	if (len!==0) {
@@ -207,6 +207,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 				children[childrenLen++] = child;
 			}
 		}
+		l = keyedLen - vlen;
 	}
 
 	if (vlen!==0) {
@@ -244,7 +245,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 				if (f==null) {
 					dom.appendChild(child);
 				}
-				else if (child===f.nextSibling) {
+				else if (child===f.nextSibling || (l > 0 && child===originalChildren[i + l])) {
 					removeNode(f);
 				}
 				else {

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -245,11 +245,14 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 				if (f==null) {
 					dom.appendChild(child);
 				}
-				else if (child===f.nextSibling || (l > 0 && child===originalChildren[i + l])) {
+				else if (child===f.nextSibling) {
 					removeNode(f);
+				}
+				else if (l > 0 && child===originalChildren[i + l]) {
 				}
 				else {
 					dom.insertBefore(child, f);
+					l++;
 				}
 			}
 		}


### PR DESCRIPTION
Currently removing multiply keyed children will cause subsequent children unmount and remount. This fix expand check on `child===f.nextSibling` to make sure `child` has a match if only removing children.