### PR TITLE
Fix Element.prototype.remove not available in IE11 

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,6 +1,7 @@
 import { diff, unmount } from './index';
 import { coerceToVNode, Fragment } from '../create-element';
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
+import { removeNode } from '../util';
 
 /**
  * Diff the children of a virtual node
@@ -117,7 +118,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	}
 
 	// Remove children that are not part of any vnode. Only used by `hydrate`
-	if (excessDomChildren!=null && newParentVNode.type!==Fragment) for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) excessDomChildren[i].remove();
+	if (excessDomChildren!=null && newParentVNode.type!==Fragment) for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) removeNode(excessDomChildren[i]);
 
 	// Remove remaining oldChildren if there are any.
 	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], ancestorComponent);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -306,7 +306,7 @@ export function unmount(vnode, ancestorComponent, skipRemove) {
 		applyRef(r, null, ancestorComponent);
 	}
 
-	if (!skipRemove && (skipRemove = ((r = vnode._dom)!=null))) removeNode(r);
+	if (!skipRemove && vnode._lastDomChild==null && (skipRemove = ((r = vnode._dom)!=null))) removeNode(r);
 
 	vnode._dom = vnode._lastDomChild = null;
 
@@ -325,7 +325,7 @@ export function unmount(vnode, ancestorComponent, skipRemove) {
 	}
 	else if (r = vnode._children) {
 		for (let i = 0; i < r.length; i++) {
-			unmount(r[i], ancestorComponent, skipRemove && vnode.type!==Fragment);
+			unmount(r[i], ancestorComponent, skipRemove);
 		}
 	}
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -298,7 +298,7 @@ export function applyRef(ref, value, ancestorComponent) {
  * @param {import('../internal').Component} ancestorComponent The parent
  * component to this virtual node
  */
-export function unmount(vnode, ancestorComponent) {
+export function unmount(vnode, ancestorComponent, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(vnode);
 
@@ -306,7 +306,7 @@ export function unmount(vnode, ancestorComponent) {
 		applyRef(r, null, ancestorComponent);
 	}
 
-	if ((r = vnode._dom)!=null) removeNode(r);
+	if (!skipRemove && (skipRemove = ((r = vnode._dom)!=null))) removeNode(r);
 
 	vnode._dom = vnode._lastDomChild = null;
 
@@ -321,11 +321,11 @@ export function unmount(vnode, ancestorComponent) {
 		}
 
 		r.base = r._parentDom = null;
-		if (r = r._prevVNode) unmount(r, ancestorComponent);
+		if (r = r._prevVNode) unmount(r, ancestorComponent, skipRemove);
 	}
 	else if (r = vnode._children) {
 		for (let i = 0; i < r.length; i++) {
-			unmount(r[i], ancestorComponent);
+			unmount(r[i], ancestorComponent, skipRemove && vnode.type!==Fragment);
 		}
 	}
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -297,6 +297,8 @@ export function applyRef(ref, value, ancestorComponent) {
  * @param {import('../internal').VNode} vnode The virtual node to unmount
  * @param {import('../internal').Component} ancestorComponent The parent
  * component to this virtual node
+ * @param {boolean} skipRemove Flag that indicates that a parent node of the
+ * current element is already detached from the DOM.
  */
 export function unmount(vnode, ancestorComponent, skipRemove) {
 	let r;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -3,7 +3,7 @@ import { Component, enqueueRender } from '../component';
 import { coerceToVNode, Fragment } from '../create-element';
 import { diffChildren } from './children';
 import { diffProps } from './props';
-import { assign } from '../util';
+import { assign, removeNode } from '../util';
 import options from '../options';
 
 /**
@@ -306,7 +306,7 @@ export function unmount(vnode, ancestorComponent) {
 		applyRef(r, null, ancestorComponent);
 	}
 
-	if ((r = vnode._dom)!=null) r.remove();
+	if ((r = vnode._dom)!=null) removeNode(r);
 
 	vnode._dom = vnode._lastDomChild = null;
 

--- a/src/util.js
+++ b/src/util.js
@@ -9,3 +9,12 @@ export function assign(obj, props) {
 	for (let i in props) obj[i] = props[i];
 	return /** @type {O & P} */ (obj);
 }
+
+/**
+ * Remove a child node from its parent if attached.
+ * @param {Node} node The node to remove
+ */
+export function removeNode(node) {
+	let parentNode = node.parentNode;
+	if (parentNode) parentNode.removeChild(node);
+}

--- a/src/util.js
+++ b/src/util.js
@@ -11,7 +11,9 @@ export function assign(obj, props) {
 }
 
 /**
- * Remove a child node from its parent if attached.
+ * Remove a child node from its parent if attached. This is a workaround for
+ * IE11 which doesn't support `Element.prototype.remove()`. Using this function
+ * is smaller than including a dedicated polyfill.
  * @param {Node} node The node to remove
  */
 export function removeNode(node) {

--- a/test/_util/logCall.js
+++ b/test/_util/logCall.js
@@ -28,7 +28,11 @@ export function logCall(obj, method) {
 			if (c) c += ', ';
 			c += serialize(args[i]);
 		}
-		const operation = `${serialize(this)}.${method}(${c})`;
+
+		// Normalize removeChild -> remove to keep output clean and readable
+		const operation = method!='removeChild'
+			? `${serialize(this)}.${method}(${c})`
+			: `${serialize(c)}.remove()`;
 		log.push(operation);
 		return old.apply(this, args);
 	};

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -14,6 +14,7 @@ describe('hydrate()', () => {
 	before(() => {
 		logCall(Element.prototype, 'appendChild');
 		logCall(Element.prototype, 'insertBefore');
+		logCall(Element.prototype, 'removeChild');
 		logCall(Element.prototype, 'remove');
 		logCall(Element.prototype, 'setAttribute');
 		logCall(Element.prototype, 'removeAttribute');

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -52,6 +52,7 @@ describe('keys', () => {
 	before(() => {
 		logCall(Element.prototype, 'appendChild');
 		logCall(Element.prototype, 'insertBefore');
+		logCall(Element.prototype, 'removeChild');
 		logCall(Element.prototype, 'remove');
 	});
 


### PR DESCRIPTION
This PR replaces calls to `Element.remove()` with `Element.removeChild()`. Reason being that the former is not available in IE11. I normalized the logger though because `<parent>.removeChild(foo)` is a lot harder on the eyes than `foo.remove()`. This is in particular makes it easier to see at one glance what our reconciler is doing.

I also tried if adding just the polyfill would be smaller, but it's in `6 B` bigger than the changes in this PR. It feels a lot cleaner though, so I'm wondering if we should just take the hit and keep our internals clean from any IE11 shenanigans. 

The downside would be that in IE11 every node will be removed recursively from a tree. `remove()` already detaches all sub-nodes from their parent automatically in the browser. So IE11 would be a lot slower with the polyfilled version.

This is the polyfill I tried:

```js
// IE11 Polyfill for Element.remove()
Element.prototype.remove || (Element.prototype.remove = function() {
	if (this.parentNode!=null) this.parentNode.removeChild(this);
});
```

Fixes #624 (again) 😬
Adds `+27 B`.