### PR TITLE
[types] Add more type tests for h function

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -101,14 +101,15 @@ declare namespace preact {
 		abstract render(props?: RenderableProps<P>, state?: Readonly<S>, context?: any): ComponentChild;
 	}
 
-	function h<P>(
-		node: ComponentFactory<P>,
-		params: Attributes & P | null,
-		...children: ComponentChildren[]
-	): VNode<any>;
 	function h(
 		node: string,
 		params: JSX.HTMLAttributes & JSX.SVGAttributes & Record<string, any> | null,
+		...children: ComponentChildren[]
+	): VNode<any>;
+
+	function h<P>(
+		node: ComponentFactory<P>,
+		params: Attributes & P & Record<string, any> | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -39,6 +39,8 @@ function DummerComponent({ input, initialInput }: DummerComponentProps) {
 	return <div>Input: {input}, initial: {initialInput}</div>;
 }
 
+render(h('div', { key: "1" }), document);
+render(h(DummyComponent, { initialInput: "The input", input: "New input", key: "1" }), document);
 render(h(DummerComponent, { initialInput: "The input", input: "New input", key: "1"}), document);
 
 // Accessing children

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -39,8 +39,8 @@ function DummerComponent({ input, initialInput }: DummerComponentProps) {
 	return <div>Input: {input}, initial: {initialInput}</div>;
 }
 
-render(h('div', { key: "1" }), document);
-render(h(DummyComponent, { initialInput: "The input", input: "New input", key: "1" }), document);
+render(h('div', { title: "test", key: "1" }), document);
+render(h(DummyComponent, { initialInput: "The input", key: "1" }), document);
 render(h(DummerComponent, { initialInput: "The input", input: "New input", key: "1"}), document);
 
 // Accessing children


### PR DESCRIPTION
Fixes & tests type errors for the `h` function when passing a component instead of a string.

Without this, the following fails type checking 2x:
```ts
h(MyComponent, { foo: 'bar' })
```

1. `Argument of type 'typeof MyComponent' is not assignable to parameter of type 'string'`
Solution: component h function needs to overload the string version (see #1214)
2. `Object literal may only specify know properties, and 'foo' does not exist in type 'Attributes & DummyProps'`
Solution: Added missing `Record<string, any>` to params

--- 

Edit: This was fixed by #1214.  This PR just adds more tests.