### PR TITLE
Query recyclerComponents array length at its usage point

### DIFF
--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -17,7 +17,7 @@ export const recyclerComponents = [];
  * @returns {import('../component').Component}
  */
 export function createComponent(Ctor, props, context) {
-	let inst, i = recyclerComponents.length;
+	let inst;
 
 	if (Ctor.prototype && Ctor.prototype.render) {
 		inst = new Ctor(props, context);
@@ -29,6 +29,7 @@ export function createComponent(Ctor, props, context) {
 		inst.render = doRender;
 	}
 
+	let i = recyclerComponents.length;
 
 	while (i--) {
 		if (recyclerComponents[i].constructor===Ctor) {


### PR DESCRIPTION
#### Question

Related commit: https://github.com/developit/preact/commit/7cbaa2ac0141ad7c98f6a1a960a4e208d25c166f#diff-a480bde1c2f4c6ab259cbb4d81e21199

It's possible to change the length of `recyclerComponents` between its read at the start of `createComponent` and the time iteration starts. 

I hear this is going away, but currently running into this on 8.3.1 and I see it's still in master for 8.x.

Perhaps this is mainly due to misuse on my part, but the current workaround I'm testing is to modify the distributable in a similar way as this PR.

** couldn't find any associated issues, PRs, or contribution guidelines
Is the label "The Wreckoning" about the recycler?

