### PR TITLE
Remove ElementChildrenAttributes

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -136,10 +136,6 @@ declare global {
 			props: any;
 		}
 
-		interface ElementChildrenAttribute {
-			children: any;
-		}
-
 		interface SVGAttributes extends HTMLAttributes {
 			accentHeight?: number | string;
 			accumulate?: "none" | "sum";


### PR DESCRIPTION
The definition of `ElementChildrenAttributes` broke JSX typings for me. `children` was said to be expected to be `HTMLCollection` but was `Elementp[]`.

Gonna be honest, not 100% clear how this change caused _that_ error, so please make sure this is the right way to fix it — but it _does_ fix it for me.

cc @marvinhagemeister