### PR TITLE
(fix) - select value not set

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -218,6 +218,7 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	isSvg = newVNode.type==='svg' || isSvg;
+	const isSelect = newVNode.type==='select';
 
 	if (dom==null && excessDomChildren!=null) {
 		for (let i=0; i<excessDomChildren.length; i++) {
@@ -258,10 +259,14 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					}
 				}
 			}
+			if (isSelect) {
+				diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
+			}
 			diffProps(dom, newVNode.props, oldProps, isSvg);
 		}
-
-		diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
+		if (!isSelect) {
+			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
+		}
 	}
 
 	return dom;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -258,10 +258,12 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					}
 				}
 			}
-			if (newVNode.props.dangerouslySetInnerHTML || oldProps.dangerouslySetInnerHTML) {
+			let oldHtml = oldProps.dangerouslySetInnerHTML;
+			let newHtml = newVNode.props.dangerouslySetInnerHTML;
+			if (newHtml || oldHtml) {
 				// Avoid re-applying the same '__html' if it did not changed between re-render
-				if (!newVNode.props.dangerouslySetInnerHTML || !oldProps.dangerouslySetInnerHTML || newVNode.props.dangerouslySetInnerHTML.__html!=oldProps.dangerouslySetInnerHTML.__html) {
-					dom.innerHTML = newVNode.props.dangerouslySetInnerHTML && newVNode.props.dangerouslySetInnerHTML.__html || '';
+				if (!newHtml || !oldHtml || newHtml.__html!=oldHtml.__html) {
+					dom.innerHTML = newHtml && newHtml.__html || '';
 				}
 			}
 			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -258,7 +258,7 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					}
 				}
 			}
-			if (newVNode.props.dangerouslySetInnerHTML) {
+			if (newVNode.props.dangerouslySetInnerHTML || oldProps.dangerouslySetInnerHTML) {
 				// Avoid re-applying the same '__html' if it did not changed between re-render
 				if (!newVNode.props.dangerouslySetInnerHTML || !oldProps.dangerouslySetInnerHTML || newVNode.props.dangerouslySetInnerHTML.__html!=oldProps.dangerouslySetInnerHTML.__html) {
 					dom.innerHTML = newVNode.props.dangerouslySetInnerHTML && newVNode.props.dangerouslySetInnerHTML.__html || '';

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -259,7 +259,6 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 				}
 			}
 			if (newVNode.props.dangerouslySetInnerHTML) {
-				console.log(newVNode.props.dangerouslySetInnerHTML, oldProps.dangerouslySetInnerHTML);
 				// Avoid re-applying the same '__html' if it did not changed between re-render
 				if (!newVNode.props.dangerouslySetInnerHTML || !oldProps.dangerouslySetInnerHTML || newVNode.props.dangerouslySetInnerHTML.__html!=oldProps.dangerouslySetInnerHTML.__html) {
 					dom.innerHTML = newVNode.props.dangerouslySetInnerHTML && newVNode.props.dangerouslySetInnerHTML.__html || '';

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -218,7 +218,6 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	isSvg = newVNode.type==='svg' || isSvg;
-	const isSelect = newVNode.type==='select';
 
 	if (dom==null && excessDomChildren!=null) {
 		for (let i=0; i<excessDomChildren.length; i++) {
@@ -259,14 +258,18 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					}
 				}
 			}
-			if (isSelect) {
-				diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
+			if (newVNode.props.dangerouslySetInnerHTML) {
+				console.log(newVNode.props.dangerouslySetInnerHTML, oldProps.dangerouslySetInnerHTML);
+				// Avoid re-applying the same '__html' if it did not changed between re-render
+				if (!newVNode.props.dangerouslySetInnerHTML || !oldProps.dangerouslySetInnerHTML || newVNode.props.dangerouslySetInnerHTML.__html!=oldProps.dangerouslySetInnerHTML.__html) {
+					dom.innerHTML = newVNode.props.dangerouslySetInnerHTML && newVNode.props.dangerouslySetInnerHTML.__html || '';
+				}
 			}
-			diffProps(dom, newVNode.props, oldProps, isSvg);
-		}
-		if (!isSelect) {
 			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
+			diffProps(dom, newVNode.props, oldProps, isSvg);
+			return dom;
 		}
+		diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
 	}
 
 	return dom;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -266,9 +266,7 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 			}
 			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
 			diffProps(dom, newVNode.props, oldProps, isSvg);
-			return dom;
 		}
-		diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
 	}
 
 	return dom;

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -63,10 +63,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 	}
 	else if (name==='dangerouslySetInnerHTML') {
-		// Avoid re-applying the same '__html' if it did not changed between re-render
-		if (!value || !oldValue || value.__html!=oldValue.__html) {
-			dom.innerHTML = value && value.__html || '';
-		}
+		return;
 	}
 	// Benchmark for comparison: https://esbench.com/bench/574c954bdb965b9a00965ac6
 	else if (name[0]==='o' && name[1]==='n') {

--- a/test/browser/select.test.js
+++ b/test/browser/select.test.js
@@ -1,0 +1,31 @@
+import { createElement as h, render } from '../../src/index';
+import { setupScratch, teardown } from '../_util/helpers';
+
+/** @jsx h */
+
+describe('Select', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should set <select> value', () => {
+		function App() {
+			return (
+				<select value="B">
+					<option value="A">A</option>
+					<option value="B">B</option>
+					<option value="C">C</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(scratch.firstChild.value).to.equal('B');
+	});
+});


### PR DESCRIPTION
This is not the ideal fix yet, but it shows what @marvinhagemeister sais, the diffing of props going first makes the value unset.
This solution is not ideal but I don't know what is changed will continue working on it but will leave this as a draft so it can be referenced from the issue to see this works.

I assume this happens because preact strips properties from the native html element and puts them into props, that way we lose the native working of value. Should we propagate value to the native element when it is a `select`? Slowly discovering the internals so pardon the naive solution atm

EDIT: tried changing to this in diffProps:

```
else if (name==='value' && isSelect) {
  console.log('setting', name, value);
  dom.setAttribute(name, value);
}
```

Turns out I was on the wrong track with that one, so it's really the children that have to be evaluated.

Fixes https://github.com/developit/preact/issues/1392

Adds `+24 B` - @marvinhagemeister 