### PR TITLE
debug: Allow ref to be an object (fixes #1271)

### DIFF
--- a/debug/index.js
+++ b/debug/index.js
@@ -15,10 +15,11 @@ if (process.env.NODE_ENV === 'development') {
 		if (
 			attributes && attributes.ref !== void 0 &&
 			typeof attributes.ref !== 'function' &&
+			typeof attributes.ref !== 'object' &&
 			!('$$typeof' in vnode)  // allow string refs when preact-compat is installed
 		) {
 			throw new Error(
-				`Component's "ref" property should be a function,` +
+				`Component's "ref" property should be a function or createRef() object,` +
 				` but [${typeof attributes.ref}] passed\n` + serializeVNode(vnode)
 			);
 		}


### PR DESCRIPTION
This fixes the issue where `preact/debug` throws an error when using `createRef()` (#1271)