### PR TITLE
Only run travis tests once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: node_js
 
 node_js:
-  - "8"
   - "10"
 
 cache:


### PR DESCRIPTION
Preact and its build don't do anything that is specific to Node 8 vs 10, so we should just use 10.