### PR TITLE
Chrome poor performance when calling array.unshift on a large array.

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -189,7 +189,7 @@ export function renderComponent(component, renderMode, mountAll, isChild) {
 	}
 
 	if (!isUpdate || mountAll) {
-		mounts.unshift(component);
+		mounts.push(component);
 	}
 	else if (!skip) {
 		// Ensure that pending componentDidMount() hooks of child components

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -24,11 +24,13 @@ let hydrating = false;
 
 /** Invoke queued componentDidMount lifecycle methods */
 export function flushMounts() {
-	let c;
-	while ((c=mounts.pop())) {
+	let c, i;
+	for (i=0; i<mounts.length; ++i) {
+		c = mounts[i];
 		if (options.afterMount) options.afterMount(c);
 		if (c.componentDidMount) c.componentDidMount();
 	}
+	mounts.length = 0;
 }
 
 


### PR DESCRIPTION
I'm really enjoying preact, thanks for developing the project!

I noticed when quickly adding and removing a large amount of nodes, Chrome 68 experiences poor performance. Using the profiler, most of the time is spent in `mounts.unshift()`. This PR changes `mounts.unshift()` to `mounts.push()` and reversing the order that mounts are flushed to maintain functionality.

This project demonstrates the issue: https://github.com/lowaa/preact-perf

With preact 8.3.1, Chrome 68 running on a macbook pro 2018:

![image](https://user-images.githubusercontent.com/3772160/45478303-2cc60900-b776-11e8-99f5-44512f0dd9ea.png)

After the change:

![image](https://user-images.githubusercontent.com/3772160/45478380-60a12e80-b776-11e8-9f29-f18ff117caeb.png)

The scripting time is significantly decreased but maximum heap usage goes up by ~25%

Also tested on Firefox 62 and Edge 17. These browsers did not seem to have an issue with the use of `array.unshift()`. The change to `array.push` also seemed to have no effect.

