### PR TITLE
Fix confusing type errors by reversing order of overloaded h() definitions

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -101,14 +101,14 @@ declare namespace preact {
 		abstract render(props?: RenderableProps<P>, state?: Readonly<S>, context?: any): ComponentChild;
 	}
 
-	function h<P>(
-		node: ComponentFactory<P>,
-		params: Attributes & P | null,
-		...children: ComponentChildren[]
-	): VNode<any>;
 	function h(
 		node: string,
 		params: JSX.HTMLAttributes & JSX.SVGAttributes & Record<string, any> | null,
+		...children: ComponentChildren[]
+	): VNode<any>;
+	function h<P>(
+		node: ComponentFactory<P>,
+		params: Attributes & P | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 


### PR DESCRIPTION
For overloaded functions, TypeScript reports errors based on the last of the overloaded definitions. For `h`'s overloaded definitions, the string version is currently last. When type checking of an `h` call fails (for example, due to a missing prop, or due to an incorrect prop type), TypeScript simply says "Argument of type 'typeof OurComponent' is not assignable to parameter of type 'string'." This patch switches the order of the `h` definitions, so that the `h<P>` version comes last. This makes TypeScript report a more specific error that will include missing props, etc.

Before this change:

```
$ tsc
src/mycomponent.ts:5:14 - error TS2345: Argument of type 'typeof MyComponent2' is not assignable to parameter of type 'string'.

5     return h(MyComponent2, {})
```

After this change:

```
$ tsc
src/mycomponent.ts:5:28 - error TS2345: Argument of type '{}' is not assignable to parameter of type 'Attributes & Props'.
  Type '{}' is not assignable to type 'Props'.
    Property 'foo' is missing in type '{}'.

5     return h(MyComponent2, {})
```

See my [working example repo](https://github.com/garybernhardt/preact-typescript-component-wont-build). Switch the order of the `h` definitions in `src/preact-8.2.9.min.d.ts` in that repo and you'll see that the error goes from the first (confusing) error above to the second (very clear) error.