### PR TITLE
Fix operator precedence (React.memo)

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -292,9 +292,9 @@ function memo(c, comparer) {
 	}
 
 	function Memoed(props, context) {
-		this.shouldComponentUpdate = this.shouldComponentUpdate || comparer!=null
-			? shouldUpdate
-			: PureComponent.prototype.shouldComponentUpdate;
+		this.shouldComponentUpdate =
+			this.shouldComponentUpdate ||
+			(comparer ? shouldUpdate : PureComponent.prototype.shouldComponentUpdate);
 		return c.call(this, props, context);
 	}
 	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';


### PR DESCRIPTION

```js
function memo(c, comparer) {
	// ...
	function Memoed(props, context) {
		this.shouldComponentUpdate = this.shouldComponentUpdate || comparer!=null
					? shouldUpdate
					: PureComponent.prototype.shouldComponentUpdate;
		return c.call(this, props, context);
	}
	// ...
}
```

This is evaluated as:

```js
(this.shouldComponentUpdate || comparer!=null)
	? shouldUpdate
	: PureComponent.prototype.shouldComponentUpdate
```

but should be:

```js
this.shouldComponentUpdate ||
(comparer!=null ? shouldUpdate : PureComponent.prototype.shouldComponentUpdate)
```

and, `!!comparer` is enough for checking undefined.

-------------------

refs: https://github.com/developit/preact/blob/753d8849997612f2fa3d168a28ff4dfba65b39bc/compat/src/index.js#L295-297