### PR TITLE
Change editorconfig to use 2 space indent for all json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,.*rc,*.yml}]
+[{*.json,.*rc,*.yml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
Simple PR to change `.editorconfig` to use 2 space indent for all json files since we have `package.json`, `config/properties.json` and `typings.json` using this pattern already.

I think it's fair to keep this stated in `.editorconfig`.