### PR TITLE
Add `createRef` to Flow definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "diff": "^3.0.0",
     "eslint": "^4.18.2",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.67.1",
+    "flow-bin": "^0.89.0",
     "gzip-size-cli": "^2.0.0",
     "istanbul-instrumenter-loader": "^3.0.0",
     "jscodeshift": "^0.5.0",

--- a/src/preact.js.flow
+++ b/src/preact.js.flow
@@ -1,13 +1,13 @@
 /* @flow */
 
-import { createElement, cloneElement, Component, type Node } from 'react';
+import { createElement, cloneElement, createRef, Component, type Node } from 'react';
 
 declare var h: typeof createElement;
 
 declare function render(vnode: Node, parent: Element, toReplace?: Element): Element;
 
-export { h, createElement, cloneElement, Component, render };
-export default { h, createElement, cloneElement, Component, render };
+export { h, createElement, cloneElement, createRef, Component, render };
+export default { h, createElement, cloneElement, createRef, Component, render };
 
 declare type VNode<P> = {
     nodeName: string | Function,


### PR DESCRIPTION
`createRef` was added in https://github.com/developit/preact/pull/1138 however the Flow definition wasn’t added, so using it on Flow codebases was inconvenient.