### PR TITLE
use `console.error` instead of `console.log` in catchErrors

### DIFF
--- a/debug/src/devtools/index.js
+++ b/debug/src/devtools/index.js
@@ -16,7 +16,7 @@ function catchErrors(fn) {
 			/* istanbul ignore next */
 			console.error('The react devtools encountered an error');
 			/* istanbul ignore next */
-			console.log(e); // eslint-disable-line no-console
+			console.error(e); // eslint-disable-line no-console
 		}
 	};
 }


### PR DESCRIPTION
I saw the error messages with both red background and normal one. A bit weird.
Don't know why here's two forms of console. But I'd like the line to be`console.error` since it is an error object.