### PR TITLE
Fix TypeScript type checking of setState with function argument.

### DIFF
--- a/src/preact.d.ts
+++ b/src/preact.d.ts
@@ -95,8 +95,14 @@ declare namespace preact {
 		context: any;
 		base?: HTMLElement;
 
-		setState<K extends keyof S>(state: Pick<S, K>, callback?: () => void): void;
-		setState<K extends keyof S>(fn: (prevState: S, props: P) => Pick<S, K>, callback?: () => void): void;
+		// From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
+		// // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+		// // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+		// // Also, the ` | S` allows intellisense to not be dumbisense
+		setState<K extends keyof S>(
+			state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+			callback?: () => void
+		): void;
 
 		forceUpdate(callback?: () => void): void;
 


### PR DESCRIPTION
Fixes #1284.

See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
and https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
for why this change is required.

Before:

    $ cat a.tsx
    import { Component } from './src/preact';

    class A extends Component<{}, { a: number }> {
      a() {
        this.setState(() => ({ a: 'a' }));
      }

      render() {
        return null;
      }
    }

    $ tsc --noEmit a.tsx && echo ok
    ok

After:

    $ tsc --noEmit a.tsx
    a.tsx:5:19 -     error TS2345: Argument of type '() => { a: string; }' is not assignable to parameter of type '{ a: number; } | Pick<{ a: number; }, "a"> | ((prevState: Readonly<{ a: number; }>, props: Readonly<{}>) => { a: number; } | Pick<{ a: number; }, "a">)'.
      Type '() => { a: string; }' is not assignable to type '(prevState: Readonly<{ a: number; }>, props: Readonly<{}>) => { a: number; } | Pick<{ a: number; }, "a">'.
        Type '{ a: string; }' is not assignable to type '{ a: number; } | Pick<{ a: number; }, "a">'.
          Type '{ a: string; }' is not assignable to type 'Pick<{ a: number; }, "a">'.
            Types of property 'a' are incompatible.
              Type 'string' is not assignable to type 'number'.

    5     this.setState(() => ({ a: 'a' }));