### PR TITLE
Optimize cloneElement

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,6 +1,6 @@
 import { assign } from './util';
 import { EMPTY_ARR } from './constants';
-import { createElement } from './create-element';
+import { createVNode } from './create-element';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
@@ -9,9 +9,7 @@ import { createElement } from './create-element';
  * @param {Array<import('./index').ComponentChildren>} rest Any additional arguments will be used as replacement children.
  */
 export function cloneElement(vnode, props) {
-	let out = createElement(vnode.type, assign(assign({}, vnode.props), props));
-	out.key = out.key || vnode.key;
-	out.ref = out.ref || vnode.ref;
-	if (arguments.length>2) out.props.children = EMPTY_ARR.slice.call(arguments, 2);
-	return out;
+	props = assign(assign({}, vnode.props), props);
+	if (arguments.length>2) props.children = EMPTY_ARR.slice.call(arguments, 2);
+	return createVNode(vnode.type, props, null, props.key || vnode.key, props.ref || vnode.ref);
 }

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -49,7 +49,7 @@ export function createElement(type, props, children) {
  * receive a reference to its created child
  * @returns {import('./internal').VNode}
  */
-function createVNode(type, props, text, key, ref) {
+export function createVNode(type, props, text, key, ref) {
 	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
 	// Do not inline into createElement and coerceToVNode!
 	const vnode = {


### PR DESCRIPTION
As a plus, also ensures createVNode doesn't get inlined.