### PR TITLE
Add `playsInline` attribute to HTMLAttributes

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -675,6 +675,7 @@ declare global {
 			optimum?: number;
 			pattern?: string;
 			placeholder?: string;
+			playsInline?: boolean;
 			poster?: string;
 			preload?: string;
 			radioGroup?: string;


### PR DESCRIPTION
It is used by the `<video>` element.

From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

> `playsinline`: A Boolean attribute which indicates that the video is to be played "inline", that is within the element's playback area. Note that the absence of this attribute does not imply that the video will always be played in fullscreen.