### PR TITLE
Pluggable recycling pr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Fast 3kb React alternative with the same modern API. Components & Virtual DOM.",
   "main": "dist/preact.js",
   "jsnext:main": "dist/preact.mjs",

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,8 @@
  * @property {(component: Component) => void} [beforeUnmount] Hook invoked immediately before a component is unmounted.
  * @property {(rerender: function) => void} [debounceRendering] Hook invoked whenever a rerender is requested. Can be used to debounce rerenders.
  * @property {(event: Event) => Event | void} [event] Hook invoked before any Preact event listeners. The return value (if any) replaces the native browser event given to event listeners
+ * @property {(component: Component, base: HTMLElement) => void} [recycle] Stores a component's base (element) for later reuse. Default implementation reuses per component type.
+ * @property {(component: Component) => HTMLElement | void} [reclaimRecycledBase] Finds a base (element) for a component type if available, and removes it from the pool of recycled component bases.
  */
 
 /** @type {Options}  */

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -120,7 +120,7 @@ declare namespace preact {
 		syncComponentUpdates?: boolean;
 		debounceRendering?: (render: () => void) => void;
 		recycle?: (component: Component<any, any>, base: HTMLElement) => void;
-		reclaimRecycledBase?: (component: ComponentFactory<any>) => HTMLElement|void|null;
+		reclaimRecycledBase?: <P>(component: ComponentFactory<P>, props: Readonly<P>, context: any) => HTMLElement|void|null;
 		vnode?: (vnode: VNode<any>) => void;
 		event?: (event: Event) => Event;
 	};

--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -119,6 +119,8 @@ declare namespace preact {
 	var options: {
 		syncComponentUpdates?: boolean;
 		debounceRendering?: (render: () => void) => void;
+		recycle?: (component: Component<any, any>, base: HTMLElement) => void;
+		reclaimRecycledBase?: (component: ComponentFactory<any>) => HTMLElement|void|null;
 		vnode?: (vnode: VNode<any>) => void;
 		event?: (event: Event) => Event;
 	};

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -58,7 +58,7 @@ export function createComponent(Ctor, props, context) {
 	}
 
 
-	inst.nextBase = (options.reclaimRecycledBase || reclaimRecycledBase)(Ctor);
+	inst.nextBase = (options.reclaimRecycledBase || reclaimRecycledBase)(Ctor, props, context);
 
 	return inst;
 }

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -4,7 +4,7 @@ import { extend, applyRef } from '../util';
 import { enqueueRender } from '../render-queue';
 import { getNodeProps } from './index';
 import { diff, mounts, diffLevel, flushMounts, recollectNodeTree, removeChildren } from './diff';
-import { createComponent, recyclerComponents } from './component-recycler';
+import { createComponent, recycle } from './component-recycler';
 import { removeNode } from '../dom/index';
 
 /**
@@ -284,10 +284,9 @@ export function unmountComponent(component) {
 	else if (base) {
 		if (base[ATTR_KEY]!=null) applyRef(base[ATTR_KEY].ref, null);
 
-		component.nextBase = base;
-
 		removeNode(base);
-		recyclerComponents.push(component);
+
+		(options.recycle || recycle)(component, base);
 
 		removeChildren(base);
 	}


### PR DESCRIPTION
This PR is a way to allow a pluggable recycling via two new options: `recycle` and `reclaimRecycledBase`. I understand that the future holds a removal of this. But...this would help people in the meantime. And, possibly allow for recycling as an opt-in future wise. Default implementation could then be a no-op.

. With this PR:
- you can control when to do garbage collection
- you don't have to keep references to unused component instances (not HTML elements)
- you can use a more efficient Map structure
- you can allow components to opt out from recycling.

This addresses
https://github.com/developit/preact/issues/1208
https://github.com/developit/preact/issues/957
https://github.com/developit/preact/issues/716
...and possibly others

FYI: Our internal recycling plugs look like this:

```js
const recycled = new Map();
options.recycle = (component, base) => {
    if ('shouldRecycle' in component && !(component.shouldRecycle()))
        return;

    const arr = map.get(component.constructor);
    if (!arr) {
       arr = [];
       map.set(component.constructor, arr);
    }
    arr.push(base);
};
options.reclaimRecycledBase = (ctor) => {
    const arr = recycled.get(ctor);
    return arr && arr.pop();
};
```