### PR TITLE
Fix remove button adding todos in demo app

### DIFF
--- a/demo/todo.js
+++ b/demo/todo.js
@@ -38,7 +38,7 @@ class TodoItems extends Component {
 	render({ todos, removeTodo }) {
 		return todos.map( todo => (
 			<li key={todo.id}>
-				<button onClick={removeTodo} data-id={todo.id}>&times;</button>
+				<button type="button" onClick={removeTodo} data-id={todo.id}>&times;</button>
 				{' '}
 				{todo.text}
 			</li>

--- a/demo/todo.js
+++ b/demo/todo.js
@@ -26,7 +26,7 @@ export default class TodoList extends Component {
 				<input value={text} onInput={this.setText} />
 				<button type="submit">Add</button>
 				<ul>
-					<TodoItems todos={todos} removeTodo={this.removeTodo}/>
+					<TodoItems todos={todos} removeTodo={this.removeTodo} />
 				</ul>
 			</form>
 		);


### PR DESCRIPTION
This PR fixes an issue where the `x` buttons in the todo demo would actually add a todo instead of removing it. Note that there is a second issue at play that needs to fixed separately which causes stale dom nodes when wrapped in a `Fragment`.

The issue is caused by weird browser behavior which treat any `<buttton>` that doesn't have a `type` attribute as a `submit` button if it is inside a `<form>` :man_shrugging:

In our case it would immediately submit the form which always adds a todo.
```jsx
<form onSubmit={this.addTodo} action="javascript:">...</form>
```