### PR TITLE
Fix incorrect this binding for setState callback

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -158,7 +158,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 		newVNode._dom = dom;
 
 		if (c!=null) {
-			while (p=c._renderCallbacks.pop()) p();
+			while (p=c._renderCallbacks.pop()) p.call(c);
 
 			// Don't call componentDidUpdate on mount or when we bailed out via
 			// `shouldComponentUpdate`

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -1734,6 +1734,27 @@ describe('Lifecycle methods', () => {
 			rerender();
 			expect(renderSpy).to.not.be.called;
 		});
+
+		it('should call callback with correct this binding', () => {
+			let inst;
+			let updateState;
+			class Foo extends Component {
+				constructor() {
+					super();
+					updateState = () => this.setState({}, this.onUpdate);
+				}
+
+				onUpdate() {
+					inst = this;
+				}
+			}
+
+			render(<Foo />, scratch);
+			updateState();
+			rerender();
+
+			expect(inst).to.be.instanceOf(Foo);
+		});
 	});
 
 	describe('#componentDidCatch', () => {


### PR DESCRIPTION
This PR fixes an issue where the `callback` that can be passed to `setState` was called without any `this` binding.

Adds `+3` bytes (`fn.apply()` would add 5 bytes) :tada: 
Fixes #1342 .