### PR TITLE
Add BitMidi; add link to Play.cash repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Preact supports modern browsers and IE9+:
 #### Real-World Apps
 
 - [**Preact Hacker News**](https://hn.kristoferbaxter.com) _([GitHub Project](https://github.com/kristoferbaxter/preact-hn))_
-- [**Play.cash**](https://play.cash) :notes:
+- [**Play.cash**](https://play.cash) :notes: _([GitHub Project](https://github.com/feross/play.cash))_
+- [**BitMidi**](https://bitmidi.com/) 🎹 Wayback machine for free MIDI files _([GitHub Project](https://github.com/feross/bitmidi.com))_
 - [**ESBench**](http://esbench.com) is built using Preact.
 - [**BigWebQuiz**](https://bigwebquiz.com) _([GitHub Project](https://github.com/jakearchibald/big-web-quiz))_
 - [**Nectarine.rocks**](http://nectarine.rocks) _([GitHub Project](https://github.com/developit/nectarine))_ :peach:


### PR DESCRIPTION
https://bitmidi.com is built with Preact! ✨ Also, I've open sourced the Play.cash repo too.