### PR TITLE
move JSX namespace into preact one

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,11 @@
 export = preact;
 export as namespace preact;
 
-import "./jsx";
+import { JSXInternal } from "./jsx";
 
 declare namespace preact {
+	export import JSX = JSXInternal;
+
 	//
 	// Preact Virtual DOM
 	// -----------------------------------
@@ -134,7 +136,7 @@ declare namespace preact {
 
 	function createElement(
 		type: string,
-		props: JSX.HTMLAttributes & JSX.SVGAttributes & Record<string, any> | null,
+		props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 	function createElement<P>(
@@ -142,8 +144,14 @@ declare namespace preact {
 		props: Attributes & P | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
+	namespace createElement {
+		export import JSX = JSXInternal;
+	}
 
-	const h: typeof createElement;
+	type h = typeof createElement;
+	namespace h {
+		export import JSX = JSXInternal;
+	}
 
 	//
 	// Preact render

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -7,7 +7,7 @@ type Defaultize<Props, Defaults> =
 			& Pick<Props, Exclude<keyof Props, keyof Defaults>>
 		: never;
 
-declare namespace JSX {
+export namespace JSXInternal {
 
 	type LibraryManagedAttributes<Component, Props> =
 	Component extends { defaultProps: infer Defaults }

--- a/test/ts/jsx-namespacce-test.tsx
+++ b/test/ts/jsx-namespacce-test.tsx
@@ -1,0 +1,16 @@
+import { createElement, Component } from "../../src";
+
+// declare global JSX types that should not be mixed with preact's internal types
+declare global {
+	namespace JSX {
+		interface Element {
+			unknownProperty: string
+		}
+	}
+}
+
+class SimpleComponent extends Component {
+	render() {
+		return <div>It works</div>;
+	}
+}


### PR DESCRIPTION
closes #1036. Still requires some work, but open for initial feedback.

This change fixes issues when preact is used together with `@types/react` in dependencies. Conflicting JSX namespace definitions confuse typescript. Here is a demo project, where I tested integration with react typings: https://github.com/just-boris/preact-mix 

Implementing the approach described in the related typescript issue: https://github.com/Microsoft/TypeScript/issues/23762#issuecomment-385444169

Not yet ready to merge, because it requires the fix in typescript to be released https://github.com/Microsoft/TypeScript/pull/30160.