### PR TITLE
fix #1177

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -51,6 +51,20 @@ export function removeNode(node) {
 }
 
 
+const refs = [];
+
+
+/**
+ * Execute ref functions
+ */
+export function setRefs() {
+	for (let i = 0, max = refs.length; i < max; i++) {
+		refs[i][0](refs[i][1]);
+	}
+	refs.length = 0;
+}
+
+
 /**
  * Set a named attribute on the given Node, with special behavior for some names
  * and event handlers. If `value` is `null`, the attribute/handler will be
@@ -72,7 +86,12 @@ export function setAccessor(node, name, old, value, isSvg) {
 	}
 	else if (name==='ref') {
 		applyRef(old, null);
-		applyRef(value, node);
+		if (typeof value=='function') {
+			refs.push([value, node]);
+		}
+		else {
+			applyRef(value, node);
+		}
 	}
 	else if (name==='class' && !isSvg) {
 		node.className = value || '';

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -5,7 +5,7 @@ import { enqueueRender } from '../render-queue';
 import { getNodeProps } from './index';
 import { diff, mounts, diffLevel, flushMounts, recollectNodeTree, removeChildren } from './diff';
 import { createComponent, recyclerComponents } from './component-recycler';
-import { removeNode } from '../dom/index';
+import { removeNode, setRefs } from '../dom/index';
 
 /**
  * Set a component's `props` and possibly re-render the component
@@ -192,6 +192,8 @@ export function renderComponent(component, renderMode, mountAll, isChild) {
 		mounts.push(component);
 	}
 	else if (!skip) {
+		setRefs();
+
 		// Ensure that pending componentDidMount() hooks of child components
 		// are called before the componentDidUpdate() hook in the parent.
 		// Note: disabled as it causes duplicate hooks, see https://github.com/developit/preact/issues/750

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -1,7 +1,7 @@
 import { ATTR_KEY } from '../constants';
 import { isSameNodeType, isNamedNode } from './index';
 import { buildComponentFromVNode } from './component';
-import { createNode, setAccessor } from '../dom/index';
+import { createNode, setAccessor, setRefs } from '../dom/index';
 import { unmountComponent } from './component';
 import options from '../options';
 import { applyRef } from '../util';
@@ -25,6 +25,7 @@ let hydrating = false;
 /** Invoke queued componentDidMount lifecycle methods */
 export function flushMounts() {
 	let c, i;
+	setRefs();
 	for (i=0; i<mounts.length; ++i) {
 		c = mounts[i];
 		if (options.afterMount) options.afterMount(c);

--- a/test/browser/refs.js
+++ b/test/browser/refs.js
@@ -200,6 +200,46 @@ describe('refs', () => {
 		expect(innermost, 'innerMost unmount').to.have.been.calledOnce.and.calledWith(null);
 	});
 
+	it('should execute ref functions after the component is mounted', () => {
+		let setRef = spy('setRef'),
+			app;
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { show:false };
+				this.setRef = this.setRef.bind(this);
+				app = this;
+			}
+			componentDidMount() {
+				expect(setRef).to.have.been.calledOnce.and.calledWith('foo');
+			}
+			componentDidUpdate() {
+				expect(setRef).to.have.been.calledOnce.and.calledWith('bar');
+			}
+			setRef(el) {
+				setRef(el.id);
+				expect(!!(el.compareDocumentPosition(scratch) & Node.DOCUMENT_POSITION_CONTAINS)).to.be.true;
+			}
+			render(_, {show}) {
+				return (
+					<div>
+						<p id="foo" ref={this.setRef}></p>
+						{show && <h1 id="bar" ref={this.setRef}></h1>}
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(setRef).to.have.been.calledOnce.and.calledWith('foo');
+
+		setRef.resetHistory();
+
+		app.setState({ show:true });
+		app.forceUpdate();
+		expect(setRef).to.have.been.calledOnce.and.calledWith('bar');
+	});
+
 	it('should not pass ref into component as a prop', () => {
 		let foo = spy('foo'),
 			bar = spy('bar');


### PR DESCRIPTION
It is necessary that the ref function is executed after the component is mounted.
It is necessary that the ref function is executed before `componentDidMount()` and `componentDidUpdate()`.