### PR TITLE
Fix AnyComponent with ComponentConstructor

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -69,7 +69,7 @@ declare namespace preact {
 	}
 
 	// Type alias for a component considered generally, whether stateless or stateful.
-	type AnyComponent<P = {}, S = {}> = FunctionalComponent<P> | Component<P, S>;
+	type AnyComponent<P = {}, S = {}> = FunctionalComponent<P> | ComponentConstructor<P, S>;
 
 	interface Component<P = {}, S = {}> {
 		componentWillMount?(): void;

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -5,6 +5,7 @@ import {
 	Component,
 	FunctionalComponent,
 	ComponentConstructor,
+	AnyComponent
 } from "../../src/preact";
 
 class SimpleComponent extends Component<{}, {}> {
@@ -16,6 +17,9 @@ class SimpleComponent extends Component<{}, {}> {
 }
 
 const SimpleFunctionalComponent = () => <div />;
+
+const a: AnyComponent = SimpleComponent;
+const b: AnyComponent = SimpleFunctionalComponent;
 
 describe("VNode", () => {
 	it("is returned by h", () => {


### PR DESCRIPTION
`AnyComponent` should be allowed to be a functional or class component.

Updated the typescript definition to allow for a component constructor and added a check to one of the typescript tests.