### PR TITLE
Add more createElement warnings in debug

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -29,7 +29,17 @@ export function initDebug() {
 		let children = props && props.children;
 
 		if (type===undefined) {
-			throw new Error('Undefined component passed to createElement()\n'+serializeVNode(vnode));
+			throw new Error('Undefined component passed to createElement()\n\n'+
+			'You likely forgot to export your component or might have mixed up default and named imports'+
+			serializeVNode(vnode));
+		}
+		else if (type!=null && typeof type==='object') {
+			if (type._lastDomChild!==undefined && type._dom!==undefined) {
+				let info = 'Did you accidentilly passed a JSX Literal as JSX twice?';
+				throw new Error('Invalid type passed to createElement(): '+type+'\n\n'+info+'\n\n'+serializeVNode(type));
+			}
+
+			throw new Error('Invalid type passed to createElement(): '+(Array.isArray(type) ? 'array' : type));
 		}
 
 		if (

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -47,7 +47,7 @@ describe('debug', () => {
 	});
 
 	it('should print an error with (function) component name when available', () => {
-		const App = () => <div />
+		const App = () => <div />;
 		let fn = () => render(<App />, 6);
 		expect(fn).to.throw(/<App/);
 		expect(fn).to.throw(/6/);
@@ -59,7 +59,7 @@ describe('debug', () => {
 	it('should print an error with (class) component name when available', () => {
 		class App extends Component {
 			render() {
-				return <div />
+				return <div />;
 			}
 		}
 		let fn = () => render(<App />, 6);
@@ -68,6 +68,17 @@ describe('debug', () => {
 
 	it('should print an error on undefined component', () => {
 		let fn = () => render(h(undefined), scratch);
+		expect(fn).to.throw(/createElement/);
+	});
+
+	it('should print an error on double jsx conversion', () => {
+		let Foo = <div />;
+		let fn = () => render(h(<Foo />), scratch);
+		expect(fn).to.throw(/createElement/);
+	});
+
+	it('should print an error when component is an array', () => {
+		let fn = () => render(h([<div />]), scratch);
 		expect(fn).to.throw(/createElement/);
 	});
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -13,13 +13,15 @@ import ProfilerDemo from './profiler';
 import KeyBug from './key_bug';
 import PeopleBrowser from './people';
 import { initDevTools } from 'preact/debug/src/devtools';
+import { initDebug } from 'preact/debug/src/debug';
 import DevtoolsDemo from './devtools';
 
 let isBenchmark = /(\/spiral|\/pythagoras|[#&]bench)/g.test(window.location.href);
 if (!isBenchmark) {
 	// eslint-disable-next-line no-console
-	console.log('Enabling devtools');
+	console.log('Enabling devtools and debug');
 	initDevTools();
+	initDebug();
 }
 
 // mobx-state-tree fix


### PR DESCRIPTION
- Add new warnings for various invalid input passed to `createElement`.
- Enable debug messages in demo app.