### PR TITLE
Fix type definition

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -39,7 +39,7 @@ export function createElement(type, props, children) {
  * Create a VNode (used internally by Preact)
  * @param {import('./internal').VNode["type"]} type The node name or Component
  * Constructor for this virtual node
- * @param {object} props The properites of this virtual node
+ * @param {object | null} props The properites of this virtual node
  * @param {string | number} text If this virtual node represents a text node,
  * this is the text of the node
  * @param {string |number | null} key The key for this virtual node, used when

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,10 +10,10 @@ declare namespace preact {
 
 	interface VNode<P = {}> {
 		type: ComponentFactory<P> | string | null;
-		props: P & { children: ComponentChildren };
-		text?: string | number | null;
-		key?: Key;
-		ref?: Ref<any>;
+		props: P & { children: ComponentChildren } | null;
+		text: string | number | null;
+		key: Key;
+		ref: Ref<any> | null;
 		/**
 		 * The time this `vnode` started rendering. Will only be set when
 		 * the devtools are attached.

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -25,16 +25,16 @@ export interface PreactElement extends HTMLElement {
 export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentFactory type
 	type: string | ComponentFactory<P> | null;
-	_children?: Array<VNode> | null;
+	_children: Array<VNode> | null;
 	/**
 	 * The [first (for Fragments)] DOM child of a VNode
 	 */
-	_dom?: PreactElement | Text | null;
+	_dom: PreactElement | Text | null;
 	/**
 	 * The last dom child of a Fragment, or components that return a Fragment
 	 */
-	_lastDomChild?: PreactElement | Text | null;
-	_component?: Component | null;
+	_lastDomChild: PreactElement | Text | null;
+	_component: Component | null;
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {


### PR DESCRIPTION
I think that `text`, `key`, `ref`, `_children`, `_dom`, `_lastDomChild`,  and `_component` always exist.

https://github.com/developit/preact/blob/66aa9e24bbf116fa30a5fddce7ebc21d8ea3199f/src/create-element.js#L54-L64

`props` is set to null.

https://github.com/developit/preact/blob/66aa9e24bbf116fa30a5fddce7ebc21d8ea3199f/src/create-element.js#L87

May I ask.
This is another issue.
Is the reason why setting null to `key` and `ref`  for V8?
I don't know why it is `return createVNode(null, null, possibleVNode, null, null);` instead of `return createVNode(null, null, possibleVNode);`.
https://github.com/developit/preact/blob/66aa9e24bbf116fa30a5fddce7ebc21d8ea3199f/src/create-element.js#L87