### PR TITLE
Move devtools prevState injection into DevTools.

### DIFF
--- a/debug/src/devtools/index.js
+++ b/debug/src/devtools/index.js
@@ -1,4 +1,4 @@
-import { options, Fragment } from 'preact';
+import { options, Component, Fragment } from 'preact';
 import { Renderer } from './renderer';
 
 /**
@@ -152,6 +152,18 @@ export function initDevTools() {
 		if (prevBeforeUnmount!=null) prevBeforeUnmount(vnode);
 		onCommitUnmount(vnode);
 	});
+
+	// Inject tracking into setState
+	const setState = Component.prototype.setState;
+	Component.prototype.setState = function(update, callback) {
+		// Duplicated in setState() but doesn't matter due to the guard.
+		let s = (this._nextState!==this.state && this._nextState) || (this._nextState = Object.assign({}, this.state));
+
+		// Needed in order to check if state has changed after the tree has been committed:
+		this._prevState = Object.assign({}, s);
+
+		return setState.call(this, update, callback);
+	};
 }
 
 /**

--- a/src/component.js
+++ b/src/component.js
@@ -42,10 +42,6 @@ Component.prototype.setState = function(update, callback) {
 	// only clone state when copying to nextState the first time.
 	let s = (this._nextState!==this.state && this._nextState) || (this._nextState = assign({}, this.state));
 
-	// Needed for the devtools to check if state has changed after the tree
-	// has been committed
-	this._prevState = assign({}, s);
-
 	// if update() mutates state in-place, skip the copy:
 	if (typeof update!=='function' || (update = update(s, this.props))) {
 		assign(s, update);


### PR DESCRIPTION
Just an easy way to drop `6b` in prod. Because of the `this._nextState` guard, duplicating that line in DevTools doesn't cause any changes to state updates.  It's unfortunate to have to duplicate the line though.  I had thought maybe it'd be interesting to install a setter for `Component.prototype._nextState`? But it'd have to store nextState somewhere on the instance.