### PR TITLE
Don't iterate over old css string

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -50,9 +50,11 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 		else {
 			if (typeof oldValue==='string') s.cssText = '';
-			// remove values not in the new list
-			for (let i in oldValue) {
-				if (value==null || !(i in value)) s.setProperty(i.replace(CAMEL_REG, '-'), '');
+			else {
+				// remove values not in the new list
+				for (let i in oldValue) {
+					if (value==null || !(i in value)) s.setProperty(i.replace(CAMEL_REG, '-'), '');
+				}
 			}
 			for (let i in value) {
 				v = value[i];

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -418,6 +418,14 @@ describe('render()', () => {
 			expect(style.zIndex.toString()).to.equal('');
 		});
 
+		it('should remove old styles', () => {
+			render(<div style="color: red;" />, scratch);
+			let s = scratch.firstChild.style;
+			sinon.spy(s, 'setProperty');
+			render(<div style={{ background: 'blue' }} />, scratch);
+			expect(s.setProperty).to.be.calledOnce;
+		});
+
 		// Skip test if the currently running browser doesn't support CSS Custom Properties
 		if (window.CSS && CSS.supports('color', 'var(--fake-var)')) {
 			it('should support css custom properties', () => {


### PR DESCRIPTION
This PR fixes an issue where we did iterate over each character of the previous style value. This only happened when the previous value was of type `string`. See the debug logs here: https://travis-ci.org/developit/preact/builds/50882293

Related to #1394 