### PR TITLE
Fix stale DOM caused by empty Fragments

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -43,6 +43,10 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 		outer: if (oldVNode.type===Fragment || newType===Fragment) {
 			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, c);
 
+			// Mark dom as empty in case `_children` is any empty array. If it isn't
+			// we'll set `dom` to the correct value just a few lines later.
+			dom = null;
+
 			if (newVNode._children.length) {
 				dom = newVNode._children[0]._dom;
 				newVNode._lastDomChild = newVNode._children[newVNode._children.length - 1]._dom;

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1540,4 +1540,19 @@ describe('Fragment', () => {
 			'<div>1.appendChild(<div>2)'
 		], 'rendering from false to true');
 	});
+
+	it('should clear empty Fragments', () => {
+		function Foo(props) {
+			if (props.condition) {
+				return <Fragment>foo</Fragment>;
+			}
+			return <Fragment />;
+		}
+
+		render(<Foo condition={true} />, scratch);
+		expect(scratch.textContent).to.equal('foo');
+
+		render(<Foo condition={false} />, scratch);
+		expect(scratch.textContent).to.equal('');
+	});
 });


### PR DESCRIPTION
This PR fixes an issue where the DOM for `Fragments` wasn't cleared when they previously had children. This was most noticeable in the `todo` demo where the first added todo item could never be removed.

Adds `+2 B` :tada: 