### PR TITLE
Dont leak Text vnodes out of toChildArray

### DIFF
--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -43,7 +43,7 @@ describe('Children', () => {
 
 		it('should only allow 1 child', () => {
 			render(<Foo>foo</Foo>, scratch);
-			expect(actual.text).to.equal('foo');
+			expect(actual).to.equal('foo');
 		});
 
 		it('should throw if no children are passed', () => {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -131,7 +131,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
  */
 function getVNodeChildren(vnode) {
 	if (vnode._children==null) {
-		toChildArray(vnode.props.children, vnode._children=[]);
+		toChildArray(vnode.props.children, vnode._children=[], coerceToVNode);
 	}
 	return vnode._children;
 }
@@ -142,7 +142,7 @@ function getVNodeChildren(vnode) {
  * children of a virtual node
  * @param {Array<import('../internal').VNode | null>} [flattened] An flat array of children to modify
  */
-export function toChildArray(children, flattened) {
+export function toChildArray(children, flattened, map) {
 	if (flattened == null) flattened = [];
 	if (children==null || typeof children === 'boolean') {}
 	else if (Array.isArray(children)) {
@@ -151,7 +151,7 @@ export function toChildArray(children, flattened) {
 		}
 	}
 	else {
-		flattened.push(coerceToVNode(children));
+		flattened.push(map ? map(children) : children);
 	}
 
 	return flattened;

--- a/test/browser/toChildArray.test.js
+++ b/test/browser/toChildArray.test.js
@@ -71,18 +71,16 @@ describe('props.children', () => {
 
 		expect(children).to.be.an('array');
 		expect(children).to.have.lengthOf(1);
-		expect(children[0].type).to.be.null;
-		expect(children[0].text).to.equal('text');
+		expect(children[0]).to.equal('text');
 		expect(scratch.innerHTML).to.equal('<div>text</div>');
 	});
 
 	it('returns an array containing a VNode with a number child', () => {
-		render(<Foo>1</Foo>, scratch);
+		render(<Foo>{1}</Foo>, scratch);
 
 		expect(children).to.be.an('array');
 		expect(children).to.have.lengthOf(1);
-		expect(children[0].type).to.be.null;
-		expect(children[0].text).to.equal('1');
+		expect(children[0]).to.equal(1);
 		expect(scratch.innerHTML).to.equal('<div>1</div>');
 	});
 
@@ -108,13 +106,11 @@ describe('props.children', () => {
 		render(<Foo>0<span /><input /><div />1</Foo>, scratch);
 
 		expect(children).to.be.an('array');
-		expect(children[0].type).to.equal(null);
-		expect(children[0].text).to.equal('0');
+		expect(children[0]).to.equal('0');
 		expect(children[1].type).to.equal('span');
 		expect(children[2].type).to.equal('input');
 		expect(children[3].type).to.equal('div');
-		expect(children[4].type).to.equal(null);
-		expect(children[4].text).to.equal('1');
+		expect(children[4]).to.equal('1');
 		expect(scratch.innerHTML).to.equal(`<div>0<span></span><input><div></div>1</div>`);
 	});
 
@@ -147,8 +143,7 @@ describe('props.children', () => {
 			let actualChild = children[i];
 
 			if (typeof originalChild == 'string' || typeof originalChild == 'number') {
-				expect(actualChild.type).to.be.null;
-				expect(actualChild.text).to.equal(originalChild);
+				expect(actualChild).to.equal(originalChild);
 			}
 			else {
 				expect(actualChild.type).to.equal(originalChild.type);
@@ -177,8 +172,7 @@ describe('props.children', () => {
 		expect(scratch.innerHTML).to.equal('<div>0123456789</div>');
 
 		for (let i = 0; i < flatList.length; i++) {
-			expect(children[i].type).to.be.null;
-			expect(children[i].text).to.equal(flatList[i]);
+			expect(children[i]).to.equal(flatList[i]);
 		}
 	});
 });


### PR DESCRIPTION
before:
```js
const vnode = <div>a</div>;
toChildArray(vnode.props.children) // [{ text: 'a' }]
```

after:
```js
const vnode = <div>a</div>;
toChildArray(vnode.props.children) // ['a']
```

+7b