### PR TITLE
Add missing _parentDom mangle prop for hooks

### DIFF
--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -9,7 +9,8 @@
       "$__hooks": "__H",
       "$_component": "__c",
       "$_defaultValue": "__p",
-      "$_id": "__c"
+      "$_id": "__c",
+      "$_parentDom": "__P"
     }
   }
 }

--- a/mangle.json
+++ b/mangle.json
@@ -30,7 +30,8 @@
       "$_processingException": "__p",
       "$_context": "__n",
       "$_defaultValue": "__p",
-      "$_id": "__c"
+      "$_id": "__c",
+      "$_parentDom": "__P"
     }
   }
 }


### PR DESCRIPTION
`_parentDom` is used by `useEffect` to ensure a component is mounted before invoking its effect. So we need to consistently mangle the `_parentDom` property so it can be shared between them.