### PR TITLE
Switch from *.mjs -> *.module.js

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "A React compatibility layer for Preact",
   "main": "dist/compat.js",
-  "module": "dist/compat.mjs",
+  "module": "dist/compat.module.js",
   "umd:main": "dist/compat.umd.js",
   "source": "src/index.js",
   "license": "MIT",

--- a/debug/package.json
+++ b/debug/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Preact extensions for development",
   "main": "dist/debug.js",
-  "module": "dist/debug.mjs",
+  "module": "dist/debug.module.js",
   "umd:main": "dist/debug.umd.js",
   "source": "src/index.js",
   "license": "MIT",

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Hook addon for Preact",
   "main": "dist/hooks.js",
-  "module": "dist/hooks.mjs",
+  "module": "dist/hooks.module.js",
   "umd:main": "dist/hooks.umd.js",
   "source": "src/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",
-  "module": "dist/preact.mjs",
+  "module": "dist/preact.module.js",
   "umd:main": "dist/preact.umd.js",
   "source": "src/index.js",
   "license": "MIT",

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "Test-utils for Preact",
   "main": "dist/testUtils.js",
-  "module": "dist/testUtils.mjs",
+  "module": "dist/testUtils.module.js",
   "umd:main": "dist/testUtils.umd.js",
   "source": "src/index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR basically reverts #1285 and moves back to `.js` files. It reduces friction with webpack which doesn't resolve `.mjs` the same way as `.js` thus breaking imports in submodules. We've been pointing users to the excellent [webpack-modules](https://github.com/lukeed/webpack-modules) plugin which corrects that as a current workaround.

This PR should remove the need for that plugin making preact work right out of the box with any webpack configuration.

Fixes #1424 , #1321 and lots of questions on slack :+1: 