### PR TITLE
Proposal to fix config for UglifyJS 3

### DIFF
--- a/config/properties.json
+++ b/config/properties.json
@@ -1,6 +1,5 @@
 {
   "props": {
-    "cname": 16,
     "props": {
       "$_dirty": "__d",
       "$_disable": "__x",
@@ -21,7 +20,6 @@
     }
   },
   "vars": {
-    "cname": -1,
     "props": {}
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "transpile:esm": "rollup -c config/rollup.config.esm.js",
     "transpile:debug": "babel debug/ -o debug.js -s",
     "transpile": "npm-run-all transpile:main transpile:esm transpile:devtools transpile:debug",
-    "optimize": "uglifyjs dist/preact.dev.js -c conditionals=false,sequences=false,loops=false,join_vars=false,collapse_vars=false --pure-funcs=Object.defineProperty --mangle-props --mangle-regex=\"/^(_|normalizedNodeName|nextBase|prev[CPS]|_parentC)/\" --name-cache config/properties.json -b width=120,quote_style=3 -o dist/preact.js -p relative --in-source-map dist/preact.dev.js.map --source-map dist/preact.js.map",
-    "minify": "uglifyjs dist/preact.js -c collapse_vars,evaluate,screw_ie8,unsafe,loops=false,keep_fargs=false,pure_getters,unused,dead_code -m -o dist/preact.min.js -p relative --in-source-map dist/preact.js.map --source-map dist/preact.min.js.map",
+    "optimize": "uglifyjs dist/preact.dev.js -c conditionals=false,sequences=false,loops=false,join_vars=false,collapse_vars=false --pure-funcs=Object.defineProperty --mangle keep_fnames=true --mangle-props regex=\"/^(_|normalizedNodeName|nextBase|prev[CPS]|_parentC)/\" --name-cache config/properties.json -b width=120,quote_style=3 -o dist/preact.js --source-map \"content='dist/preact.dev.js.map',filename='dist/preact.js.map',url='preact.js.map'\"",
+    "minify": "uglifyjs dist/preact.js -c collapse_vars=true,evaluate=true,ie8=false,unsafe=true,loops=false,keep_fargs=false,pure_getters=true,unused=true,dead_code=true -m -o dist/preact.min.js --source-map \"content='dist/preact.js.map',filename='dist/preact.min.js.map',url='preact.min.js.map'\"",
     "strip:main": "jscodeshift --run-in-band -s -t config/codemod-strip-tdz.js dist/preact.dev.js && jscodeshift --run-in-band -s -t config/codemod-const.js dist/preact.dev.js && jscodeshift --run-in-band -s -t config/codemod-let-name.js dist/preact.dev.js",
     "strip:esm": "jscodeshift --run-in-band -s -t config/codemod-strip-tdz.js dist/preact.esm.js && jscodeshift --run-in-band -s -t config/codemod-const.js dist/preact.esm.js && jscodeshift --run-in-band -s -t config/codemod-let-name.js dist/preact.esm.js",
     "strip": "npm-run-all strip:main strip:esm",
@@ -119,7 +119,7 @@
     "sinon": "^4.4.2",
     "sinon-chai": "^3.0.0",
     "typescript": "^2.9.0-rc",
-    "uglify-js": "^2.7.5",
+    "uglify-js": "^3.3.28",
     "webpack": "^4.3.0"
   },
   "greenkeeper": {


### PR DESCRIPTION
I'm aware of #1077 and #1075.

This PR is a test I did which worked to update UglifyJS to version 3, maybe it's not ready to merge but I would like to see your thoughts on this.

Tests ran just fine and gzip size goes to `3481` from the `3498` bytes we currently have on `master`. 

One thing I noticed is that the behavior changed in `dist/preact.js`, now it mangles the variables internally. Is this going to be a problem?

I couldn't find a way to disable this and keep mangling props with `--mangle-props` enabled because `--mangle-props` activates default `--mangle` implicitly in version 3 apparently.

So, to mitigate that, I activated `keep_fnames` to keep function names, but the vars are being mangled no matter what (even when omitting `--mangle`).

I opened mishoo/UglifyJS2#3168 to see if we can get version 2 behavior back on this matter.

Nonetheless, it works. Exports look fine and props like `_component`, `__preactattr_`, etc too.

Please check this out when you have the time and share your thoughts.