### PR TITLE
Fix cloneElement Typescript definition

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -114,7 +114,7 @@ declare namespace preact {
 
 	function render(node: ComponentChild, parent: Element | Document | ShadowRoot | DocumentFragment, mergeWith?: Element): Element;
 	function rerender(): void;
-	function cloneElement(element: JSX.Element, props: any): JSX.Element;
+	function cloneElement(element: JSX.Element, props: any, children?: ComponentChildren): JSX.Element;
 
 	var options: {
 		syncComponentUpdates?: boolean;


### PR DESCRIPTION
This adds the optional third argument to the cloneElement function's Typescript definition.