### PR TITLE
Fix `_dom` being `null` whenever sCU returns `false`

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -93,7 +93,9 @@ export function coerceToVNode(possibleVNode) {
 
 	// Clone vnode if it has already been used. ceviche/#57
 	if (possibleVNode._dom!=null) {
-		return createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.text, possibleVNode.key, null);
+		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.text, possibleVNode.key, null);
+		vnode._dom = possibleVNode._dom;
+		return vnode;
 	}
 
 	return possibleVNode;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -108,6 +108,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 				}
 
 				if (!force && c.shouldComponentUpdate!=null && c.shouldComponentUpdate(newVNode.props, s, cctx)===false) {
+					dom = oldVNode._dom;
 					c.props = newVNode.props;
 					c.state = s;
 					c._dirty = false;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -64,6 +64,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 			if (oldVNode._component) {
 				c = newVNode._component = oldVNode._component;
 				clearProcessingException = c._processingException;
+				newVNode._dom = oldVNode._dom;
 			}
 			else {
 				// Instantiate the new component

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -108,7 +108,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 				}
 
 				if (!force && c.shouldComponentUpdate!=null && c.shouldComponentUpdate(newVNode.props, s, cctx)===false) {
-					dom = oldVNode._dom;
+					dom = newVNode._dom;
 					c.props = newVNode.props;
 					c.state = s;
 					c._dirty = false;

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1252,4 +1252,56 @@ describe('Components', () => {
 			expect(C3.prototype.componentWillMount, 'inject between, C3 w/ intermediary div').to.have.been.calledOnce;
 		});
 	});
+
+	it('should set component._vnode._dom when sCU returns false', () => {
+		let parent;
+		 class Parent extends Component {
+			 render() {
+				parent = this;
+				return <Child />;
+			}
+		}
+
+		let condition = false;
+
+		let child;
+		class Child extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+			render() {
+				child = this;
+				if (!condition) return false;
+				return <div class="child" />;
+			}
+		}
+
+		let app;
+		class App extends Component {
+			render() {
+				app = this;
+				return <Parent />;
+			}
+		}
+
+		render(<App />, scratch);
+		expect(child._vnode._dom).to.equal(child.base);
+
+		app.forceUpdate();
+		expect(child._vnode._dom).to.equal(child.base);
+
+		parent.setState({});
+		condition = true;
+		child.forceUpdate();
+		expect(child._vnode._dom).to.equal(child.base);
+		rerender();
+
+		expect(child._vnode._dom).to.equal(child.base);
+
+		condition = false;
+		app.setState({});
+		child.forceUpdate();
+		rerender();
+		expect(child._vnode._dom).to.equal(child.base);
+	});
 });

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1271,7 +1271,7 @@ describe('Components', () => {
 			}
 			render() {
 				child = this;
-				if (!condition) return false;
+				if (!condition) return null;
 				return <div class="child" />;
 			}
 		}

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1304,4 +1304,22 @@ describe('Components', () => {
 		rerender();
 		expect(child._vnode._dom).to.equal(child.base);
 	});
+
+	it('should update old dom on forceUpdate in a lifecycle', () => {
+		let i = 0;
+		class App extends Component {
+			componentWillReceiveProps() {
+				this.forceUpdate();
+			}
+			render() {
+				if (i++==0) return <div>foo</div>;
+				return <div>bar</div>;
+			}
+		}
+
+		render(<App />, scratch);
+		render(<App />, scratch);
+
+		expect(scratch.innerHTML).to.equal('<div>bar</div>');
+	});
 });


### PR DESCRIPTION
The issue is caused by a mismatch of `component.base` with `component._vnode._dom`. We use the latter for diffing and it lead to leaving old DOM nodes around whenever `shouldComponentUpdate` returns `false`.

I can't take credit alone for it, because the fix wouldn't be possible without all the debugging help from @JoviDeCroock, @developit and @andrewiggins :+1: :100: 

Adds ~~`+3 B`~~ ~~`+11 B`~~ ~~`+17 B`~~ `+13 B` :tada: 