### PR TITLE
fix #1225

### DIFF
--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -1,9 +1,9 @@
-import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER, ATTR_KEY } from '../constants';
+import { SYNC_RENDER, NO_RENDER, FORCE_RENDER, ASYNC_RENDER } from '../constants';
 import options from '../options';
 import { extend, applyRef } from '../util';
 import { enqueueRender } from '../render-queue';
 import { getNodeProps } from './index';
-import { diff, mounts, diffLevel, flushMounts, recollectNodeTree, removeChildren } from './diff';
+import { diff, mounts, diffLevel, flushMounts, recollectNodeTree, removeChildren, removeRef } from './diff';
 import { createComponent, recyclerComponents } from './component-recycler';
 import { removeNode } from '../dom/index';
 
@@ -282,10 +282,7 @@ export function unmountComponent(component) {
 		unmountComponent(inner);
 	}
 	else if (base) {
-		if (base[ATTR_KEY]!=null) {
-			applyRef(base[ATTR_KEY].ref, null);
-			delete base[ATTR_KEY].ref;
-		}
+		removeRef(base);
 
 		component.nextBase = base;
 

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -282,7 +282,10 @@ export function unmountComponent(component) {
 		unmountComponent(inner);
 	}
 	else if (base) {
-		if (base[ATTR_KEY]!=null) applyRef(base[ATTR_KEY].ref, null);
+		if (base[ATTR_KEY]!=null) {
+			applyRef(base[ATTR_KEY].ref, null);
+			delete base[ATTR_KEY].ref;
+		}
 
 		component.nextBase = base;
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -270,6 +270,17 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 }
 
 
+/**
+ * Remove ref if ref exists in props.
+ * @param {import('../dom').PreactElement} node DOM node
+ */
+export function removeRef(node) {
+	if (node[ATTR_KEY]!=null) {
+		applyRef(node[ATTR_KEY].ref, null);
+		delete node[ATTR_KEY].ref;
+	}
+}
+
 
 /**
  * Recursively recycle (or just unmount) a node and its descendants.
@@ -287,10 +298,7 @@ export function recollectNodeTree(node, unmountOnly) {
 	else {
 		// If the node's VNode had a ref function, invoke it with null here.
 		// (this is part of the React spec, and smart for unsetting references)
-		if (node[ATTR_KEY]!=null) {
-			applyRef(node[ATTR_KEY].ref, null);
-			delete node[ATTR_KEY].ref;
-		}
+		removeRef(node);
 
 		if (unmountOnly===false || node[ATTR_KEY]==null) {
 			removeNode(node);

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -287,7 +287,10 @@ export function recollectNodeTree(node, unmountOnly) {
 	else {
 		// If the node's VNode had a ref function, invoke it with null here.
 		// (this is part of the React spec, and smart for unsetting references)
-		if (node[ATTR_KEY]!=null) applyRef(node[ATTR_KEY].ref, null);
+		if (node[ATTR_KEY]!=null) {
+			applyRef(node[ATTR_KEY].ref, null);
+			delete node[ATTR_KEY].ref;
+		}
 
 		if (unmountOnly===false || node[ATTR_KEY]==null) {
 			removeNode(node);

--- a/test/browser/refs.js
+++ b/test/browser/refs.js
@@ -84,20 +84,25 @@ describe('refs', () => {
 	});
 
 	it('should be executed when the element which has a ref attribute is created', () => {
-		let setRef = spy('setRef'),
+		let setBase = spy('setBase'),
+			setChildren = spy('setChildren'),
 			outer, inner;
 		class Outer extends Component {
 			constructor(props) {
 				super(props);
 				this.state = { show:false };
-				this.setRef = this.setRef.bind(this);
+				this.setBase = this.setBase.bind(this);
+				this.setChildren = this.setChildren.bind(this);
 				outer = this;
 			}
-			setRef(el) {
-				setRef(el);
+			setBase(el) {
+				setBase(el);
+			}
+			setChildren(el) {
+				setChildren(el);
 			}
 			render(_, {show}) {
-				const content = show ? <Inner><p ref={this.setRef}></p></Inner> : null;
+				const content = show ? <Inner setBase={this.setBase}><p ref={this.setChildren}></p></Inner> : null;
 				return <div>{content}</div>;
 			}
 		}
@@ -106,29 +111,34 @@ describe('refs', () => {
 				super(props);
 				inner = this;
 			}
-			render({children}) {
-				return <div>{children}</div>;
+			render({children, setBase}) {
+				return <div ref={setBase}>{children}</div>;
 			}
 		}
 
 		render(<Outer />, scratch);
-		expect(setRef.notCalled).to.be.true;
+		expect(setChildren.notCalled).to.be.true;
 
 		outer.setState({ show:true });
 		outer.forceUpdate();
-		expect(setRef).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
+		expect(setBase).to.have.been.calledOnce.and.calledWith(inner.base);
+		expect(setChildren).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
 
-		setRef.resetHistory();
+		setBase.resetHistory();
+		setChildren.resetHistory();
 
 		outer.setState({ show:false });
 		outer.forceUpdate();
-		expect(setRef).to.have.been.calledOnce.and.calledWith(null);
+		expect(setBase).to.have.been.calledOnce.and.calledWith(null);
+		expect(setChildren).to.have.been.calledOnce.and.calledWith(null);
 
-		setRef.resetHistory();
+		setBase.resetHistory();
+		setChildren.resetHistory();
 
 		outer.setState({ show:true });
 		outer.forceUpdate();
-		expect(setRef).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
+		expect(setBase).to.have.been.calledOnce.and.calledWith(inner.base);
+		expect(setChildren).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
 	});
 
 	it('should pass children to ref functions', () => {

--- a/test/browser/refs.js
+++ b/test/browser/refs.js
@@ -83,6 +83,54 @@ describe('refs', () => {
 		expect(ref).to.have.been.calledOnce.and.calledWith(null);
 	});
 
+	it('should be executed when the element which has a ref attribute is created', () => {
+		let setRef = spy('setRef'),
+			outer, inner;
+		class Outer extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { show:false };
+				this.setRef = this.setRef.bind(this);
+				outer = this;
+			}
+			setRef(el) {
+				setRef(el);
+			}
+			render(_, {show}) {
+				const content = show ? <Inner><p ref={this.setRef}></p></Inner> : null;
+				return <div>{content}</div>;
+			}
+		}
+		class Inner extends Component {
+			constructor(props) {
+				super(props);
+				inner = this;
+			}
+			render({children}) {
+				return <div>{children}</div>;
+			}
+		}
+
+		render(<Outer />, scratch);
+		expect(setRef.notCalled).to.be.true;
+
+		outer.setState({ show:true });
+		outer.forceUpdate();
+		expect(setRef).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
+
+		setRef.resetHistory();
+
+		outer.setState({ show:false });
+		outer.forceUpdate();
+		expect(setRef).to.have.been.calledOnce.and.calledWith(null);
+
+		setRef.resetHistory();
+
+		outer.setState({ show:true });
+		outer.forceUpdate();
+		expect(setRef).to.have.been.calledOnce.and.calledWith(inner.base.firstChild);
+	});
+
 	it('should pass children to ref functions', () => {
 		let outer = spy('outer'),
 			inner = spy('inner'),


### PR DESCRIPTION
When the HTML Element in `recyclerComponents` is used, 
`ref` which is owned by the HTML Element is same as `ref` which is owned by VNode.
Therefore, `ref` is not reseted.

https://github.com/developit/preact/blob/329d7c14140624d8b194f04f6c093f7f55e19d97/src/vdom/diff.js#L335