### PR TITLE
Jump to the next childDom if its `_dom` is null

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -29,7 +29,15 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 
 	let oldChildrenLength = oldChildren.length;
 
-	childDom = oldChildrenLength ? oldChildren[0] && oldChildren[0]._dom : null;
+	if (oldChildrenLength) {
+		for (i = 0; i< oldChildrenLength; i++) {
+			if (oldChildren[i] && oldChildren[i]._dom) {
+				childDom = oldChildren[i]._dom;
+				break;
+			}
+		}
+	}
+
 	if (excessDomChildren!=null) {
 		for (i = 0; i < excessDomChildren.length; i++) {
 			if (excessDomChildren[i]!=null) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -29,12 +29,10 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 
 	let oldChildrenLength = oldChildren.length;
 
-	if (oldChildrenLength) {
-		for (i = 0; i< oldChildrenLength; i++) {
-			if (oldChildren[i] && oldChildren[i]._dom) {
-				childDom = oldChildren[i]._dom;
-				break;
-			}
+	for (i = 0; i < oldChildrenLength; i++) {
+		if (oldChildren[i] && oldChildren[i]._dom) {
+			childDom = oldChildren[i]._dom;
+			break;
 		}
 	}
 


### PR DESCRIPTION
I think this should fix https://github.com/developit/preact/issues/1343, but not other reconciliation issues like https://github.com/developit/preact/issues/1326