### PR TITLE
(refactor): use test-utils package

### DIFF
--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -1,4 +1,5 @@
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupRerender } from '../../../test-utils/src';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import React from '../../src';
 
 describe('components', () => {

--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import React from '../../src';
 

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,4 +1,5 @@
-import { setupScratch, setupRerender, teardown } from '../../../test/_util/helpers';
+import { setupRerender } from '../../../test-utils/src';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { Component, render, createElement as h, memo } from '../../src';
 
 /** @jsx h */

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { Component, render, createElement as h, memo } from '../../src';
 

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -1,6 +1,7 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement, createElement as h, Fragment, options, Component, render } from 'preact';
 import { getDisplayName, setIn, isRoot, getData, shallowEqual, hasDataChanged, hasProfileDataChanged, getChildren } from '../../src/devtools/custom';
-import { setupScratch, setupRerender, teardown, clearOptions } from '../../../test/_util/helpers';
+import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';
 import { initDevTools } from '../../src/devtools';
 import { Renderer } from '../../src/devtools/renderer';
 import { memo, forwardRef } from '../../../compat/src';

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement, createElement as h, Fragment, options, Component, render } from 'preact';
 import { getDisplayName, setIn, isRoot, getData, shallowEqual, hasDataChanged, hasProfileDataChanged, getChildren } from '../../src/devtools/custom';
 import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -1,6 +1,7 @@
-import { createElement as h, render, Component } from 'preact';
+import { setupRerender } from '../../../test-utils/src';
+import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useState, useReducer, useEffect, useLayoutEffect, useRef } from '../../src';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
 
@@ -64,7 +65,7 @@ describe('combinations', () => {
 		function Comp() {
 			const [counter, setCounter] = useState(0);
 
-			useEffect(() => { if (counter === 0) setCounter(1) });
+			useEffect(() => { if (counter === 0) setCounter(1); });
 
 			didRender(counter);
 			return null;
@@ -74,7 +75,7 @@ describe('combinations', () => {
 
 		return scheduleEffectAssert(() => {
 			rerender();
-			expect(didRender).to.have.been.calledTwice.and.calledWith(1)
+			expect(didRender).to.have.been.calledTwice.and.calledWith(1);
 		});
 	});
 
@@ -84,7 +85,7 @@ describe('combinations', () => {
 		function Comp() {
 			const [counter, setCounter] = useState(0);
 
-			useLayoutEffect(() => { if (counter === 0) setCounter(1) });
+			useLayoutEffect(() => { if (counter === 0) setCounter(1); });
 
 			didRender(counter);
 			return null;
@@ -93,7 +94,7 @@ describe('combinations', () => {
 		render(<Comp />, scratch);
 		rerender();
 
-		expect(didRender).to.have.been.calledTwice.and.calledWith(1)
+		expect(didRender).to.have.been.calledTwice.and.calledWith(1);
 	});
 
 	it('can access refs from within a layout effect callback', () => {
@@ -172,6 +173,6 @@ describe('combinations', () => {
 
 		return scheduleEffectAssert(() => {
 			expect(effectCount).to.equal(1);
-		})
+		});
 	});
 });

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/hooks/test/browser/useCallback.test.js
+++ b/hooks/test/browser/useCallback.test.js
@@ -1,6 +1,6 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
-import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useCallback } from '../../src';
 
 /** @jsx h */

--- a/hooks/test/browser/useCallback.test.js
+++ b/hooks/test/browser/useCallback.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useCallback } from '../../src';

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,6 +1,7 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffect } from '../../src';
 import { useEffectAssertions } from './useEffectAssertions.test';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/hooks/test/browser/useEffectAssertions.test.js
+++ b/hooks/test/browser/useEffectAssertions.test.js
@@ -1,6 +1,7 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 
 /** @jsx h */

--- a/hooks/test/browser/useEffectAssertions.test.js
+++ b/hooks/test/browser/useEffectAssertions.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -1,6 +1,7 @@
-import { createElement as h, render, options } from 'preact';
+import { setupRerender } from '../../../test-utils/src';
+import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions.test';
 import { useLayoutEffect } from '../../src';
 

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -1,6 +1,7 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useMemo } from '../../src';
 
 /** @jsx h */

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/hooks/test/browser/useReducer.test.js
+++ b/hooks/test/browser/useReducer.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useReducer } from '../../src';

--- a/hooks/test/browser/useReducer.test.js
+++ b/hooks/test/browser/useReducer.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useReducer } from '../../src';
 
 /** @jsx h */
@@ -27,7 +28,7 @@ describe('useReducer', () => {
 		const states = [];
 		let _dispatch;
 
-		const initState = { count: 0 }
+		const initState = { count: 0 };
 
 		function reducer(state, action) {
 			switch (action.type) {
@@ -51,7 +52,7 @@ describe('useReducer', () => {
 	});
 
 	it('can be dispatched by another component', () => {
-		const initState = { count: 0 }
+		const initState = { count: 0 };
 
 		function reducer(state, action) {
 			switch (action.type) {
@@ -61,14 +62,14 @@ describe('useReducer', () => {
 
 		function ReducerComponent() {
 			const [state, dispatch] = useReducer(reducer, initState);
-			return <div>
+			return (<div>
 				<p>Count: {state.count}</p>
 				<DispatchComponent dispatch={dispatch} />
-			</div>;
+			</div>);
 		}
 
 		function DispatchComponent(props) {
-			return <button onClick={() => props.dispatch({ type: 'increment', by: 10 })}>Increment</button>
+			return <button onClick={() => props.dispatch({ type: 'increment', by: 10 })}>Increment</button>;
 		}
 
 		render(<ReducerComponent />, scratch);

--- a/hooks/test/browser/useRef.test.js
+++ b/hooks/test/browser/useRef.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useRef } from '../../src';

--- a/hooks/test/browser/useRef.test.js
+++ b/hooks/test/browser/useRef.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useRef } from '../../src';
 
 /** @jsx h */

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,6 +1,7 @@
+import { setupRerender } from '../../../test-utils/src';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
-import { setupScratch, teardown, setupRerender } from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useState } from '../../src';
 
 /** @jsx h */
@@ -41,7 +42,7 @@ describe('useState', () => {
 	});
 
 	it('can initialize the state via a function', () => {
-		const initState = spy(() => { a: 1 })
+		const initState = spy(() => { 1; });
 
 		function Comp() {
 			useState(initState);
@@ -82,18 +83,18 @@ describe('useState', () => {
 	});
 
 	it('can be set by another component', () => {
-		const initState = { count: 0 }
+		const initState = { count: 0 };
 
 		function StateContainer() {
 			const [count, setCount] = useState(0);
-			return <div>
+			return (<div>
 				<p>Count: {count}</p>
 				<Increment increment={() => setCount(c => c + 10)} />
-			</div>;
+			</div>);
 		}
 
 		function Increment(props) {
-			return <button onClick={props.increment}>Increment</button>
+			return <button onClick={props.increment}>Increment</button>;
 		}
 
 		render(<StateContainer />, scratch);

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { spy } from 'sinon';
 import { setupScratch, teardown } from '../../../test/_util/helpers';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -152,6 +152,7 @@ module.exports = function(config) {
 				// directly
 				alias: {
 					'preact/hooks': path.join(__dirname, './hooks/src'),
+					'preact/test-utils': path.join(__dirname, './test-utils/src'),
 					preact: path.join(__dirname, './src')
 				}
 			},

--- a/test-utils/src/index.d.ts
+++ b/test-utils/src/index.d.ts
@@ -1,2 +1,2 @@
-export function setupRerender(): void;
+export function setupRerender(): () => void;
 export function act(callback: () => void): void;

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -15,17 +15,6 @@ export function setupScratch() {
 	return scratch;
 }
 
-/**
- * Setup a rerender function that will drain the queue of pending renders
- * @returns {() => void}
- */
-export function setupRerender() {
-	Component.__test__previousDebounce = options.debounceRendering;
-	options.debounceRendering = cb => Component.__test__drainQueue = cb;
-
-	return () => Component.__test__drainQueue && Component.__test__drainQueue();
-}
-
 let oldOptions = null;
 export function clearOptions() {
 	oldOptions = assign({}, options);

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1,5 +1,6 @@
 import { createElement as h, render, Component, Fragment } from '../../src/index';
-import { setupScratch, teardown, setupRerender, getMixedArray, mixedArrayHTML } from '../_util/helpers';
+import { setupRerender } from '../../test-utils/src';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
 
 /** @jsx h */
 

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1,5 +1,5 @@
 import { createElement as h, render, Component, Fragment } from '../../src/index';
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
 
 /** @jsx h */

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component, createContext } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 import { Fragment } from '../../src';
 import { i as ctxId } from '../../src/create-context';
 

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, createContext } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 import { Fragment } from '../../src';

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, Fragment, hydrate } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 import { div, span, input as inputStr } from '../_util/dom';

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component, Fragment, hydrate } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 import { div, span, input as inputStr } from '../_util/dom';
 /* eslint-disable react/jsx-boolean-value */
 

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component, Fragment } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 import { span, div, ul, ol, li } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, Fragment } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 import { span, div, ul, ol, li } from '../_util/dom';

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx h */
 

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component, createRef } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx h */
 

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, createRef } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1,6 +1,6 @@
 /* global DISABLE_FLAKEY */
 
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
 import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1,7 +1,8 @@
 /* global DISABLE_FLAKEY */
 
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, setupRerender, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
+import { setupScratch, teardown, getMixedArray, mixedArrayHTML } from '../_util/helpers';
 
 /** @jsx h */
 

--- a/test/browser/spec.test.js
+++ b/test/browser/spec.test.js
@@ -1,5 +1,6 @@
+import { setupRerender } from '../../test-utils/src';
 import { createElement as h, render, Component } from '../../src/index';
-import { setupScratch, teardown, setupRerender } from '../_util/helpers';
+import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx h */
 

--- a/test/browser/spec.test.js
+++ b/test/browser/spec.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from '../../test-utils/src';
+import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 


### PR DESCRIPTION
Use the newly created test-utils package in our tests.
This also adds a fix for the typings in test-utils