### PR TITLE
Get rid of top-level dependency on prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,6 @@
     "url": "https://github.com/developit/preact/issues"
   },
   "homepage": "https://github.com/developit/preact",
-  "dependencies": {
-    "prop-types": "^15.6.2"
-  },
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",


### PR DESCRIPTION
It looks like this was inadvertently added in https://github.com/developit/preact/commit/069bc8f8a9ea4f514df034d77cadd8160ebb4baa#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R63 when the debug app started using it.

Later it was properly added to the debug module itself via https://github.com/developit/preact/commit/109bdbdcd8aa1babffb2610e60f2b44b9351180c#diff-7a30b5ab41cde7241b4fc10f730143fdR23 but **without** cleaning it up from the main package.

This restores the `preact` package itself to have no dependencies, so we can all sleep better at night.