### PR TITLE
set string style prop via setAttribute ref: #1066

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -35,8 +35,8 @@ export function setAccessor(node, name, old, value, isSvg) {
 		node.className = value || '';
 	}
 	else if (name==='style') {
-		if (!value || isString(value) || isString(old)) {
-			node.style.cssText = value || '';
+		if (!value || typeof value==='string' || typeof old==='string') {
+			node.setAttribute('style', value || '');
 		}
 		if (value && typeof value==='object') {
 			if (!isString(old)) {

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -35,7 +35,7 @@ export function setAccessor(node, name, old, value, isSvg) {
 		node.className = value || '';
 	}
 	else if (name==='style') {
-		if (!value || typeof value==='string' || typeof old==='string') {
+		if (!value || isString(value) || isString(old)) {
 			node.setAttribute('style', value || '');
 		}
 		if (value && typeof value==='object') {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -194,7 +194,7 @@ describe('render()', () => {
 			.deep.equal(['style', style]);
 		expect(scratch.childNodes[0]).to.have.deep.property('style.cssText')
 			.that.equals(style);
-		spy.restore()
+		spy.restore();
 	});
 
 	it('object style prop should not call setAttribute', () => {
@@ -203,7 +203,7 @@ describe('render()', () => {
 		render(<div style={style} />, scratch);
 		
 		expect(spy).not.to.have.been.called;
-		spy.restore()
+		spy.restore();
 	});
 
 	it('should only register on* functions as handlers', () => {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -185,6 +185,27 @@ describe('render()', () => {
 			.and.matches(/position\s*:\s*relative\s*/);
 	});
 
+	it('string style should call setAttribute', () => {
+		const style = 'background-color: red;';
+		const spy = sinon.spy(Element.prototype, 'setAttribute');
+		render(<div style={style} />, scratch);
+		
+		expect(spy.firstCall.args).to
+			.deep.equal(['style', style]);
+		expect(scratch.childNodes[0]).to.have.deep.property('style.cssText')
+			.that.equals(style);
+		spy.restore()
+	});
+
+	it('object style prop should not call setAttribute', () => {
+		const style = { backgroundColor: 'papayawhip' };
+		const spy = sinon.spy(Element.prototype, 'setAttribute');
+		render(<div style={style} />, scratch);
+		
+		expect(spy).not.to.have.been.called;
+		spy.restore()
+	});
+
 	it('should only register on* functions as handlers', () => {
 		let click = () => {},
 			onclick = () => {};


### PR DESCRIPTION
Changes node.style.cssText assignment to node.setAttribute call. added tests to confirm functionality was unchanged.

ref: #1066 