### PR TITLE
fix: support IE9

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 export const EMPTY_OBJ = {};
 export const EMPTY_ARR = [];
-export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
+export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i;

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -59,7 +59,12 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 			for (let i in value) {
 				v = value[i];
 				if (oldValue==null || v!==oldValue[i]) {
-					s.setProperty(i.replace(CAMEL_REG, '-'), typeof v==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (v + 'px') : v);
+					if (i.indexOf('--')===0) {
+						s.setProperty(i.replace(CAMEL_REG, '-'), v);
+					}
+					else {
+						s[i] = typeof v==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (v + 'px') : v;
+					}
 				}
 			}
 		}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -59,7 +59,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 			for (let i in value) {
 				v = value[i];
 				if (oldValue==null || v!==oldValue[i]) {
-					if (!i.indexOf('--')) {
+					if (i[0]=='-') {
 						s.setProperty(i.replace(CAMEL_REG, '-'), v);
 					}
 					else {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -59,7 +59,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 			for (let i in value) {
 				v = value[i];
 				if (oldValue==null || v!==oldValue[i]) {
-					if (i.indexOf('--')===0) {
+					if (!i.indexOf('--')) {
 						s.setProperty(i.replace(CAMEL_REG, '-'), v);
 					}
 					else {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -426,13 +426,12 @@ describe('render()', () => {
 			expect(style.zIndex.toString()).to.equal('');
 		});
 
-		it.skip('should remove old styles', () => {
-			render(<div style="color: red;" />, scratch);
+		it('should remove old custom variables', () => {
+			render(<div style="'--foo': 'red';" />, scratch);
 			let s = scratch.firstChild.style;
 			sinon.spy(s, 'setProperty');
-			render(<div style={{ background: 'blue' }} />, scratch);
-			// this won't call setProperty...
-			// expect(s.setProperty).to.be.calledOnce;
+			render(<div style={{ '--foo': 'blue' }} />, scratch);
+			expect(s.setProperty).to.be.calledOnce;
 		});
 
 		it.skip('should add important', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -426,12 +426,19 @@ describe('render()', () => {
 			expect(style.zIndex.toString()).to.equal('');
 		});
 
-		it('should remove old styles', () => {
+		it.skip('should remove old styles', () => {
 			render(<div style="color: red;" />, scratch);
 			let s = scratch.firstChild.style;
 			sinon.spy(s, 'setProperty');
 			render(<div style={{ background: 'blue' }} />, scratch);
-			expect(s.setProperty).to.be.calledOnce;
+			// this won't call setProperty...
+			// expect(s.setProperty).to.be.calledOnce;
+		});
+
+		it.skip('should add important', () => {
+			render(<div style={{ background: 'blue !important' }} />, scratch);
+			// This does not work
+			expect(scratch.firstChild.style.background).to.be.equal('blue !important');
 		});
 
 		// Skip test if the currently running browser doesn't support CSS Custom Properties


### PR DESCRIPTION
Recovers support for IE9 and maintains supporting custom variables.

Support for `!important` still does not work but I wonder if this is even needed, it does however if people use it disable the full propagation of the prop.

`style={{ background: 'blue !important' }}` --> evaluates to `style={{}}`. This is pretty akward for devs relying on it. If we would want to support !important we would have to use `setProperty` and neglect the bug with IE9. setProperty can set !important with its thirth argument.

I do feel like that maybe we support the majority of IE9 and then we're fine but this could also open up a rabbit hole against future features. (this is when we'd officially declare IE9 support)

ADDS: ~~12~~ ~~10B~~ 9B