### PR TITLE
Sort DOM attributes before assertion

### DIFF
--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -25,6 +25,6 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(scratch.innerHTML).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
 	});
 });

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -1,4 +1,4 @@
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
 import React from '../../src';
 
 describe('jsx', () => {
@@ -25,6 +25,6 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(scratch.innerHTML).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -1,5 +1,5 @@
 import React from '../../src';
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
 
 describe('svg', () => {
 
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
 	});
 });

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -78,3 +78,15 @@ export const mixedArrayHTML = '0ab<span>c</span>def1';
 export function clear(obj) {
 	Object.keys(obj).forEach(key => delete obj[key]);
 }
+
+/**
+ * Hacky normalization of attribute order across browsers.
+ * @param {string} html
+ */
+export function sortAttributes(html) {
+	return html.replace(/<([a-z0-9-]+)((?:\s[a-z0-9:_.-]+=".*?")+)((?:\s*\/)?>)/gi, (s, pre, attrs, after) => {
+		let list = attrs.match(/\s[a-z0-9:_.-]+=".*?"/gi).sort( (a, b) => a>b ? 1 : -1 );
+		if (~after.indexOf('/')) after = '></'+pre+'>';
+		return '<' + pre + list.join('') + after;
+	});
+}

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -1,5 +1,5 @@
 import { createElement, hydrate, Fragment } from '../../src/index';
-import { setupScratch, teardown } from '../_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
 import { ul, li, div } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
@@ -137,7 +137,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(scratch.innerHTML).to.equal('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -137,7 +137,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/svg.test.js
+++ b/test/browser/svg.test.js
@@ -1,18 +1,7 @@
 import { createElement as h, render } from '../../src/index';
-import { setupScratch, teardown } from '../_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
 
 /** @jsx h */
-
-
-// hacky normalization of attribute order across browsers.
-function sortAttributes(html) {
-	return html.replace(/<([a-z0-9-]+)((?:\s[a-z0-9:_.-]+=".*?")+)((?:\s*\/)?>)/gi, (s, pre, attrs, after) => {
-		let list = attrs.match(/\s[a-z0-9:_.-]+=".*?"/gi).sort( (a, b) => a>b ? 1 : -1 );
-		if (~after.indexOf('/')) after = '></'+pre+'>';
-		return '<' + pre + list.join('') + after;
-	});
-}
-
 
 describe('svg', () => {
 	let scratch;


### PR DESCRIPTION
Browsers do sort DOM attributes differently. Ported over from the `8` branch.