### PR TITLE
(feature) - multi select support

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -125,8 +125,8 @@ function createElement(...args) {
 		}
 
 		if (Array.isArray(props.value) && props.multiple && type==='select') {
-			props.children.forEach((child) => {
-				if (props.value.includes(child.props.value)) {
+			toChildArray(props.children).forEach((child) => {
+				if (props.value.indexOf(child.props.value)!==-1) {
 					child.props.selected = true;
 				}
 			});

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -114,6 +114,7 @@ let Children = {
  */
 function createElement(...args) {
 	let vnode = h(...args);
+
 	let type = vnode.type, props = vnode.props;
 	if (typeof type!='function') {
 		if (props.defaultValue) {

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -114,7 +114,6 @@ let Children = {
  */
 function createElement(...args) {
 	let vnode = h(...args);
-
 	let type = vnode.type, props = vnode.props;
 	if (typeof type!='function') {
 		if (props.defaultValue) {
@@ -124,6 +123,14 @@ function createElement(...args) {
 			delete props.defaultValue;
 		}
 
+		if (Array.isArray(props.value) && props.multiple && type==='select') {
+			props.children.forEach((child) => {
+				if (props.value.includes(child.props.value)) {
+					child.props.selected = true;
+				}
+			});
+			delete props.value;
+		}
 		handleElementVNode(vnode, props);
 	}
 

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -3,7 +3,7 @@ import { render, createElement as h } from '../../src';
 
 /** @jsx h */
 
-describe.only('Select', () => {
+describe('Select', () => {
 	let scratch;
 
 	beforeEach(() => {

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -1,0 +1,32 @@
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { render, createElement as h } from '../../src';
+
+/** @jsx h */
+
+describe.only('Select', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+
+	it('should work with multiple selected (array of values)', () => {
+		function App() {
+			return (
+				<select multiple value={['B', 'C']}>
+					<option value="A">A</option>
+					<option value="B">B</option>
+					<option value="C">C</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(scratch.firstChild.value).to.equal('B');
+	});
+});

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -15,7 +15,7 @@ describe('Select', () => {
 	});
 
 
-	it('should work with multiple selected (array of values)', () => {
+	it.only('should work with multiple selected (array of values)', () => {
 		function App() {
 			return (
 				<select multiple value={['B', 'C']}>
@@ -27,6 +27,11 @@ describe('Select', () => {
 		}
 
 		render(<App />, scratch);
+		Array.prototype.slice.call(scratch.firstChild.childNodes).forEach(node => {
+			if (node.value === 'B' || node.value === 'C') {
+				expect(node.selected).to.equal(true);
+			}
+		});
 		expect(scratch.firstChild.value).to.equal('B');
 	});
 });

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -15,7 +15,7 @@ describe('Select', () => {
 	});
 
 
-	it.only('should work with multiple selected (array of values)', () => {
+	it('should work with multiple selected (array of values)', () => {
 		function App() {
 			return (
 				<select multiple value={['B', 'C']}>

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -266,6 +266,9 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					dom.innerHTML = newHtml && newHtml.__html || '';
 				}
 			}
+			if (newVNode.props.multiple && newVNode.type==='select') {
+				dom.multiple = newVNode.props.multiple;
+			}
 			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);
 			diffProps(dom, newVNode.props, oldProps, isSvg);
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -266,7 +266,7 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					dom.innerHTML = newHtml && newHtml.__html || '';
 				}
 			}
-			if (newVNode.props.multiple && newVNode.type==='select') {
+			if (newVNode.props.multiple) {
 				dom.multiple = newVNode.props.multiple;
 			}
 			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent);

--- a/test/browser/select.test.js
+++ b/test/browser/select.test.js
@@ -28,4 +28,34 @@ describe('Select', () => {
 		render(<App />, scratch);
 		expect(scratch.firstChild.value).to.equal('B');
 	});
+
+	it('should set value with selected', () => {
+		function App() {
+			return (
+				<select>
+					<option value="A">A</option>
+					<option selected value="B">B</option>
+					<option value="C">C</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(scratch.firstChild.value).to.equal('B');
+	});
+
+	it('should work with multiple selected', () => {
+		function App() {
+			return (
+				<select multiple>
+					<option value="A">A</option>
+					<option selected value="B">B</option>
+					<option selected value="C">C</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(scratch.firstChild.value).to.equal('B');
+	});
 });

--- a/test/browser/select.test.js
+++ b/test/browser/select.test.js
@@ -56,6 +56,11 @@ describe('Select', () => {
 		}
 
 		render(<App />, scratch);
+		Array.prototype.slice.call(scratch.firstChild.childNodes).forEach(node => {
+			if (node.value === 'B' || node.value === 'C') {
+				expect(node.selected).to.equal(true);
+			}
+		});
 		expect(scratch.firstChild.value).to.equal('B');
 	});
 });


### PR DESCRIPTION
We did not support having multiple `selected` attributes on `<option>` tags.
After evaluating this issue I saw that our compat missed the option to pass an array of values to `<select>`. This was made possible by the first fix.

Fixes: https://github.com/developit/preact/issues/761
Adds ~~`+24B`~~ `+17B` - @marvinhagemeister 