### PR TITLE
Don't call CSSStyleDeclaration.setProperty for style strings

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -54,12 +54,11 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 			for (let i in oldValue) {
 				if (value==null || !(i in value)) s.setProperty(i.replace(CAMEL_REG, '-'), '');
 			}
-		}
-
-		for (let i in value) {
-			v = value[i];
-			if (oldValue==null || v!==oldValue[i]) {
-				s.setProperty(i.replace(CAMEL_REG, '-'), typeof v==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (v + 'px') : v);
+			for (let i in value) {
+				v = value[i];
+				if (oldValue==null || v!==oldValue[i]) {
+					s.setProperty(i.replace(CAMEL_REG, '-'), typeof v==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (v + 'px') : v);
+				}
 			}
 		}
 	}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -319,6 +319,13 @@ describe('render()', () => {
 				.to.equal('top: 5px; position: relative;');
 		});
 
+		it('should not call CSSStyleDeclaration.setProperty for style strings', () => {
+			render(<div style="top: 5px; position: relative;" />, scratch);
+			sinon.stub(scratch.firstChild.style, 'setProperty');
+			render(<div style="top: 10px; position: absolute;" />, scratch);
+			expect(scratch.firstChild.style.setProperty).to.not.be.called;
+		});
+
 		it('should properly switch from string styles to object styles and back', () => {
 			render((
 				<div style="display: inline;">test</div>


### PR DESCRIPTION
Avoids unnecessary calls to `setProperty` for style strings. 

- Browsers and JSDOM will ignore these but workerDOM (currently) doesn't since it lacks a property whitelist.
- Minor perf boost by avoiding loop of `value.length` and some regex ops.

/cc @kristoferbaxter 