### PR TITLE
Disallow applyRef when the ref is boolean false.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -15,7 +15,7 @@ export function extend(obj, props) {
  *  @param {any} [value]
  */
 export function applyRef(ref, value) {
-	if (ref!=null) {
+	if (ref!=null&&ref!==false) {
 		if (typeof ref=='function') ref(value);
 		else ref.current = value;
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -15,7 +15,7 @@ export function extend(obj, props) {
  *  @param {any} [value]
  */
 export function applyRef(ref, value) {
-	if (ref!=null&&ref!==false) {
+	if (ref) {
 		if (typeof ref=='function') ref(value);
 		else ref.current = value;
 	}


### PR DESCRIPTION
Kept running into rendering errors with our component, and tracked it down to here.

preact.mjs:65 Uncaught (in promise) TypeError: Cannot create property 'current' on boolean 'false'
    at applyRef (preact.mjs:65)
    at setAccessor (preact.mjs:138)
    at diffAttributes (preact.mjs:407)
    at idiff (preact.mjs:286)
    at diff (preact.mjs:209)
    at renderComponent (preact.mjs:564)
    at renderComponent (preact.mjs:550)
    at setComponentProps (preact.mjs:471)
    at buildComponentFromVNode (preact.mjs:637)
    at idiff (preact.mjs:248)