### PR TITLE
Allow native preact vnodes in isValidElement

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -116,10 +116,6 @@ function upgradeToVNodes(arr, offset) {
 		if (Array.isArray(obj)) {
 			upgradeToVNodes(obj);
 		}
-		else if (obj && typeof obj==='object' && !isValidElement(obj) && ((obj.props && obj.type) || obj.text!=null)) {
-			if (obj.text) continue;
-			arr[i] = createElement(obj.type, obj.props, obj.props.children);
-		}
 	}
 }
 
@@ -133,7 +129,6 @@ function upgradeToVNodes(arr, offset) {
 function createElement(...args) {
 	upgradeToVNodes(args, 2);
 	let vnode = h(...args);
-	vnode.$$typeof = REACT_ELEMENT_TYPE;
 
 	let type = vnode.type, props = vnode.props;
 	if (typeof type!='function') {
@@ -182,7 +177,7 @@ function cloneElement(element) {
  * @returns {boolean}
  */
 function isValidElement(element) {
-	return element && element.$$typeof===REACT_ELEMENT_TYPE;
+	return element!=null && element.$$typeof===REACT_ELEMENT_TYPE;
 }
 
 /**
@@ -338,6 +333,8 @@ function forwardRef(fn) {
 
 let oldVNodeHook = options.vnode;
 options.vnode = vnode => {
+	vnode.$$typeof = REACT_ELEMENT_TYPE;
+
 	let type = vnode.type;
 	if (type!=null && type._forwarded) {
 		vnode.props.ref = vnode.ref;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -106,20 +106,6 @@ let Children = {
 };
 
 /**
- * Upgrade all found vnodes recursively
- * @param {Array} arr
- * @param {number} offset
- */
-function upgradeToVNodes(arr, offset) {
-	for (let i=offset || 0; i<arr.length; i++) {
-		let obj = arr[i];
-		if (Array.isArray(obj)) {
-			upgradeToVNodes(obj);
-		}
-	}
-}
-
-/**
  * Wrap `createElement` to apply various vnode normalizations.
  * @param {import('./internal').VNode["type"]} type The node name or Component constructor
  * @param {object | null | undefined} [props] The vnode's properties
@@ -127,7 +113,6 @@ function upgradeToVNodes(arr, offset) {
  * @returns {import('./internal').VNode}
  */
 function createElement(...args) {
-	upgradeToVNodes(args, 2);
 	let vnode = h(...args);
 
 	let type = vnode.type, props = vnode.props;

--- a/compat/test/browser/index.test.js
+++ b/compat/test/browser/index.test.js
@@ -7,6 +7,7 @@ import React, {
 	unmountComponentAtNode,
 	createFactory
 } from '../../src';
+import { createElement as preactH } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 let ce = type => document.createElement(type);
@@ -235,6 +236,16 @@ describe('preact-compat', () => {
 			let element = { foo: 42 };
 			let clone = cloneElement(element);
 			expect(clone).to.eql(element);
+		});
+
+		it('should work with jsx constructor from core', () => {
+			function Foo(props) {
+				return <div>{props.value}</div>;
+			}
+
+			let clone = cloneElement(preactH(Foo), { value: 'foo' });
+			render(clone, scratch);
+			expect(scratch.textContent).to.equal('foo');
 		});
 	});
 

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -1,5 +1,6 @@
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React from '../../src';
+import React, { isValidElement } from '../../src';
+import { h as preactH } from 'preact';
 
 describe('jsx', () => {
 
@@ -26,5 +27,23 @@ describe('jsx', () => {
 
 		React.render(jsx, scratch);
 		expect(scratch.innerHTML).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
+	});
+
+	describe('isValidElement', () => {
+		it('should check return false for invalid arguments', () => {
+			expect(isValidElement(null)).to.equal(false);
+			expect(isValidElement(false)).to.equal(false);
+			expect(isValidElement(true)).to.equal(false);
+			expect(isValidElement('foo')).to.equal(false);
+			expect(isValidElement(123)).to.equal(false);
+		});
+
+		it('should detect a preact vnode', () => {
+			expect(isValidElement(preactH('div'))).to.equal(true);
+		});
+
+		it('should detect a compat vnode', () => {
+			expect(isValidElement(React.createElement('div'))).to.equal(true);
+		});
 	});
 });


### PR DESCRIPTION
This PR fixes an issue where `compat` would bail out on standard preact `vnodes` because they didn't have the `$$typeof` property. Instead patching the `isValidElement` function [like we did before](https://github.com/developit/preact-compat/blob/ae018abbefdfeb61a0e0f7a50ac0d7c9f12940ea/src/index.js#L336) I chose to add it in `options.vnode` instead.

Removes `111 B`. :tada: 
Fixes #1349 .