### PR TITLE
Fix impossible type arguments with static methods

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,8 +99,15 @@ declare namespace preact {
 		static displayName?: string;
 		static defaultProps?: any;
 		static contextType?: PreactContext<any>;
-		static getDerivedStateFromProps?<P, S>(props: P, state: S): Partial<S>;
-		static getDerivedStateFromError?<S>(error: any): Partial<S>;
+
+		// Static members cannot reference class type parameters. This is not
+		// supported in TypeScript. Reusing the same type arguments from `Component`
+		// will lead to an impossible state where one cannot satisfy the type
+		// constraint under no circumstances, see #1356.In general type arguments
+		// seem to be a bit buggy and not supported well at the time of this
+		// writing with TS 3.3.3333.
+		static getDerivedStateFromProps?(props: Readonly<object>, state: Readonly<object>): object;
+		static getDerivedStateFromError?(error: any): object;
 
 		state: Readonly<S>;
 		props: RenderableProps<P>;

--- a/test/ts/Component-test.tsx
+++ b/test/ts/Component-test.tsx
@@ -97,6 +97,25 @@ class RandomChildrenComponent extends Component<RandomChildrenComponenProps> {
 	}
 }
 
+class StaticComponent extends Component<SimpleComponentProps, SimpleState> {
+	static getDerivedStateFromProps(props: SimpleComponentProps, state: SimpleState): Partial<SimpleState> {
+		return {
+			...props,
+			...state
+		}
+	}
+
+	static getDerivedStateFromError(err: Error) {
+		return {
+			name: err.message
+		};
+	}
+
+	render() {
+		return null;
+	}
+}
+
 describe("Component", () => {
 	const component = new SimpleComponent({ initialName: "da name" });
 


### PR DESCRIPTION
Okay, so I had enough time to play around with it during my lunch break and the situation is quite nasty. When you put the relevant sections of our definitions into the [TypeScript playground](https://www.typescriptlang.org/play/index.html#src=class%20Component%3CP%2C%20S%3E%20%7B%0A%20%20static%20getDerivedStateFromProps(props%3A%20P%2C%20state%3A%20S)%3A%20any%20%7B%0A%20%20%20%20%0A%20%20%7D%0A%7D), you'll get a more helpful error message:

```
Static members cannot reference class type parameters.
```

Seems fair, so I switched to using new type arguments for our static functions:

```ts
abstract class Component<P, S> {
  static getDerivedStateFromProps?<P2, S2>(props: Readonly<P2>, state: Readonly<S2>): Partial<S2>;

  // ...
}
```

With this the definition won't show any errors anymore, but still remains impossible to employ when extending `Component`. TS doesn't recognise any type parameters and keeps complaining that they don't match. At this point it's getting deeper and deepr into the rabbit hole!

So I had a hard look again to what the `@types/react` package does and it turns out they leave both `getDerivedStateFromProps` and `getDerivedStateFromError` untyped. The only mention is [an interface](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/480aadcbb3d1225f1a8a768ecad4724ee454c97a/types/react/index.d.ts#L552) which is similarly used like our [ComponentConstructor](https://github.com/developit/preact/blob/15d4d07d93ff5846e825da4ea81a14fb03327bbd/src/index.d.ts#L72) interface.

But instead of leaving it completely untyped this PR loosens the types a bit making it possible for the language server to use it for autocompletion and other IDE features 👍 This the best compromise we can make, because this issue can only be properly fixed in TS.

Fixes #1356 .