### PR TITLE
Don't append px suffix for css custom properties

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 export const EMPTY_OBJ = {};
 export const EMPTY_ARR = [];
-export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
+export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -425,6 +425,11 @@ describe('render()', () => {
 				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo: red; color: var(--foo);');
 				expect(window.getComputedStyle(scratch.firstChild).color).to.equal('rgb(255, 0, 0)');
 			});
+
+			it('should not add "px" suffix for custom properties', () => {
+				render(<div style={{ '--foo': 2, animationDelay: 'calc(var(--foo) * 20ms)' }}>test</div>, scratch);
+				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo: 2; animation-delay: calc(var(--foo) * 20ms);');
+			});
 		}
 	});
 


### PR DESCRIPTION
Fixes #1423 .
Adds `+5 B`.