### PR TITLE
fix: missing mangle config for _prevState

### DIFF
--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -18,6 +18,7 @@
     "cname": 6,
     "props": {
       "$_dirty": "__d",
+      "$_prevState": "__u",
       "$_nextState": "__s",
       "$_renderCallbacks": "__h",
       "$_vnode": "__v",


### PR DESCRIPTION
it is used in:
https://github.com/developit/preact/blob/750189b1978a032dfcd8e255325a32580d2c32b8/debug/src/devtools/index.js#L158-L166