### PR TITLE
Use <time> for example Clock component

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ import { h, render, Component } from 'preact';
 
 class Clock extends Component {
 	render() {
-		let time = new Date().toLocaleTimeString();
-		return <span>{ time }</span>;
+		let time = new Date();
+		return <time datetime={time.toISOString()}>{ time.toLocaleTimeString() }</time>;
 	}
 }
 


### PR DESCRIPTION
Just because [there’s an element for that](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time).