### PR TITLE
Use puppeteer to get a local Chrome for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "karma-webpack": "^3.0.0",
     "mocha": "^5.0.4",
     "npm-run-all": "^4.0.0",
+    "puppeteer": "^1.5.0",
     "rimraf": "^2.5.3",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^3.0.2",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -8,6 +8,10 @@ var coverage = String(process.env.COVERAGE) === 'true',
 	performance = !coverage && String(process.env.PERFORMANCE)!=='false',
 	webpack = require('webpack');
 
+if (!process.env.CHROME_BIN) {
+	process.env.CHROME_BIN = require('puppeteer').executablePath();
+}
+
 var sauceLabsLaunchers = {
 	sl_chrome: {
 		base: 'SauceLabs',


### PR DESCRIPTION
Use puppeteer to get a local install of Chromium for CI/VM testing. Also helps for ChromeOS and Windows/LXSS.

Technique is stolen from [karmatic](https://github.com/developit/karmatic), which I think we'll move to soon anyway.