### PR TITLE
editorconfig: **/manlge.json newlines too

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,5 @@ trim_trailing_whitespace = false
 # Uglify (or some other tool) always rewrites this file
 # without a final newline on build, so disabling that
 # editorconfig feature specifically for this file
-[mangle.json]
+[mangle.json,**/mangle.json]
 insert_final_newline = false


### PR DESCRIPTION
tweak editorconfig to deal with trailing newlines in nested mangle.json files