### PR TITLE
Specify the arguments for lifecycle methods

### DIFF
--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -801,10 +801,72 @@ describe('Lifecycle methods', () => {
 		});
 	});
 
-	// TODO - Look at
 	describe('#componentDidUpdate', () => {
-		it('should be passed previous state', () => {
-			//
+		it('should be passed previous props and state', () => {
+			let previousProps = [];
+			let previousStates = [];
+
+			let currentProps = [];
+			let currentStates = [];
+
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						value: 0
+					};
+				}
+				static getDerivedStateFromProps(props, state) {
+					return {
+						value: state.value + 1,
+					};
+				}
+				componentDidUpdate(prevProps, prevState) {
+					previousProps.push(prevProps);
+					previousStates.push(prevState);
+
+					currentProps.push(this.props);
+					currentStates.push(this.state);
+				}
+				componentDidMount() {
+					this.setState({
+						value: this.state.value + 1
+					});
+				}
+				render() {
+					return <div>{this.state.value}</div>
+				}
+			}
+
+			let element = render(<Foo foo="foo" />, scratch);
+			expect(element.textContent).to.be.equal('1');
+			expect(previousStates).to.have.length(0);
+			expect(currentStates).to.have.length(0);
+
+			element = render(<Foo foo="bar" />, scratch, scratch.firstChild);
+			expect(element.textContent).to.be.equal('3');
+
+			expect(previousProps).to.deep.equal([{
+				foo: "foo",
+				children: []
+			}]);
+
+			// prevState in componentDidUpdate should be
+			// the state before getDerivedStateFromProps is called...
+			expect(previousStates).to.deep.equal([{
+				value: 1
+			}]);
+
+			// ...and this.state in componentDidUpdate should be
+			// the updated state after getDerivedStateFromProps is called...
+			expect(currentStates).to.deep.equal([{
+				value: 3
+			}]);
+
+			expect(currentProps).to.deep.equal([{
+				foo: "bar",
+				children: []
+			}]);
 		});
 	});
 

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -700,7 +700,6 @@ describe('Lifecycle methods', () => {
 		});
 	});
 
-	// TODO - add test for parameters
 	describe('#componentWillUpdate', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -433,6 +433,59 @@ describe('Lifecycle methods', () => {
 
 		// TODO: Investigate this test:
 		// [should not override state with stale values if prevState is spread within getDerivedStateFromProps](https://github.com/facebook/react/blob/25dda90c1ecb0c662ab06e2c80c1ee31e0ae9d36/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js#L1035)
+
+		it('should be passed next props and state', () => {
+			let nextPropsLog = [];
+			let nextStatesLog = [];
+
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						value: 0
+					};
+				}
+				static getDerivedStateFromProps(props, state) {
+					nextPropsLog.push({...props});
+					nextStatesLog.push({...state});
+
+					return {
+						value: state.value + 1,
+					};
+				}
+				componentDidMount() {
+					this.setState({
+						value: this.state.value + 1
+					});
+				}
+				render() {
+					return <div>{this.state.value}</div>
+				}
+			}
+
+			let element = render(<Foo foo="foo" />, scratch);
+			expect(element.textContent).to.be.equal('1');
+			expect(nextStatesLog).to.have.length(1);
+
+			element = render(<Foo foo="bar" />, scratch, scratch.firstChild);
+			expect(element.textContent).to.be.equal('3');
+
+			// ...and nextState in shouldComponentUpdate should be
+			// the updated state after getDerivedStateFromProps is called...
+			expect(nextStatesLog).to.deep.equal([{
+				value: 0
+			},{
+				value: 2
+			}]);
+
+			expect(nextPropsLog).to.deep.equal([{
+				foo: "foo",
+				children: []
+			},{
+				foo: "bar",
+				children: []
+			}]);
+		});
 	});
 
 	describe("#getSnapshotBeforeUpdate", () => {
@@ -600,7 +653,7 @@ describe('Lifecycle methods', () => {
 		});
 	});
 
-	// TODO - look at
+	// TODO - add test for parameters
 	describe('#componentWillUpdate', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {
@@ -704,7 +757,6 @@ describe('Lifecycle methods', () => {
 		});
 	});
 
-	// TODO - look at
 	describe('#componentWillReceiveProps', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -531,8 +531,76 @@ describe('Lifecycle methods', () => {
 				'componentDidUpdate'
 			]);
 		});
+
+		it('should be passed the previous props and state', () => {
+			let previousProps = [];
+			let previousStates = [];
+
+			let currentProps = [];
+			let currentStates = [];
+
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						value: 0
+					};
+				}
+				static getDerivedStateFromProps(props, state) {
+					return {
+						value: state.value + 1,
+					};
+				}
+				getSnapshotBeforeUpdate(prevProps, prevState) {
+					previousProps.push(prevProps);
+					previousStates.push(prevState);
+
+					currentProps.push(this.props);
+					currentStates.push(this.state);
+				}
+				componentDidMount() {
+					this.setState({
+						value: this.state.value + 1
+					});
+				}
+				render() {
+					return <div>{this.state.value}</div>
+				}
+			}
+
+			let element = render(<Foo foo="foo" />, scratch);
+			expect(element.textContent).to.be.equal('1');
+			expect(previousStates).to.have.length(0);
+			expect(currentStates).to.have.length(0);
+
+			element = render(<Foo foo="bar" />, scratch, scratch.firstChild);
+			expect(element.textContent).to.be.equal('3');
+
+			expect(previousProps).to.deep.equal([{
+				foo: "foo",
+				children: []
+			}]);
+
+			// prevState in getSnapshotBeforeUpdate should be
+			// the state before getDerivedStateFromProps is called...
+			expect(previousStates).to.deep.equal([{
+				value: 1
+			}]);
+
+			// ...and this.state in getSnapshotBeforeUpdate should be
+			// the updated state after getDerivedStateFromProps is called...
+			expect(currentStates).to.deep.equal([{
+				value: 3
+			}]);
+
+			expect(currentProps).to.deep.equal([{
+				foo: "bar",
+				children: []
+			}]);
+		});
 	});
 
+	// TODO - look at
 	describe('#componentWillUpdate', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {
@@ -636,6 +704,7 @@ describe('Lifecycle methods', () => {
 		});
 	});
 
+	// TODO - look at
 	describe('#componentWillReceiveProps', () => {
 		it('should NOT be called on initial render', () => {
 			class ReceivePropsComponent extends Component {
@@ -729,6 +798,13 @@ describe('Lifecycle methods', () => {
 
 			expect(Inner.prototype.componentWillReceiveProps).to.have.been.calledBefore(Inner.prototype.componentWillUpdate);
 			expect(Inner.prototype.componentWillUpdate).to.have.been.calledBefore(Inner.prototype.componentDidUpdate);
+		});
+	});
+
+	// TODO - Look at
+	describe('#componentDidUpdate', () => {
+		it('should be passed previous state', () => {
+			//
 		});
 	});
 
@@ -922,6 +998,7 @@ describe('Lifecycle methods', () => {
 	});
 
 
+	// TODO - look at
 	describe('shouldComponentUpdate', () => {
 		let setState;
 

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -1060,7 +1060,6 @@ describe('Lifecycle methods', () => {
 	});
 
 
-	// TODO - look at
 	describe('shouldComponentUpdate', () => {
 		let setState;
 
@@ -1101,6 +1100,75 @@ describe('Lifecycle methods', () => {
 
 			expect(ShouldNot.prototype.shouldComponentUpdate).to.have.been.calledOnce;
 			expect(ShouldNot.prototype.render).to.have.been.calledOnce;
+		});
+
+		it('should be passed next props and state', () => {
+			let currentPropsLog = [];
+			let currentStatesLog = [];
+
+			let nextPropsLog = [];
+			let nextStatesLog = [];
+
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						value: 0
+					};
+				}
+				static getDerivedStateFromProps(props, state) {
+					return {
+						value: state.value + 1,
+					};
+				}
+				shouldComponentUpdate(nextProps, nextState) {
+					nextPropsLog.push(nextProps);
+					nextStatesLog.push(nextState);
+
+					currentPropsLog.push(this.props);
+					currentStatesLog.push(this.state);
+
+					return true;
+				}
+				componentDidMount() {
+					this.setState({
+						value: this.state.value + 1
+					});
+				}
+				render() {
+					return <div>{this.state.value}</div>
+				}
+			}
+
+			let element = render(<Foo foo="foo" />, scratch);
+			expect(element.textContent).to.be.equal('1');
+			expect(nextStatesLog).to.have.length(0);
+			expect(currentStatesLog).to.have.length(0);
+
+			element = render(<Foo foo="bar" />, scratch, scratch.firstChild);
+			expect(element.textContent).to.be.equal('3');
+
+			expect(currentPropsLog).to.deep.equal([{
+				foo: "foo",
+				children: []
+			}]);
+
+			// this.state in shouldComponentUpdate should be
+			// the state before getDerivedStateFromProps is called...
+			expect(currentStatesLog).to.deep.equal([{
+				value: 1
+			}]);
+
+			// ...and nextState in shouldComponentUpdate should be
+			// the updated state after getDerivedStateFromProps is called...
+			expect(nextStatesLog).to.deep.equal([{
+				value: 3
+			}]);
+
+			expect(nextPropsLog).to.deep.equal([{
+				foo: "bar",
+				children: []
+			}]);
 		});
 	});
 


### PR DESCRIPTION
Add some more unit tests to specify the arguments each lifecycle method expects to be passed. With the addition of `getDerivedStateFromProps`, it is important to pass the proper state values into the right parameters. For example, should the next state argument for shouldComponentUpdate get the new state before or after `getDerivedStateFromProps` was called? These tests specify that behavior (answer: after).

While not the most useful at this time, I think these tests will be useful if the relevant internals of Preact are refactored.