### PR TITLE
Remove double Promise on defer initialization

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -108,7 +108,7 @@ let q = [];
  * Asynchronously schedule a callback
  * @type {(cb) => void}
  */
-const defer = typeof Promise=='function' ? Promise.resolve().then.bind(Promise.resolve()) : setTimeout;
+const defer = typeof Promise=='function' ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout;
 
 /*
  * The value of `Component.debounce` must asynchronously invoke the passed in callback. It is


### PR DESCRIPTION
This PR changes the `defer` function so that it only needs one `Promise` on creation. Thanks and credits go to @bmeurer for making that suggestion at https://github.com/developit/preact/pull/911#issuecomment-446704485 🎉👍 

Adds `+1` byte (imo we can take that hit).