### PR TITLE
Fix saucelabs cross browser test assertions

### DIFF
--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -1,4 +1,4 @@
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, serializeHtml } from '../../../test/_util/helpers';
 // eslint-disable-next-line no-unused-vars
 import React, { Children, render } from '../../src';
 import { div, span } from '../../../test/_util/dom';
@@ -73,12 +73,12 @@ describe('Children', () => {
 				span('foo'),
 				span(div('bar'))
 			].join(''));
-			expect(scratch.innerHTML).to.equal(expected);
+			expect(serializeHtml(scratch)).to.equal(expected);
 		});
 
 		it('should work with no children', () => {
 			render(<Foo />, scratch);
-			expect(scratch.innerHTML).to.equal('<div></div>');
+			expect(serializeHtml(scratch)).to.equal('<div></div>');
 		});
 	});
 
@@ -95,7 +95,7 @@ describe('Children', () => {
 				span('foo'),
 				span(div('bar'))
 			].join(''));
-			expect(scratch.innerHTML).to.equal(expected);
+			expect(serializeHtml(scratch)).to.equal(expected);
 		});
 	});
 });

--- a/compat/test/browser/index.test.js
+++ b/compat/test/browser/index.test.js
@@ -8,7 +8,7 @@ import React, {
 	createFactory
 } from '../../src';
 import { createElement as preactH } from 'preact';
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, createEvent } from '../../../test/_util/helpers';
 
 let ce = type => document.createElement(type);
 let text = text => document.createTextNode(text);
@@ -176,7 +176,7 @@ describe('preact-compat', () => {
 		it('should normalize beforeinput event listener', () => {
 			let spy = sinon.spy();
 			render(<input onBeforeInput={spy} />, scratch);
-			scratch.firstChild.dispatchEvent(new Event('beforeinput'));
+			scratch.firstChild.dispatchEvent(createEvent('beforeinput'));
 			expect(spy).to.be.calledOnce;
 		});
 	});

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -1,4 +1,4 @@
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, serializeHtml } from '../../../test/_util/helpers';
 import React, { isValidElement } from '../../src';
 import { h as preactH } from 'preact';
 
@@ -26,7 +26,7 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(scratch.innerHTML).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
+		expect(serializeHtml(scratch)).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
 	});
 
 	describe('isValidElement', () => {

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -1,4 +1,4 @@
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
 import React, { isValidElement } from '../../src';
 import { h as preactH } from 'preact';
 
@@ -26,7 +26,7 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(scratch.innerHTML).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
 	});
 
 	describe('isValidElement', () => {

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -1,4 +1,4 @@
-import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import React, { isValidElement } from '../../src';
 import { h as preactH } from 'preact';
 
@@ -26,7 +26,7 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
+		expect(scratch.innerHTML).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
 	});
 
 	describe('isValidElement', () => {

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -26,7 +26,7 @@ describe('jsx', () => {
 		expect(jsx.props).to.have.property('className', 'foo bar');
 
 		React.render(jsx, scratch);
-		expect(scratch.innerHTML).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>'));
 	});
 
 	describe('isValidElement', () => {

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 z"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 Z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 Z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -1,5 +1,5 @@
 import React from '../../src';
-import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
+import { setupScratch, teardown, serializeHtml, sortAttributes } from '../../../test/_util/helpers';
 
 describe('svg', () => {
 
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 Z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 Z"></path></svg>'));
+		expect(serializeHtml(scratch)).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 Z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 Z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M 0 0 L 100 100"></path></svg>'));
+		expect(serializeHtml(scratch)).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M 0 0 L 100 100"></path></svg>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -27,12 +27,12 @@ describe('svg', () => {
 	it('should render SVG to DOM #1', () => {
 		const Demo = () => (
 			<svg viewBox="0 0 360 360">
-				<path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z" />
+				<path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 L 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 l 118.3 72.8V47.2H58.5z" />
 			</svg>
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 13 357.9 V 1.7 h 334.1 v 356.2 z M 58.5 47.2 v 231.4 l 124.8-74.1 118.3 72.8 V 47.2 H 58.5 z"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -1,5 +1,5 @@
 import React from '../../src';
-import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../../../test/_util/helpers';
 
 describe('svg', () => {
 
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M 347.1 357.9 L 183.3 256.5 13 357.9 V 1.7 h 334.1 v 356.2 z M 58.5 47.2 v 231.4 l 124.8-74.1 118.3 72.8 V 47.2 H 58.5 z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M 0 0 L 100 100"></path></svg>'));
 	});
 });

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -32,7 +32,7 @@ describe('svg', () => {
 		);
 		React.render(<Demo />, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 360 360"><path stroke="white" fill="black" d="M347.1 357.9L183.3 256.5 13 357.9V1.7h334.1v356.2zM58.5 47.2v231.4l124.8-74.1 118.3 72.8V47.2H58.5z"></path></svg>'));
 	});
 
 	it('should render SVG to DOM #2', () => {
@@ -43,6 +43,6 @@ describe('svg', () => {
 			</svg>
 		), scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<svg viewBox="0 0 100 100"><text text-anchor="mid">foo</text><path vector-effect="non-scaling-stroke" d="M0 0 L100 100"></path></svg>'));
 	});
 });

--- a/debug/src/devtools/custom.js
+++ b/debug/src/devtools/custom.js
@@ -187,13 +187,3 @@ export function hasDataChanged(prev, next) {
 		|| prev._dom !== next._dom
 		|| prev.ref !== next.ref;
 }
-
-/**
- * Check if a the profiling data ahs changed between vnodes
- * @param {import('../internal').VNode} next
- * @param {import('../internal').VNode} prev
- * @returns {boolean}
- */
-export function hasProfileDataChanged(prev, next) {
-	return prev.startTime!==next.startTime || prev.endTime!==next.endTime;
-}

--- a/debug/src/devtools/renderer.js
+++ b/debug/src/devtools/renderer.js
@@ -1,4 +1,4 @@
-import { getData, getChildren, getInstance, hasProfileDataChanged, hasDataChanged, isRoot } from './custom';
+import { getData, getChildren, getInstance, hasDataChanged, isRoot } from './custom';
 
 /**
  * Custom renderer tailored for Preact. It converts updated vnode trees
@@ -129,7 +129,9 @@ export class Renderer {
 
 		// The `updateProfileTimes` event is a faster version of `updated` and
 		// is processed much quicker inside the devtools extension.
-		if (!hasDataChanged(prev, vnode) && hasProfileDataChanged(prev, vnode)) {
+		if (!hasDataChanged(prev, vnode)) {
+			// Always assume profiling data has changed. When we skip an event here
+			// the devtools element picker will somehow break.
 			this.pending.push({
 				// This property is only used as an id inside the devtools. The
 				// relevant data will be read from `.data` instead which is a

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement, createElement as h, Fragment, options, Component, render } from 'preact';
-import { getDisplayName, setIn, isRoot, getData, shallowEqual, hasDataChanged, hasProfileDataChanged, getChildren } from '../../src/devtools/custom';
+import { getDisplayName, setIn, isRoot, getData, shallowEqual, hasDataChanged, getChildren } from '../../src/devtools/custom';
 import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';
 import { initDevTools } from '../../src/devtools';
 import { Renderer } from '../../src/devtools/renderer';
@@ -273,18 +273,6 @@ describe('devtools', () => {
 
 			b._component = { state: { foo: 2 }, _prevState: { foo: 1 } };
 			expect(hasDataChanged(a, b)).to.equal(true);
-		});
-	});
-
-	describe('hasProfileDataChanged', () => {
-		it('should check if data has changed', () => {
-			let a = createElement('div', { foo: 1 });
-			let b = createElement('div', { foo: 1 });
-			a.startTime = 1;
-			b.startTime = 2;
-
-			expect(hasProfileDataChanged(a, a)).to.equal(false);
-			expect(hasProfileDataChanged(a, b)).to.equal(true);
 		});
 	});
 
@@ -587,7 +575,6 @@ describe('devtools', () => {
 			checkEventReferences(prev.concat(hook.log));
 
 			expect(serialize(hook.log)).to.deep.equal([
-				{ type: 'update', component: 'Fragment' },
 				{ type: 'rootCommitted', component: 'Fragment' }
 			]);
 		});
@@ -605,7 +592,6 @@ describe('devtools', () => {
 			expect(serialize(hook.log)).to.deep.equal([
 				{ type: 'unmount', component: '#text: Hello World' },
 				{ type: 'mount', component: 'span' },
-				{ type: 'update', component: 'Fragment' },
 				{ type: 'rootCommitted', component: 'Fragment' }
 			]);
 		});
@@ -719,7 +705,6 @@ describe('devtools', () => {
 			checkEventReferences(prev.concat(hook.log));
 
 			expect(serialize(hook.log)).to.deep.equal([
-				{ type: 'update', component: 'Fragment' },
 				{ type: 'rootCommitted', component: 'Fragment' }
 			]);
 		});
@@ -734,7 +719,6 @@ describe('devtools', () => {
 				{ type: 'unmount', component: 'span' },
 				{ type: 'unmount', component: '#text: Hello World' },
 				{ type: 'update', component: 'div' },
-				{ type: 'update', component: 'Fragment' },
 				{ type: 'rootCommitted', component: 'Fragment' }
 			]);
 		});

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useState, useReducer, useEffect, useLayoutEffect, useRef } from '../../src';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
@@ -60,7 +59,7 @@ describe('combinations', () => {
 	});
 
 	it('can rerender asynchronously from within an effect', () => {
-		const didRender = spy();
+		const didRender = sinon.spy();
 
 		function Comp() {
 			const [counter, setCounter] = useState(0);
@@ -80,7 +79,7 @@ describe('combinations', () => {
 	});
 
 	it('can rerender synchronously from within a layout effect', () => {
-		const didRender = spy();
+		const didRender = sinon.spy();
 
 		function Comp() {
 			const [counter, setCounter] = useState(0);

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffect } from '../../src';
 import { useEffectAssertions } from './useEffectAssertions.test';
@@ -14,12 +13,8 @@ describe('useEffect', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
 
-	/** @type {() => void} */
-	let rerender;
-
 	beforeEach(() => {
 		scratch = setupScratch();
-		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -30,8 +25,8 @@ describe('useEffect', () => {
 
 
 	it('calls the effect immediately if another render is about to start', () => {
-		const cleanupFunction = spy();
-		const callback = spy(() => cleanupFunction);
+		const cleanupFunction = sinon.spy();
+		const callback = sinon.spy(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);
@@ -51,8 +46,8 @@ describe('useEffect', () => {
 	});
 
 	it('cancels the effect when the component get unmounted before it had the chance to run it', () => {
-		const cleanupFunction = spy();
-		const callback = spy(() => cleanupFunction);
+		const cleanupFunction = sinon.spy();
+		const callback = sinon.spy(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);

--- a/hooks/test/browser/useEffectAssertions.test.js
+++ b/hooks/test/browser/useEffectAssertions.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 
@@ -26,7 +25,7 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 
 
 	it('performs the effect after every render by default', () => {
-		const callback = spy();
+		const callback = sinon.spy();
 
 		function Comp() {
 			useEffect(callback);
@@ -42,7 +41,7 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 	});
 
 	it('performs the effect only if one of the inputs changed', () => {
-		const callback = spy();
+		const callback = sinon.spy();
 
 		function Comp(props) {
 			useEffect(callback, [props.a, props.b]);
@@ -61,7 +60,7 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 	});
 
 	it('performs the effect at mount time and never again if an empty input Array is passed', () => {
-		const callback = spy();
+		const callback = sinon.spy();
 
 		function Comp() {
 			useEffect(callback, []);
@@ -79,8 +78,8 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 	});
 
 	it('calls the cleanup function followed by the effect after each render', () => {
-		const cleanupFunction = spy();
-		const callback = spy(() => cleanupFunction);
+		const cleanupFunction = sinon.spy();
+		const callback = sinon.spy(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);
@@ -103,8 +102,8 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 	});
 
 	it('cleanups the effect when the component get unmounted if the effect was called before', () => {
-		const cleanupFunction = spy();
-		const callback = spy(() => cleanupFunction);
+		const cleanupFunction = sinon.spy();
+		const callback = sinon.spy(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions.test';
 import { useLayoutEffect } from '../../src';
@@ -12,12 +11,8 @@ describe('useLayoutEffect', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
 
-	/** @type {() => void} */
-	let rerender;
-
 	beforeEach(() => {
 		scratch = setupScratch();
-		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -34,8 +29,8 @@ describe('useLayoutEffect', () => {
 
 
 	it('calls the effect immediately after render', () => {
-		const cleanupFunction = spy();
-		const callback = spy(() => cleanupFunction);
+		const cleanupFunction = sinon.spy();
+		const callback = sinon.spy(() => cleanupFunction);
 
 		function Comp() {
 			useLayoutEffect(callback);
@@ -55,7 +50,7 @@ describe('useLayoutEffect', () => {
 	});
 
 	it('works on a nested component', () => {
-		const callback = spy();
+		const callback = sinon.spy();
 
 		function Parent() {
 			return (

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useMemo } from '../../src';
 
@@ -12,12 +11,8 @@ describe('useMemo', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
 
-	/** @type {() => void} */
-	let rerender;
-
 	beforeEach(() => {
 		scratch = setupScratch();
-		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -25,7 +20,7 @@ describe('useMemo', () => {
 	});
 
 	it('only recomputes the result when inputs change', () => {
-		let memoFunction = spy((a, b) => a + b);
+		let memoFunction = sinon.spy((a, b) => a + b);
 		const results = [];
 
 		function Comp({ a, b }) {

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,6 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useState } from '../../src';
 
@@ -42,7 +41,7 @@ describe('useState', () => {
 	});
 
 	it('can initialize the state via a function', () => {
-		const initState = spy(() => { 1; });
+		const initState = sinon.spy(() => { 1; });
 
 		function Comp() {
 			useState(initState);
@@ -59,7 +58,7 @@ describe('useState', () => {
 		let lastState;
 		let doSetState;
 
-		const Comp = spy(() => {
+		const Comp = sinon.spy(() => {
 			const [state, setState] = useState(0);
 			lastState = state;
 			doSetState = setState;
@@ -83,8 +82,6 @@ describe('useState', () => {
 	});
 
 	it('can be set by another component', () => {
-		const initState = { count: 0 };
-
 		function StateContainer() {
 			const [count, setCount] = useState(0);
 			return (<div>

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -1,5 +1,4 @@
 import { options, createElement as h, render } from 'preact';
-import sinon from 'sinon';
 import { useEffect, useState } from 'preact/hooks';
 
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -33,7 +33,7 @@ function normalizePath(str) {
 		else out += char;
 	}
 
-	return out.replace(/\s\s+/g, ' ');
+	return out.replace(/\s\s+/g, ' ').replace(/z/g, 'Z');
 }
 
 /**

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -29,9 +29,8 @@ function normalizePath(str) {
 			if (i==0) out+= char + ' ';
 			else out+= (str[i-1]==' ' ? '' : ' ') + char + (i < len -1 ? ' ' : '');
 		}
-		else {
-			out += char;
-		}
+		else if (char=='-' && str[i-1]!==' ') out+= ' ' + char;
+		else out += char;
 	}
 
 	return out.replace(/\s\s+/g, ' ');

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -141,7 +141,9 @@ export function clearOptions() {
  * @param {HTMLDivElement} scratch
  */
 export function teardown(scratch) {
-	scratch.parentNode.removeChild(scratch);
+	if (scratch) {
+		scratch.parentNode.removeChild(scratch);
+	}
 
 	if (oldOptions != null) {
 		assign(options, oldOptions);

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -116,8 +116,9 @@ function serializeDomTree(node) {
 export function sortCss(cssText) {
 	return cssText.split(';')
 		.filter(Boolean)
-		.sort((a, b) => a[0]==='-' ? -1 : b[0]==='-' ? 1 : a - b)
-		.join(';') + ';';
+		.map(s => s.replace(/^\s+|\s+$/g, '').replace(/(\s*:\s*)/g, ': '))
+		.sort((a, b) => a[0]==='-' ? -1 : b[0]==='-' ? 1 : a.localeCompare(b))
+		.join('; ') + ';';
 }
 
 /**

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -108,7 +108,10 @@ function setupDeterministicInnerHTML(element) {
  * @param {string} cssText
  */
 export function sortCss(cssText) {
-	return cssText.split(';').sort((a, b) => a[0]==='-' ? a : a - b).join(';');
+	return cssText.split(';')
+		.filter(Boolean)
+		.sort((a, b) => a[0]==='-' ? -1 : b[0]==='-' ? 1 : a - b)
+		.join(';') + ';';
 }
 
 /**

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -67,3 +67,15 @@ export const mixedArrayHTML = '0ab<span>c</span>def1';
 export function clear(obj) {
 	Object.keys(obj).forEach(key => delete obj[key]);
 }
+
+/**
+ * Hacky normalization of attribute order across browsers.
+ * @param {string} html
+ */
+export function sortAttributes(html) {
+	return html.replace(/<([a-z0-9-]+)((?:\s[a-z0-9:_.-]+=".*?")+)((?:\s*\/)?>)/gi, (s, pre, attrs, after) => {
+		let list = attrs.match(/\s[a-z0-9:_.-]+=".*?"/gi).sort( (a, b) => a>b ? 1 : -1 );
+		if (~after.indexOf('/')) after = '></'+pre+'>';
+		return '<' + pre + list.join('') + after;
+	});
+}

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -76,6 +76,14 @@ function setupDeterministicInnerHTML(element) {
 }
 
 /**
+ * Sort a cssText alphabetically.
+ * @param {string} cssText
+ */
+export function sortCss(cssText) {
+	return cssText.split(';').sort((a, b) => a[0]==='-' ? a : a - b).join(';');
+}
+
+/**
  * Setup the test environment
  * @returns {HTMLDivElement}
  */

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -110,6 +110,23 @@ function serializeDomTree(node) {
 }
 
 /**
+ * Normalize event creation in browsers
+ * @param {string} name
+ * @returns {Event}
+ */
+export function createEvent(name) {
+	// Modern browsers
+	if (typeof Event==='function') {
+		return new Event(name);
+	}
+
+	// IE 11...
+	let event = document.createEvent('Event');
+	event.initEvent(name, true, true);
+	return event;
+}
+
+/**
  * Sort a cssText alphabetically.
  * @param {string} cssText
  */

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -4,6 +4,25 @@ import { clearLog, getLog } from './logCall';
 
 /** @jsx h */
 
+export function supportsPassiveEvents() {
+	let supported = false;
+	try {
+		let options = {
+			get passive() {
+				supported = true;
+				return undefined;
+			}
+		};
+
+		window.addEventListener('test', options, options);
+		window.removeEventListener('test', options, options);
+	}
+	catch (err) {
+		supported = false;
+	}
+	return supported;
+}
+
 
 const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -23,6 +23,11 @@ export function supportsPassiveEvents() {
 	return supported;
 }
 
+export function supportsDataList() {
+	return 'list' in document.createElement('input') &&
+		Boolean(document.createElement('datalist') &&
+		'HTMLDataListElement' in window);
+}
 
 const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/;
 

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1,6 +1,6 @@
 import { createElement as h, render, Component, Fragment } from '../../src/index';
 import { setupRerender } from 'preact/test-utils';
-import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML, serializeHtml } from '../_util/helpers';
 
 /** @jsx h */
 
@@ -923,7 +923,7 @@ describe('Components', () => {
 				foo: 'bar'
 			});
 
-			expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div foo="bar" j="2" i="2">inner</div>'));
+			expect(serializeHtml(scratch)).to.equal(sortAttributes('<div foo="bar" j="2" i="2">inner</div>'));
 
 			// update & flush
 			doRender();
@@ -965,7 +965,7 @@ describe('Components', () => {
 			doRender();
 			rerender();
 
-			expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div foo="bar" j="4" i="5">inner</div>'));
+			expect(serializeHtml(scratch)).to.equal(sortAttributes('<div foo="bar" j="4" i="5">inner</div>'));
 		});
 
 		it('should resolve intermediary functional component', () => {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -1,5 +1,5 @@
 import { createElement, hydrate, Fragment } from '../../src/index';
-import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
+import { setupScratch, teardown, sortAttributes, serializeHtml } from '../_util/helpers';
 import { ul, li, div } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
@@ -138,7 +138,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
+		expect(serializeHtml(scratch)).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -138,7 +138,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
+		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -138,7 +138,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
+		expect(sortAttributes(scratch.innerHTML)).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -1,5 +1,5 @@
 import { createElement, hydrate, Fragment } from '../../src/index';
-import { setupScratch, teardown } from '../_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
 import { ul, li, div } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
@@ -138,7 +138,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(scratch.innerHTML).to.equal('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>');
+		expect(scratch.innerHTML).to.equal(sortAttributes('<div><span same-value="foo" different-value="b" new-value="c">Test</span></div>'));
 		expect(getLog()).to.deep.equal([
 			'<span>Test.setAttribute(different-value, b)',
 			'<span>Test.setAttribute(new-value, c)',

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,7 +1,6 @@
 import { createElement as h, Component, render } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
-import { spy } from 'sinon';
 
 /** @jsx h */
 
@@ -68,7 +67,7 @@ describe('keys', () => {
 
 	// https://fb.me/react-special-props
 	it('should not pass key in props', () => {
-		const Foo = spy(() => null);
+		const Foo = sinon.spy(() => null);
 		render(<Foo key="foo" />, scratch);
 		expect(Foo.args[0][0]).to.deep.equal({});
 	});

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -253,15 +253,15 @@ describe('render()', () => {
 
 		test('2');
 		test(false);
-		expect(scratch).to.have.property('innerHTML', '<div><input><table border="false"></table></div>', 'for false');
+		expect(scratch.innerHTML).to.equal('<div><input><table border="false"></table></div>', 'for false');
 
 		test('3');
 		test(null);
-		expect(scratch).to.have.property('innerHTML', '<div><input><table border=""></table></div>', 'for null');
+		expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for null');
 
 		test('4');
 		test(undefined);
-		expect(scratch).to.have.property('innerHTML', '<div><input><table border=""></table></div>', 'for undefined');
+		expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for undefined');
 	});
 
 	// Test for developit/preact#651
@@ -372,14 +372,14 @@ describe('render()', () => {
 
 			let root = scratch.firstChild;
 			let { style } = root;
-			expect(style).to.have.property('color').that.equals('rgb(255, 255, 255)');
-			expect(style).to.have.property('gridRowStart', '1');
-			expect(style).to.have.property('background').that.contains('rgb(255, 100, 0)');
-			expect(style).to.have.property('backgroundPosition').that.equals('10px 10px');
-			expect(style).to.have.property('backgroundSize', 'cover');
-			expect(style).to.have.property('padding', '5px');
-			expect(style).to.have.property('top', '100px');
-			expect(style).to.have.property('left', '100%');
+			expect(style.color).to.equal('rgb(255, 255, 255)');
+			expect(style.gridRowStart).to.equal('1');
+			expect(style.background).to.contain('rgb(255, 100, 0)');
+			expect(style.backgroundPosition).to.equal('10px 10px');
+			expect(style.backgroundSize).to.equal('cover');
+			expect(style.padding).to.equal('5px');
+			expect(style.top).to.equal('100px');
+			expect(style.left).to.equal('100%');
 		});
 
 		it('should replace previous style objects', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -412,11 +412,14 @@ describe('render()', () => {
 			expect(style).to.have.property('zIndex').that.equals('');
 		});
 
-		it('should support css custom properties', () => {
-			render(<div style={{ '--foo': 'red', color: 'var(--foo)' }}>test</div>, scratch);
-			expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo:red; color: var(--foo);');
-			expect(window.getComputedStyle(scratch.firstChild).color).to.equal('rgb(255, 0, 0)');
-		});
+		// Skip test if the currently running browser doesn't support CSS Custom Properties
+		if (window.CSS && CSS.supports('color', 'var(--fake-var)')) {
+			it('should support css custom properties', () => {
+				render(<div style={{ '--foo': 'red', color: 'var(--foo)' }}>test</div>, scratch);
+				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo:red; color: var(--foo);');
+				expect(window.getComputedStyle(scratch.firstChild).color).to.equal('rgb(255, 0, 0)');
+			});
+		}
 	});
 
 	describe('event handling', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -554,8 +554,10 @@ describe('render()', () => {
 					expect(focus, 'focus').to.have.been.calledOnce;
 
 					// IE doesn't set it
-					expect(click).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
-					expect(focus).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
+					if (!/Edge/.test(navigator.userAgent)) {
+						expect(click).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
+						expect(focus).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
+					}
 				}
 			});
 		}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -373,13 +373,17 @@ describe('render()', () => {
 			let root = scratch.firstChild;
 			let { style } = root;
 			expect(style.color).to.equal('rgb(255, 255, 255)');
-			expect(style.gridRowStart).to.equal('1');
 			expect(style.background).to.contain('rgb(255, 100, 0)');
 			expect(style.backgroundPosition).to.equal('10px 10px');
 			expect(style.backgroundSize).to.equal('cover');
 			expect(style.padding).to.equal('5px');
 			expect(style.top).to.equal('100px');
 			expect(style.left).to.equal('100%');
+
+			// Only check for this in browsers that support css grids
+			if (typeof scratch.style.grid=='string') {
+				expect(style.gridRowStart).to.equal('1');
+			}
 		});
 
 		it('should replace previous style objects', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -2,7 +2,7 @@
 
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss, serializeHtml } from '../_util/helpers';
 
 /** @jsx h */
 
@@ -276,7 +276,7 @@ describe('render()', () => {
 
 	it('should apply string attributes', () => {
 		render(<div foo="bar" data-foo="databar" />, scratch);
-		expect(scratch.innerHTML).to.equal('<div data-foo="databar" foo="bar"></div>');
+		expect(serializeHtml(scratch)).to.equal('<div data-foo="databar" foo="bar"></div>');
 	});
 
 	it('should not serialize function props as attributes', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -418,7 +418,7 @@ describe('render()', () => {
 		if (window.CSS && CSS.supports('color', 'var(--fake-var)')) {
 			it('should support css custom properties', () => {
 				render(<div style={{ '--foo': 'red', color: 'var(--foo)' }}>test</div>, scratch);
-				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo:red; color: var(--foo);');
+				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo: red; color: var(--foo);');
 				expect(window.getComputedStyle(scratch.firstChild).color).to.equal('rgb(255, 0, 0)');
 			});
 		}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -2,7 +2,7 @@
 
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss, serializeHtml, supportsPassiveEvents } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss, serializeHtml, supportsPassiveEvents, supportsDataList } from '../_util/helpers';
 
 /** @jsx h */
 
@@ -701,21 +701,25 @@ describe('render()', () => {
 	});
 
 	// Discussion: https://github.com/developit/preact/issues/287
-	('HTMLDataListElement' in window ? it : xit)('should allow <input list /> to pass through as an attribute', () => {
-		render((
-			<div>
-				<input type="range" min="0" max="100" list="steplist" />
-				<datalist id="steplist">
-					<option>0</option>
-					<option>50</option>
-					<option>100</option>
-				</datalist>
-			</div>
-		), scratch);
+	// <datalist> is not supported in Safari, even though the element
+	// constructor is present
+	if (supportsDataList()) {
+		it('should allow <input list /> to pass through as an attribute', () => {
+			render((
+				<div>
+					<input type="range" min="0" max="100" list="steplist" />
+					<datalist id="steplist">
+						<option>0</option>
+						<option>50</option>
+						<option>100</option>
+					</datalist>
+				</div>
+			), scratch);
 
-		let html = scratch.firstElementChild.firstElementChild.outerHTML;
-		expect(sortAttributes(html)).to.equal(sortAttributes('<input type="range" min="0" max="100" list="steplist">'));
-	});
+			let html = scratch.firstElementChild.firstElementChild.outerHTML;
+			expect(sortAttributes(html)).to.equal(sortAttributes('<input type="range" min="0" max="100" list="steplist">'));
+		});
+	}
 
 	it('should not execute append operation when child is at last', () => {
 		// See developit/preact#717 for discussion about the issue this addresses

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -393,7 +393,7 @@ describe('render()', () => {
 			expect(style.cssText).to.equal('display: inline;');
 			expect(style).to.have.property('display').that.equals('inline');
 			expect(style).to.have.property('color').that.equals('');
-			expect(style).to.have.property('zIndex').that.equals('');
+			expect(style.zIndex.toString()).to.equal('');
 
 			render(<div style={{ color: 'rgb(0, 255, 255)', zIndex: '3' }}>test</div>, scratch);
 
@@ -401,7 +401,9 @@ describe('render()', () => {
 			expect(style.cssText).to.equal('color: rgb(0, 255, 255); z-index: 3;');
 			expect(style).to.have.property('display').that.equals('');
 			expect(style).to.have.property('color').that.equals('rgb(0, 255, 255)');
-			expect(style).to.have.property('zIndex').that.equals('3');
+
+			// IE stores numeric z-index values as a number
+			expect(style.zIndex.toString()).to.equal('3');
 
 			render(<div style={{ color: 'rgb(0, 255, 255)', display: 'inline' }}>test</div>, scratch);
 
@@ -409,7 +411,7 @@ describe('render()', () => {
 			expect(style.cssText).to.equal('color: rgb(0, 255, 255); display: inline;');
 			expect(style).to.have.property('display').that.equals('inline');
 			expect(style).to.have.property('color').that.equals('rgb(0, 255, 255)');
-			expect(style).to.have.property('zIndex').that.equals('');
+			expect(style.zIndex.toString()).to.equal('');
 		});
 
 		// Skip test if the currently running browser doesn't support CSS Custom Properties

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -2,7 +2,7 @@
 
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss, serializeHtml } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss, serializeHtml, supportsPassiveEvents } from '../_util/helpers';
 
 /** @jsx h */
 
@@ -531,31 +531,34 @@ describe('render()', () => {
 			expect(click).not.to.have.been.called;
 		});
 
-		it('should use capturing for event props ending with *Capture', () => {
-			let click = sinon.spy(),
-				focus = sinon.spy();
+		// Skip test if browser doesn't support passive events
+		if (supportsPassiveEvents()) {
+			it('should use capturing for event props ending with *Capture', () => {
+				let click = sinon.spy(),
+					focus = sinon.spy();
 
-			render((
-				<div onClickCapture={click} onFocusCapture={focus}>
-					<button />
-				</div>
-			), scratch);
+				render((
+					<div onClickCapture={click} onFocusCapture={focus}>
+						<button />
+					</div>
+				), scratch);
 
-			let root = scratch.firstChild;
-			root.firstElementChild.click();
-			root.firstElementChild.focus();
+				let root = scratch.firstChild;
+				root.firstElementChild.click();
+				root.firstElementChild.focus();
 
-			expect(click, 'click').to.have.been.calledOnce;
+				expect(click, 'click').to.have.been.calledOnce;
 
-			if (DISABLE_FLAKEY!==true) {
-				// Focus delegation requires a 50b hack I'm not sure we want to incur
-				expect(focus, 'focus').to.have.been.calledOnce;
+				if (DISABLE_FLAKEY!==true) {
+					// Focus delegation requires a 50b hack I'm not sure we want to incur
+					expect(focus, 'focus').to.have.been.calledOnce;
 
-				// IE doesn't set it
-				expect(click).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
-				expect(focus).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
-			}
-		});
+					// IE doesn't set it
+					expect(click).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
+					expect(focus).to.have.been.calledWithMatch({ eventPhase: 0 });		// capturing
+				}
+			});
+		}
 	});
 
 	describe('dangerouslySetInnerHTML', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -2,7 +2,7 @@
 
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML, sortCss } from '../_util/helpers';
 
 /** @jsx h */
 
@@ -418,7 +418,7 @@ describe('render()', () => {
 
 		it('should support css custom properties', () => {
 			render(<div style={{ '--foo': 'red', color: 'var(--foo)' }}>test</div>, scratch);
-			expect(scratch.firstChild.style.cssText).to.equal('--foo:red; color: var(--foo);');
+			expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo:red; color: var(--foo);');
 			expect(window.getComputedStyle(scratch.firstChild).color).to.equal('rgb(255, 0, 0)');
 		});
 	});

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -276,15 +276,7 @@ describe('render()', () => {
 
 	it('should apply string attributes', () => {
 		render(<div foo="bar" data-foo="databar" />, scratch);
-
-		let div = scratch.childNodes[0];
-		expect(div.attributes.length).to.equal(2);
-
-		expect(div.attributes[0].name).to.equal('foo');
-		expect(div.attributes[0].value).to.equal('bar');
-
-		expect(div.attributes[1].name).to.equal('data-foo');
-		expect(div.attributes[1].value).to.equal('databar');
+		expect(scratch.innerHTML).to.equal('<div data-foo="databar" foo="bar"></div>');
 	});
 
 	it('should not serialize function props as attributes', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -241,28 +241,32 @@ describe('render()', () => {
 		expect(root.children[3]).to.have.property('value', '');
 	});
 
-	it('should not clear falsy DOM properties', () => {
-		function test(val) {
-			render((
-				<div>
-					<input value={val} />
-					<table border={val} />
-				</div>
-			), scratch);
-		}
+	// IE or IE Edge will throw when attribute values don't conform to the
+	// spec. That's the correct behaviour, but bad for this test...
+	if (!/(Edge|MSIE|Trident)/.test(navigator.userAgent)) {
+		it('should not clear falsy DOM properties', () => {
+			function test(val) {
+				render((
+					<div>
+						<input value={val} />
+						<table border={val} />
+					</div>
+				), scratch);
+			}
 
-		test('2');
-		test(false);
-		expect(scratch.innerHTML).to.equal('<div><input><table border="false"></table></div>', 'for false');
+			test('2');
+			test(false);
+			expect(scratch.innerHTML).to.equal('<div><input><table border="false"></table></div>', 'for false');
 
-		test('3');
-		test(null);
-		expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for null');
+			test('3');
+			test(null);
+			expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for null');
 
-		test('4');
-		test(undefined);
-		expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for undefined');
-	});
+			test('4');
+			test(undefined);
+			expect(scratch.innerHTML).to.equal('<div><input><table border=""></table></div>', 'for undefined');
+		});
+	}
 
 	// Test for developit/preact#651
 	it('should set enumerable boolean attribute', () => {

--- a/test/browser/svg.test.js
+++ b/test/browser/svg.test.js
@@ -1,18 +1,7 @@
 import { createElement as h, render } from '../../src/index';
-import { setupScratch, teardown } from '../_util/helpers';
+import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
 
 /** @jsx h */
-
-
-// hacky normalization of attribute order across browsers.
-function sortAttributes(html) {
-	return html.replace(/<([a-z0-9-]+)((?:\s[a-z0-9:_.-]+=".*?")+)((?:\s*\/)?>)/gi, (s, pre, attrs, after) => {
-		let list = attrs.match(/\s[a-z0-9:_.-]+=".*?"/gi).sort( (a, b) => a>b ? 1 : -1 );
-		if (~after.indexOf('/')) after = '></'+pre+'>';
-		return '<' + pre + list.join('') + after;
-	});
-}
-
 
 describe('svg', () => {
 	let scratch;

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -4,3 +4,17 @@ import 'core-js/es6/promise';
 import 'core-js/fn/array/fill';
 import 'core-js/fn/array/from';
 import 'core-js/fn/object/assign';
+
+// Fix Function#name on browsers that do not support it (IE).
+// Taken from: https://stackoverflow.com/a/17056530/755391
+if (!(function f() {}).name) {
+	Object.defineProperty(Function.prototype, 'name', {
+		get() {
+			let name = (this.toString().match(/^function\s*([^\s(]+)/) || [])[1];
+			// For better performance only parse once, and then cache the
+			// result through a new accessor for repeated access.
+			Object.defineProperty(this, 'name', { value: name });
+			return name;
+		}
+	});
+}

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -3,6 +3,8 @@ import 'core-js/es6/map';
 import 'core-js/es6/promise';
 import 'core-js/fn/array/fill';
 import 'core-js/fn/array/from';
+import 'core-js/fn/array/find';
+import 'core-js/fn/array/includes';
 import 'core-js/fn/object/assign';
 
 // Fix Function#name on browsers that do not support it (IE).

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -5,6 +5,7 @@ import 'core-js/fn/array/fill';
 import 'core-js/fn/array/from';
 import 'core-js/fn/array/find';
 import 'core-js/fn/array/includes';
+import 'core-js/fn/string/includes';
 import 'core-js/fn/object/assign';
 
 // Fix Function#name on browsers that do not support it (IE).

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -1,5 +1,6 @@
 // ES2015 APIs used by developer tools integration
 import 'core-js/es6/map';
+import 'core-js/es6/promise';
 import 'core-js/fn/array/fill';
 import 'core-js/fn/array/from';
 import 'core-js/fn/object/assign';


### PR DESCRIPTION
- [x] sort DOM attributes
- [x] sort `cssText`
- [x] make svg tests deterministic
- [x] make devtools tests deterministic
- [x] ~~Skip devtools tests in non-chrome browsers (maybe keep Firefox?)~~
- [x] Skip css-grid tests in browsers that don't support it
- [x] Sort css with CSS Custom Properties
- [x] IE11: Fix `parentNode` is undefined or null error
- [x] IE11: Fix return value of `Object.getOwnPropertyDescriptor` being undefined
- [x] IE11: Add `Promise` polyfill
- [x] IE11: Add polyfill for `Function.name`
- [x] Normalize event creation across all browsers in tests
- [x] Safari: Fails on `<input list>` test
- [x] Browsers throwing on falsy attribute values that are not valid per spec
- [x] Drop commit with failed `Object.getOwnPropertyDescriptor` polyfill
- [x] Drop saucelabs hack