### PR TITLE
Fix Portal crashing devtools

### DIFF
--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -28,7 +28,7 @@ describe('Portal', () => {
 		expect(root.innerHTML).to.equal('foobar');
 	});
 
-	it("should not render <undefined> for Portal nodes", () => {
+	it('should not render <undefined> for Portal nodes', () => {
 		let root = document.createElement('div');
 		let dialog = document.createElement('div');
 		dialog.id = 'container';
@@ -37,16 +37,18 @@ describe('Portal', () => {
 		scratch.appendChild(dialog);
 
 		function Dialog() {
-			return <div>Dialog content</div>
+			return <div>Dialog content</div>;
 		}
 
 		function App() {
-			return <div>
-				{createPortal(<Dialog/>, dialog)}
-			</div>
+			return (
+				<div>
+					{createPortal(<Dialog />, dialog)}
+				</div>
+			);
 		}
 
-		render(<App/>, root);
+		render(<App />, root);
 		expect(scratch.firstChild.firstChild.childNodes.length).to.equal(0);
 	});
 });

--- a/debug/src/devtools/custom.js
+++ b/debug/src/devtools/custom.js
@@ -1,4 +1,4 @@
-import { Fragment } from 'preact';
+import { Component, Fragment } from 'preact';
 
 /**
  * Get the type/category of a vnode
@@ -49,7 +49,7 @@ export function getData(vnode) {
 	/** @type {import('../internal').DevtoolsUpdater | null} */
 	let updater = null;
 
-	if (c!=null) {
+	if (c!=null && c instanceof Component) {
 		// These functions will be called when the user changes state, props or
 		// context values via the devtools ui panel
 		updater = {
@@ -83,7 +83,7 @@ export function getData(vnode) {
 		key: vnode.key || null,
 		updater,
 		text: vnode.text,
-		state: c!=null ? c.state : null,
+		state: c!=null && c instanceof Component ? c.state : null,
 		props: vnode.props,
 		// The devtools inline text children if they are the only child
 		children: vnode.text==null

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -4,7 +4,7 @@ import { getDisplayName, setIn, isRoot, getData, shallowEqual, hasDataChanged, g
 import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';
 import { initDevTools } from '../../src/devtools';
 import { Renderer } from '../../src/devtools/renderer';
-import { memo, forwardRef } from '../../../compat/src';
+import { memo, forwardRef, createPortal } from '../../../compat/src';
 
 /** @jsx h */
 
@@ -893,6 +893,13 @@ describe('devtools', () => {
 					expect(ev.data.treeBaseDuration > -1).to.equal(true);
 				});
 			});
+		});
+
+		// preact/#1490
+		it('should not crash on a Portal node', () => {
+			const div = document.createElement('div');
+			render(createPortal('foo', div), scratch);
+			expect(console.error).to.not.be.called;
 		});
 	});
 });


### PR DESCRIPTION
This PR fixes an exception inside the devtools when we encountered a `Portal` node. 

Fixes #1490 .

_Note that we should add proper support for `Portals` sometime in the future for the devtools. There will be a bit more work involved to support multiple roots inside our adapter, but it leads to much nicer view in the extension, see #1492._

