### PR TITLE
Fix safari failing on calc with css variables in SauceLabs

### DIFF
--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -427,8 +427,8 @@ describe('render()', () => {
 			});
 
 			it('should not add "px" suffix for custom properties', () => {
-				render(<div style={{ '--foo': 2, animationDelay: 'calc(var(--foo) * 20ms)' }}>test</div>, scratch);
-				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo: 2; animation-delay: calc(var(--foo) * 20ms);');
+				render(<div style={{ '--foo': '100px', width: 'var(--foo)' }}>test</div>, scratch);
+				expect(sortCss(scratch.firstChild.style.cssText)).to.equal('--foo: 100px; width: var(--foo);');
 			});
 		}
 	});


### PR DESCRIPTION
This PR fixes the failing CI again.