### PR TITLE
add autocorrect html attribute to jsx types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -494,6 +494,8 @@ declare namespace JSX {
 		async?: boolean;
 		autocomplete?: string;
 		autoComplete?: string;
+		autocorrect?: string;
+		autoCorrect?: string;
 		autofocus?: boolean;
 		autoFocus?: boolean;
 		autoPlay?: boolean;


### PR DESCRIPTION
This attribute is pretty widely used. E.g. it's described here: https://davidwalsh.name/disable-autocorrect