### PR TITLE
Fix mangle.json config

### DIFF
--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -7,6 +7,7 @@
     "cname": 6,
     "props": {
       "$__hooks": "__H",
+      "$_component": "__c",
       "$_defaultValue": "__p",
       "$_id": "__c"
     }

--- a/mangle.json
+++ b/mangle.json
@@ -18,7 +18,6 @@
       "$__html": "__html",
       "$_ancestorComponent": "__a",
       "$_processingException": "__p",
-      "$_context": "__c",
       "$_defaultValue": "__p",
       "$_id": "__c"
     }

--- a/mangle.json
+++ b/mangle.json
@@ -18,6 +18,7 @@
       "$__html": "__html",
       "$_ancestorComponent": "__a",
       "$_processingException": "__p",
+      "$_context": "__n",
       "$_defaultValue": "__p",
       "$_id": "__c"
     }


### PR DESCRIPTION
Add a missing mangle prop in hooks, and remove a property config that overrode an existing one (`__c` used for `_context` overrode `__c` used for `_constructor`).