### PR TITLE
Revert "Get rid of top-level dependency on prop-types (#1460)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
     "url": "https://github.com/developit/preact/issues"
   },
   "homepage": "https://github.com/developit/preact",
+  "dependencies": {
+    "prop-types": "^15.6.2"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",


### PR DESCRIPTION
Reverts developit/preact#1460

I clicked the green button to early. As @andrewiggins correctly pointed out in #1460 we do need this for `preact/debug`. This wasn't caught by our CI because a `devDependency` pulled in `prop-types` too.