### PR TITLE
Refine `options` Flow type

### DIFF
--- a/src/preact.js.flow
+++ b/src/preact.js.flow
@@ -9,5 +9,17 @@ declare function render(vnode: Node, parent: Element, toReplace?: Element): Elem
 export { h, createElement, cloneElement, Component, render };
 export default { h, createElement, cloneElement, Component, render };
 
+declare type VNode<P> = {
+    nodeName: string | Function,
+    children: Array<VNode<P> | string>,
+    key?: string | number | void,
+    attributes: P,
+};
+
 declare export function rerender(): void;
-declare export var options: Object;
+declare export var options: {
+    syncComponentUpdates?: boolean,
+    vnode?: (vnode: VNode<any>) => void,
+    debounceRendering?: (rerender: () => void) => void,
+    event?: (event: Event) => Event | void,
+};


### PR DESCRIPTION
Using Flow's `Object` types is actually a violation of [the `unclear-type` linting rule](https://flow.org/en/docs/linting/rule-reference/#toc-unclear-type):

> **unclear-type**
>
> Triggers when you use any, Object, or Function as type annotations. These types are unsafe.

So, using it to type the exported `options` object may cause issues for developers that have Flow linting enabled. Also, specifically typing this will result in a better developer experience anyway :)

As I started typing it, I ended up having to use `Function` and `any` elsewhere. Ideally those types should be refined too, but since I'm not familiar with Preact's internals I decided to leave it as-is and maybe a reviewer can suggest the right direction?