### PR TITLE
Fix Flow typing for Flow v0.82

### DIFF
--- a/src/preact.js.flow
+++ b/src/preact.js.flow
@@ -2,7 +2,7 @@
 
 import { createElement, cloneElement, Component, type Node } from 'react';
 
-declare var h: createElement;
+declare var h: typeof createElement;
 
 declare function render(vnode: Node, parent: Element, toReplace?: Element): Element;
 


### PR DESCRIPTION
https://github.com/facebook/flow/releases/tag/v0.82.0: Removed the ability to use functions as type annotations.

The old/current code will prompt this Flow error:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/preact/dist/preact.js.flow:5:16

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     2│
     3│ import { createElement, cloneElement, Component, type Node } from 'react';
     4│
     5│ declare var h: createElement;
     6│
     7│ declare function render(vnode: Node, parent: Element, toReplace?: Element): Element;
     8│



Found 1 error
error Command failed with exit code 2.
```