### PR TITLE
Reorganize and improve render unit tests

### DIFF
--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -151,12 +151,6 @@ describe('Components', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
-	// Test for #651
-	it('should set enumerable boolean attribute', () => {
-		render(<input spellcheck={false} />, scratch);
-		expect(scratch.firstChild.spellcheck).to.equal(false);
-	});
-
 	// Test for Issue #73
 	it('should remove orphaned elements replaced by Components', () => {
 		class Comp extends Component {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -417,61 +417,63 @@ describe('render()', () => {
 		});
 	});
 
-	it('should support dangerouslySetInnerHTML', () => {
-		let html = '<b>foo &amp; bar</b>';
-		// eslint-disable-next-line react/no-danger
-		let root = render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch);
+	describe('dangerouslySetInnerHTML', () => {
+		it('should support dangerouslySetInnerHTML', () => {
+			let html = '<b>foo &amp; bar</b>';
+			// eslint-disable-next-line react/no-danger
+			let root = render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch);
 
-		expect(scratch.firstChild, 'set').to.have.property('innerHTML', html);
-		expect(scratch.innerHTML).to.equal('<div>'+html+'</div>');
+			expect(scratch.firstChild, 'set').to.have.property('innerHTML', html);
+			expect(scratch.innerHTML).to.equal('<div>'+html+'</div>');
 
-		root = render(<div>a<strong>b</strong></div>, scratch, root);
+			root = render(<div>a<strong>b</strong></div>, scratch, root);
 
-		expect(scratch, 'unset').to.have.property('innerHTML', `<div>a<strong>b</strong></div>`);
+			expect(scratch, 'unset').to.have.property('innerHTML', `<div>a<strong>b</strong></div>`);
 
-		// eslint-disable-next-line react/no-danger
-		render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, root);
+			// eslint-disable-next-line react/no-danger
+			render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, root);
 
-		expect(scratch.innerHTML, 're-set').to.equal('<div>'+html+'</div>');
-	});
+			expect(scratch.innerHTML, 're-set').to.equal('<div>'+html+'</div>');
+		});
 
-	it('should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
-		class Thing extends Component {
-			constructor(props, context) {
-				super(props, context);
-				this.state.html = this.props.html;
+		it('should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
+			class Thing extends Component {
+				constructor(props, context) {
+					super(props, context);
+					this.state.html = this.props.html;
+				}
+				render(props, { html }) {
+					// eslint-disable-next-line react/no-danger
+					return html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : <div />;
+				}
 			}
-			render(props, { html }) {
-				// eslint-disable-next-line react/no-danger
-				return html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : <div />;
-			}
-		}
 
-		let thing;
+			let thing;
 
-		render(<Thing ref={c => thing=c} html="<b><i>test</i></b>" />, scratch);
+			render(<Thing ref={c => thing=c} html="<b><i>test</i></b>" />, scratch);
 
-		expect(scratch.innerHTML).to.equal('<div><b><i>test</i></b></div>');
+			expect(scratch.innerHTML).to.equal('<div><b><i>test</i></b></div>');
 
-		thing.setState({ html: false });
-		thing.forceUpdate();
+			thing.setState({ html: false });
+			thing.forceUpdate();
 
-		expect(scratch.innerHTML).to.equal('<div></div>');
+			expect(scratch.innerHTML).to.equal('<div></div>');
 
-		thing.setState({ html: '<foo><bar>test</bar></foo>' });
-		thing.forceUpdate();
+			thing.setState({ html: '<foo><bar>test</bar></foo>' });
+			thing.forceUpdate();
 
-		expect(scratch.innerHTML).to.equal('<div><foo><bar>test</bar></foo></div>');
-	});
+			expect(scratch.innerHTML).to.equal('<div><foo><bar>test</bar></foo></div>');
+		});
 
-	it('should hydrate with dangerouslySetInnerHTML', () => {
-		let html = '<b>foo &amp; bar</b>';
-		scratch.innerHTML = `<div>${html}</div>`;
-		// eslint-disable-next-line react/no-danger
-		render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, scratch.lastChild);
+		it('should hydrate with dangerouslySetInnerHTML', () => {
+			let html = '<b>foo &amp; bar</b>';
+			scratch.innerHTML = `<div>${html}</div>`;
+			// eslint-disable-next-line react/no-danger
+			render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, scratch.lastChild);
 
-		expect(scratch.firstChild).to.have.property('innerHTML', html);
-		expect(scratch.innerHTML).to.equal(`<div>${html}</div>`);
+			expect(scratch.firstChild).to.have.property('innerHTML', html);
+			expect(scratch.innerHTML).to.equal(`<div>${html}</div>`);
+		});
 	});
 
 	it('should reconcile mutated DOM attributes', () => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -252,6 +252,38 @@ describe('render()', () => {
 				.and.matches(/position\s*:\s*relative\s*/);
 		});
 
+		it('should properly switch from string styles to object styles and back', () => {
+			let root = render((
+				<div style="display: inline;">test</div>
+			), scratch);
+
+			expect(root.style.cssText).to.equal('display: inline;');
+
+			root = render((
+				<div style={{ color: 'red' }} />
+			), scratch, root);
+
+			expect(root.style.cssText).to.equal('color: red;');
+
+			root = render((
+				<div style="color: blue" />
+			), scratch, root);
+
+			expect(root.style.cssText).to.equal('color: blue;');
+
+			root = render((
+				<div style={{ color: 'yellow' }} />
+			), scratch, root);
+
+			expect(root.style.cssText).to.equal('color: yellow;');
+
+			root = render((
+				<div style="display: block" />
+			), scratch, root);
+
+			expect(root.style.cssText).to.equal('display: block;');
+		});
+
 		it('should serialize style objects', () => {
 			let root = render((
 				<div style={{
@@ -282,12 +314,6 @@ describe('render()', () => {
 			), scratch, root);
 
 			expect(root.style.cssText).to.equal('color: rgb(0, 255, 255);');
-
-			root = render((
-				<div style="display: inline;">test</div>
-			), scratch, root);
-
-			expect(root.style.cssText).to.equal('display: inline;');
 
 			root = render((
 				<div style={{ backgroundColor: 'rgb(0, 255, 255)' }}>test</div>

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -396,7 +396,22 @@ describe('render()', () => {
 				.and.to.have.been.calledWithExactly('click', sinon.match.func, false);
 		});
 
-		it('should add event handlers using a normalized event name', () => {
+		it('should support native event names', () => {
+			let click = sinon.spy(),
+				mousedown = sinon.spy();
+
+			render(<div onclick={() => click(1)} onmousedown={mousedown} />, scratch);
+
+			expect(proto.addEventListener).to.have.been.calledTwice
+				.and.to.have.been.calledWith('click')
+				.and.calledWith('mousedown');
+
+			fireEvent(scratch.childNodes[0], 'click');
+			expect(click).to.have.been.calledOnce
+				.and.calledWith(1);
+		});
+
+		it('should support camel-case event names', () => {
 			let click = sinon.spy(),
 				mousedown = sinon.spy();
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -37,8 +37,16 @@ describe('render()', () => {
 		scratch = null;
 	});
 
-	it('should render a empty text node', () => {
+	it('should render a empty text node given null', () => {
 		render(null, scratch);
+		let c = scratch.childNodes;
+		expect(c).to.have.length(1);
+		expect(c[0].data).to.equal('');
+		expect(c[0].nodeName).to.equal('#text');
+	});
+
+	it('should render an empty text node given an empty string', () => {
+		render('', scratch);
 		let c = scratch.childNodes;
 		expect(c).to.have.length(1);
 		expect(c[0].data).to.equal('');
@@ -56,13 +64,39 @@ describe('render()', () => {
 		expect(scratch.childNodes).to.have.length(1);
 		expect(scratch.childNodes[0].nodeName).to.equal('SPAN');
 
+	});
+
+	it('should support custom tag names', () => {
+		render(<foo />, scratch);
+		expect(scratch.childNodes).to.have.length(1);
+		expect(scratch.firstChild).to.have.property('nodeName', 'FOO');
+
 		scratch.innerHTML = '';
 
-		render(<foo />, scratch);
 		render(<x-bar />, scratch);
+		expect(scratch.childNodes).to.have.length(1);
+		expect(scratch.firstChild).to.have.property('nodeName', 'X-BAR');
+	});
+
+	it('should append new elements when called without a merge argument', () => {
+		render(<div />, scratch);
+		expect(scratch.childNodes).to.have.length(1);
+		expect(scratch.firstChild).to.have.property('nodeName', 'DIV');
+
+		render(<span />, scratch);
 		expect(scratch.childNodes).to.have.length(2);
-		expect(scratch.childNodes[0]).to.have.property('nodeName', 'FOO');
-		expect(scratch.childNodes[1]).to.have.property('nodeName', 'X-BAR');
+		expect(scratch.childNodes[0]).to.have.property('nodeName', 'DIV');
+		expect(scratch.childNodes[1]).to.have.property('nodeName', 'SPAN');
+	});
+
+	it('should merge new elements when called with a merge argument', () => {
+		let root = render(<div />, scratch);
+		expect(scratch.childNodes).to.have.length(1);
+		expect(scratch.firstChild).to.have.property('nodeName', 'DIV');
+
+		render(<span />, scratch, root);
+		expect(scratch.childNodes).to.have.length(1);
+		expect(scratch.firstChild).to.have.property('nodeName', 'SPAN');
 	});
 
 	it('should nest empty nodes', () => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -244,55 +244,57 @@ describe('render()', () => {
 		expect(scratch.childNodes[0]).to.have.property('className', 'bar');
 	});
 
-	it('should apply style as String', () => {
-		render(<div style="top:5px; position:relative;" />, scratch);
-		expect(scratch.childNodes[0].style.cssText)
-			.that.matches(/top\s*:\s*5px\s*/)
-			.and.matches(/position\s*:\s*relative\s*/);
-	});
+	describe('style attribute', () => {
+		it('should apply style as String', () => {
+			render(<div style="top:5px; position:relative;" />, scratch);
+			expect(scratch.childNodes[0].style.cssText)
+				.that.matches(/top\s*:\s*5px\s*/)
+				.and.matches(/position\s*:\s*relative\s*/);
+		});
 
-	it('should serialize style objects', () => {
-		let root = render((
-			<div style={{
-				color: 'rgb(255, 255, 255)',
-				background: 'rgb(255, 100, 0)',
-				backgroundPosition: '10px 10px',
-				'background-size': 'cover',
-				padding: 5,
-				top: 100,
-				left: '100%'
-			}}
-			>
-				test
-			</div>
-		), scratch);
+		it('should serialize style objects', () => {
+			let root = render((
+				<div style={{
+					color: 'rgb(255, 255, 255)',
+					background: 'rgb(255, 100, 0)',
+					backgroundPosition: '10px 10px',
+					'background-size': 'cover',
+					padding: 5,
+					top: 100,
+					left: '100%'
+				}}
+				>
+					test
+				</div>
+			), scratch);
 
-		let { style } = scratch.childNodes[0];
-		expect(style).to.have.property('color').that.equals('rgb(255, 255, 255)');
-		expect(style).to.have.property('background').that.contains('rgb(255, 100, 0)');
-		expect(style).to.have.property('backgroundPosition').that.equals('10px 10px');
-		expect(style).to.have.property('backgroundSize', 'cover');
-		expect(style).to.have.property('padding', '5px');
-		expect(style).to.have.property('top', '100px');
-		expect(style).to.have.property('left', '100%');
+			let { style } = scratch.childNodes[0];
+			expect(style).to.have.property('color').that.equals('rgb(255, 255, 255)');
+			expect(style).to.have.property('background').that.contains('rgb(255, 100, 0)');
+			expect(style).to.have.property('backgroundPosition').that.equals('10px 10px');
+			expect(style).to.have.property('backgroundSize', 'cover');
+			expect(style).to.have.property('padding', '5px');
+			expect(style).to.have.property('top', '100px');
+			expect(style).to.have.property('left', '100%');
 
-		root = render((
-			<div style={{ color: 'rgb(0, 255, 255)' }}>test</div>
-		), scratch, root);
+			root = render((
+				<div style={{ color: 'rgb(0, 255, 255)' }}>test</div>
+			), scratch, root);
 
-		expect(root.style.cssText).to.equal('color: rgb(0, 255, 255);');
+			expect(root.style.cssText).to.equal('color: rgb(0, 255, 255);');
 
-		root = render((
-			<div style="display: inline;">test</div>
-		), scratch, root);
+			root = render((
+				<div style="display: inline;">test</div>
+			), scratch, root);
 
-		expect(root.style.cssText).to.equal('display: inline;');
+			expect(root.style.cssText).to.equal('display: inline;');
 
-		root = render((
-			<div style={{ backgroundColor: 'rgb(0, 255, 255)' }}>test</div>
-		), scratch, root);
+			root = render((
+				<div style={{ backgroundColor: 'rgb(0, 255, 255)' }}>test</div>
+			), scratch, root);
 
-		expect(root.style.cssText).to.equal('background-color: rgb(0, 255, 255);');
+			expect(root.style.cssText).to.equal('background-color: rgb(0, 255, 255);');
+		});
 	});
 
 	describe('event handling', () => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -235,6 +235,12 @@ describe('render()', () => {
 		expect(scratch).to.have.property('innerHTML', '<div><input><table></table></div>', 'for undefined');
 	});
 
+	// Test for #651
+	it('should set enumerable boolean attribute', () => {
+		render(<input spellcheck={false} />, scratch);
+		expect(scratch.firstChild.spellcheck).to.equal(false);
+	});
+
 	it('should apply string attributes', () => {
 		render(<div foo="bar" data-foo="databar" />, scratch);
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -148,8 +148,9 @@ describe('render()', () => {
 			anan: 'NaN'
 		});
 
-		scratch.innerHTML = '';
+	});
 
+	it('should not render falsy attributes on initial render', () => {
 		render((
 			<div anull={null} aundefined={undefined} afalse={false} anan={NaN} a0={0} />
 		), scratch);
@@ -249,6 +250,51 @@ describe('render()', () => {
 			.that.matches(/top\s*:\s*5px\s*/)
 			.and.matches(/position\s*:\s*relative\s*/);
 	});
+
+	it('should serialize style objects', () => {
+		let root = render((
+			<div style={{
+				color: 'rgb(255, 255, 255)',
+				background: 'rgb(255, 100, 0)',
+				backgroundPosition: '10px 10px',
+				'background-size': 'cover',
+				padding: 5,
+				top: 100,
+				left: '100%'
+			}}
+			>
+				test
+			</div>
+		), scratch);
+
+		let { style } = scratch.childNodes[0];
+		expect(style).to.have.property('color').that.equals('rgb(255, 255, 255)');
+		expect(style).to.have.property('background').that.contains('rgb(255, 100, 0)');
+		expect(style).to.have.property('backgroundPosition').that.equals('10px 10px');
+		expect(style).to.have.property('backgroundSize', 'cover');
+		expect(style).to.have.property('padding', '5px');
+		expect(style).to.have.property('top', '100px');
+		expect(style).to.have.property('left', '100%');
+
+		root = render((
+			<div style={{ color: 'rgb(0, 255, 255)' }}>test</div>
+		), scratch, root);
+
+		expect(root.style.cssText).to.equal('color: rgb(0, 255, 255);');
+
+		root = render((
+			<div style="display: inline;">test</div>
+		), scratch, root);
+
+		expect(root.style.cssText).to.equal('display: inline;');
+
+		root = render((
+			<div style={{ backgroundColor: 'rgb(0, 255, 255)' }}>test</div>
+		), scratch, root);
+
+		expect(root.style.cssText).to.equal('background-color: rgb(0, 255, 255);');
+	});
+
 
 	it('should only register on* functions as handlers', () => {
 		let click = () => {},
@@ -352,51 +398,9 @@ describe('render()', () => {
 		}
 	});
 
-	it('should serialize style objects', () => {
-		let root = render((
-			<div style={{
-				color: 'rgb(255, 255, 255)',
-				background: 'rgb(255, 100, 0)',
-				backgroundPosition: '10px 10px',
-				'background-size': 'cover',
-				padding: 5,
-				top: 100,
-				left: '100%'
-			}}>
-				test
-			</div>
-		), scratch);
-
-		let { style } = scratch.childNodes[0];
-		expect(style).to.have.property('color').that.equals('rgb(255, 255, 255)');
-		expect(style).to.have.property('background').that.contains('rgb(255, 100, 0)');
-		expect(style).to.have.property('backgroundPosition').that.equals('10px 10px');
-		expect(style).to.have.property('backgroundSize', 'cover');
-		expect(style).to.have.property('padding', '5px');
-		expect(style).to.have.property('top', '100px');
-		expect(style).to.have.property('left', '100%');
-
-		root = render((
-			<div style={{ color: 'rgb(0, 255, 255)' }}>test</div>
-		), scratch, root);
-
-		expect(root.style.cssText).to.equal('color: rgb(0, 255, 255);');
-
-		root = render((
-			<div style="display: inline;">test</div>
-		), scratch, root);
-
-		expect(root.style.cssText).to.equal('display: inline;');
-
-		root = render((
-			<div style={{ backgroundColor: 'rgb(0, 255, 255)' }}>test</div>
-		), scratch, root);
-
-		expect(root.style.cssText).to.equal('background-color: rgb(0, 255, 255);');
-	});
-
 	it('should support dangerouslySetInnerHTML', () => {
 		let html = '<b>foo &amp; bar</b>';
+		// eslint-disable-next-line react/no-danger
 		let root = render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch);
 
 		expect(scratch.firstChild, 'set').to.have.property('innerHTML', html);
@@ -406,6 +410,7 @@ describe('render()', () => {
 
 		expect(scratch, 'unset').to.have.property('innerHTML', `<div>a<strong>b</strong></div>`);
 
+		// eslint-disable-next-line react/no-danger
 		render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, root);
 
 		expect(scratch.innerHTML, 're-set').to.equal('<div>'+html+'</div>');
@@ -418,13 +423,14 @@ describe('render()', () => {
 				this.state.html = this.props.html;
 			}
 			render(props, { html }) {
+				// eslint-disable-next-line react/no-danger
 				return html ? <div dangerouslySetInnerHTML={{ __html: html }} /> : <div />;
 			}
 		}
 
 		let thing;
 
-		render(<Thing ref={ c => thing=c } html="<b><i>test</i></b>" />, scratch);
+		render(<Thing ref={c => thing=c} html="<b><i>test</i></b>" />, scratch);
 
 		expect(scratch.innerHTML).to.equal('<div><b><i>test</i></b></div>');
 
@@ -442,6 +448,7 @@ describe('render()', () => {
 	it('should hydrate with dangerouslySetInnerHTML', () => {
 		let html = '<b>foo &amp; bar</b>';
 		scratch.innerHTML = `<div>${html}</div>`;
+		// eslint-disable-next-line react/no-danger
 		render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch, scratch.lastChild);
 
 		expect(scratch.firstChild).to.have.property('innerHTML', html);
@@ -509,7 +516,7 @@ describe('render()', () => {
 		};
 
 		const DOMElement = html`<div><a foo="bar"></a></div>`;
-		const preactElement = <div><a></a></div>;
+		const preactElement = <div><a /></div>;
 
 		render(preactElement, scratch, DOMElement);
 		expect(scratch).to.have.property('innerHTML', '<div><a></a></div>');
@@ -529,7 +536,7 @@ describe('render()', () => {
 		}
 
 		let comp;
-		let root = render(<Foo ref={ c => comp = c } />, scratch, root);
+		let root = render(<Foo ref={c => comp = c} />, scratch, root);
 
 		let c = document.createElement('c');
 		c.textContent = 'baz';
@@ -554,18 +561,18 @@ describe('render()', () => {
 
 		// Re-rendering from the root is non-destructive if the root was a previous render:
 		comp.alt = false;
-		root = render(<Foo ref={ c => comp = c } />, scratch, root);
+		root = render(<Foo ref={c => comp = c} />, scratch, root);
 
 		expect(scratch.firstChild.children, 'root re-render').to.have.length(4);
 		expect(scratch.innerHTML, 'root re-render').to.equal(`<div><a>foo</a><b>bar</b><c>baz</c><b>bat</b></div>`);
 
 		comp.alt = true;
-		root = render(<Foo ref={ c => comp = c } />, scratch, root);
+		root = render(<Foo ref={c => comp = c} />, scratch, root);
 
 		expect(scratch.firstChild.children, 'root re-render 2').to.have.length(4);
 		expect(scratch.innerHTML, 'root re-render 2').to.equal(`<div><b>alt</b><a>foo</a><c>baz</c><b>bat</b></div>`);
 
-		root = render(<div><Foo ref={ c => comp = c } /></div>, scratch, root);
+		root = render(<div><Foo ref={c => comp = c} /></div>, scratch, root);
 
 		expect(scratch.firstChild.children, 'root re-render changed').to.have.length(3);
 		expect(scratch.innerHTML, 'root re-render changed').to.equal(`<div><div><a>foo</a><b>bar</b></div><c>baz</c><b>bat</b></div>`);
@@ -606,9 +613,9 @@ describe('render()', () => {
 				this.setState({ todos, text: '' });
 			}
 			render() {
-				const {todos, text} = this.state;
+				const { todos, text } = this.state;
 				return (
-					<div onKeyDown={ this.addTodo }>
+					<div onKeyDown={this.addTodo}>
 						{ todos.map( todo => (<div>{todo.text}</div> )) }
 						<input value={text} onInput={this.setText} ref={(i) => input = i} />
 					</div>
@@ -623,7 +630,7 @@ describe('render()', () => {
 		});
 		root._component.addTodo();
 		expect(document.activeElement).to.equal(input);
-		setTimeout(() =>{
+		setTimeout(() => {
 			expect(/1/.test(scratch.innerHTML)).to.equal(true);
 			done();
 		}, 10);

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -1,6 +1,6 @@
 /* global DISABLE_FLAKEY */
 
-import { h, render, Component } from '../../src/preact';
+import { h, render, Component, rerender } from '../../src/preact';
 /** @jsx h */
 
 function getAttributes(node) {
@@ -678,44 +678,69 @@ describe('render()', () => {
 		expect(sortAttributes(html)).to.equal(sortAttributes('<input type="range" min="0" max="100" list="steplist">'));
 	});
 
-	it('should not execute append operation when child is at last', (done) => {
+	it('should not execute append operation when child is at last', () => {
+		// See developit/preact#717 for discussion about the issue this addresses
+
+		let todoText = 'new todo that I should complete';
 		let input;
+		let setText;
+		let addTodo;
+
+		const ENTER = 13;
+
 		class TodoList extends Component {
 			constructor(props) {
 				super(props);
 				this.state = { todos: [], text: '' };
-				this.setText = this.setText.bind(this);
-				this.addTodo = this.addTodo.bind(this);
+				setText = this.setText = this.setText.bind(this);
+				addTodo = this.addTodo = this.addTodo.bind(this);
 			}
 			setText(e) {
 				this.setState({ text: e.target.value });
 			}
-			addTodo() {
-				let { todos, text } = this.state;
-				todos = todos.concat({ text });
-				this.setState({ todos, text: '' });
+			addTodo(e) {
+				if (e.keyCode === ENTER) {
+					let { todos, text } = this.state;
+					todos = todos.concat({ text });
+					this.setState({ todos, text: '' });
+				}
 			}
 			render() {
 				const { todos, text } = this.state;
 				return (
 					<div onKeyDown={this.addTodo}>
-						{ todos.map( todo => (<div>{todo.text}</div> )) }
+						{ todos.map( todo => ([
+							<span>{todo.text}</span>,
+							<span> [ <a href="javascript:;">Delete</a> ]</span>,
+							<br />
+						])) }
 						<input value={text} onInput={this.setText} ref={(i) => input = i} />
 					</div>
 				);
 			}
 		}
-		const root = render(<TodoList />, scratch);
+
+		render(<TodoList />, scratch);
+
+		// Simulate user typing
 		input.focus();
-		input.value = 1;
-		root._component.setText({
+		input.value = todoText;
+		setText({
 			target: input
 		});
-		root._component.addTodo();
+
+		// Simulate user pressing enter
+		addTodo({
+			keyCode: ENTER
+		});
+
+		// Before Preact rerenders, focus should be on the input
 		expect(document.activeElement).to.equal(input);
-		setTimeout(() => {
-			expect(/1/.test(scratch.innerHTML)).to.equal(true);
-			done();
-		}, 10);
+
+		rerender();
+
+		// After Preact rerenders, focus should remain on the input
+		expect(document.activeElement).to.equal(input);
+		expect(scratch.innerHTML).to.contain(`<span>${todoText}</span>`);
 	});
 });


### PR DESCRIPTION
Reorganize render unit tests to better represent the expectations that the test are validating. Also, improved a couple tests to better cover their scenario.