### PR TITLE
Ref clearing perf

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -19,8 +19,22 @@ export function setComponentProps(component, props, renderMode, context, mountAl
 	if (component._disable) return;
 	component._disable = true;
 
-	if ((component.__ref = props.ref)) delete props.ref;
-	if ((component.__key = props.key)) delete props.key;
+	// if ((component.__ref = props.ref)) delete props.ref;
+	// if ((component.__key = props.key)) delete props.key;
+
+	// component.__ref = props.ref;
+	// component.__key = props.key;
+	// if ('ref' in props) delete props.ref;
+	// if ('key' in props) delete props.key;
+
+	// if ('ref' in props) {
+	// 	component.__ref = props.ref;
+	// 	delete props.ref;
+	// }
+	// if ('key' in props) {
+	// 	component.__key = props.key;
+	// 	delete props.key;
+	// }
 
 	if (typeof component.constructor.getDerivedStateFromProps === 'undefined') {
 		if (!component.base || mountAll) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -19,22 +19,10 @@ export function setComponentProps(component, props, renderMode, context, mountAl
 	if (component._disable) return;
 	component._disable = true;
 
-	// if ((component.__ref = props.ref)) delete props.ref;
-	// if ((component.__key = props.key)) delete props.key;
-
-	// component.__ref = props.ref;
-	// component.__key = props.key;
-	// if ('ref' in props) delete props.ref;
-	// if ('key' in props) delete props.key;
-
-	// if ('ref' in props) {
-	// 	component.__ref = props.ref;
-	// 	delete props.ref;
-	// }
-	// if ('key' in props) {
-	// 	component.__key = props.key;
-	// 	delete props.key;
-	// }
+	component.__ref = props.ref;
+	component.__key = props.key;
+	delete props.ref;
+	delete props.key;
 
 	if (typeof component.constructor.getDerivedStateFromProps === 'undefined') {
 		if (!component.base || mountAll) {

--- a/test/browser/performance.js
+++ b/test/browser/performance.js
@@ -30,7 +30,7 @@ function benchmark(iter, callback) {
 	for (let i=100; i--; ) noop(), iter();
 
 	let count = 2,
-		time = 500,
+		time = 1000,
 		passes = 0,
 		noops = loop(noop, time),
 		iterations = 0;


### PR DESCRIPTION
This is my attempt to benchmark a few options for #1143 / #1145.
I tested a few variants of the deletion guard (they're in the interim commit), and haven't found there to be much of a different with/without the guard.  All of the guard options except the existing combined approach added around 10 bytes.

@onstash @Pyrolistical @Kanaye @lukeed - y'all had a good discussion on the other PR. Think this is the right compromise?