### PR TITLE
(feat) - debugging effect hooks

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -6,6 +6,7 @@ import { ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } from './constants
 export function initDebug() {
 	/* eslint-disable no-console */
 	let oldBeforeDiff = options.diff;
+	let oldDiffed = options.diffed;
 
 	options.root = (vnode, parentNode) => {
 		if (!parentNode) {
@@ -82,6 +83,32 @@ export function initDebug() {
 		}
 
 		if (oldBeforeDiff) oldBeforeDiff(vnode);
+	};
+
+	options.diffed = (vnode) => {
+		if (vnode._component && vnode._component.__hooks && vnode._component.__hooks._pendingEffects.length > 0) {
+			vnode._component.__hooks._pendingEffects.forEach((x) => {
+				if (!x._args || !Array.isArray(x._args)) {
+					throw new Error(`
+						You should provide an array of arguments as the second argument to the "useEffect" hook.
+						Not doing so will invoke this effect on every render.
+						This effect can be found in the render of ${vnode.type.name || vnode.type}.
+					`);
+				}
+			});
+		}
+		if (vnode._component && vnode._component.__hooks && vnode._component.__hooks._pendingLayoutEffects.length > 0) {
+			vnode._component.__hooks._pendingLayoutEffects.forEach((x) => {
+				if (!x._args || !Array.isArray(x._args)) {
+					throw new Error(`
+						You should provide an array of arguments as the second argument to the "useEffect" hook.
+						Not doing so will invoke this effect on every render.
+						This effect can be found in the render of ${vnode.type.name || vnode.type}.
+					`);
+				}
+			});
+		}
+		if (oldDiffed) oldDiffed(vnode);
 	};
 }
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -49,8 +49,8 @@ export function initDebug() {
 		for (const key in vnode.props) {
 			if (key[0]==='o' && key[1]==='n' && typeof vnode.props[key]!=='function') {
 				throw new Error(
-					`Component's "${key}" property should be a function,
-					but got [${typeof vnode.props[key]}] instead\n` +
+					`Component's "${key}" property should be a function, ` +
+					`but got [${typeof vnode.props[key]}] instead\n` +
 					serializeVNode(vnode)
 				);
 			}
@@ -86,28 +86,28 @@ export function initDebug() {
 	};
 
 	options.diffed = (vnode) => {
-		if (vnode._component && vnode._component.__hooks && vnode._component.__hooks._pendingEffects.length > 0) {
-			vnode._component.__hooks._pendingEffects.forEach((x) => {
-				if (!x._args || !Array.isArray(x._args)) {
-					throw new Error(`
-						You should provide an array of arguments as the second argument to the "useEffect" hook.
-						Not doing so will invoke this effect on every render.
-						This effect can be found in the render of ${vnode.type.name || vnode.type}.
-					`);
-				}
-			});
+		if (vnode._component && vnode._component.__hooks) {
+			let hooks = vnode._component.__hooks;
+			if (hooks._pendingEffects.length > 0) {
+				hooks._pendingEffects.forEach((x) => {
+					if (!x._args || !Array.isArray(x._args)) {
+						throw new Error('You should provide an array of arguments as the second argument to the "useEffect" hook.\n\n' +
+							'Not doing so will invoke this effect on every render.\n\n' +
+							'This effect can be found in the render of ' + (vnode.type.name || vnode.type) + '.');
+					}
+				});
+			}
+			if (hooks._pendingLayoutEffects.length > 0) {
+				hooks._pendingLayoutEffects.forEach((x) => {
+					if (!x._args || !Array.isArray(x._args)) {
+						throw new Error('You should provide an array of arguments as the second argument to the "useEffect" hook.\n\n' +
+							'Not doing so will invoke this effect on every render.\n\n' +
+							'This effect can be found in the render of ' + (vnode.type.name || vnode.type) + '.');
+					}
+				});
+			}
 		}
-		if (vnode._component && vnode._component.__hooks && vnode._component.__hooks._pendingLayoutEffects.length > 0) {
-			vnode._component.__hooks._pendingLayoutEffects.forEach((x) => {
-				if (!x._args || !Array.isArray(x._args)) {
-					throw new Error(`
-						You should provide an array of arguments as the second argument to the "useEffect" hook.
-						Not doing so will invoke this effect on every render.
-						This effect can be found in the render of ${vnode.type.name || vnode.type}.
-					`);
-				}
-			});
-		}
+
 		if (oldDiffed) oldDiffed(vnode);
 	};
 }

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -1,4 +1,5 @@
 import { createElement as h, options, render, createRef, Component, Fragment } from 'preact';
+import { useState, useEffect, useLayoutEffect } from 'preact/hooks';
 import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';
 import { serializeVNode, initDebug } from '../../src/debug';
 import * as PropTypes from 'prop-types';
@@ -47,7 +48,7 @@ describe('debug', () => {
 	});
 
 	it('should print an error with (function) component name when available', () => {
-		const App = () => <div />
+		const App = () => <div />;
 		let fn = () => render(<App />, 6);
 		expect(fn).to.throw(/<App/);
 		expect(fn).to.throw(/6/);
@@ -59,7 +60,7 @@ describe('debug', () => {
 	it('should print an error with (class) component name when available', () => {
 		class App extends Component {
 			render() {
-				return <div />
+				return <div />;
 			}
 		}
 		let fn = () => render(<App />, 6);
@@ -69,6 +70,43 @@ describe('debug', () => {
 	it('should print an error on undefined component', () => {
 		let fn = () => render(h(undefined), scratch);
 		expect(fn).to.throw(/createElement/);
+	});
+
+	it('should throw an error for argumentless useEffect hooks', () => {
+		const App = () => {
+			const [state] = useState('test');
+			useEffect(() => 'test');
+			return (
+				<p>{state}</p>
+			);
+		};
+		const fn = () => render(<App />, scratch);
+		expect(fn).to.throw(/You should provide an array of arguments/);
+	});
+
+	it('should throw an error for argumentless useLayoutEffect hooks', () => {
+		const App = () => {
+			const [state] = useState('test');
+			useLayoutEffect(() => 'test');
+			return (
+				<p>{state}</p>
+			);
+		};
+		const fn = () => render(<App />, scratch);
+		expect(fn).to.throw(/You should provide an array of arguments/);
+	});
+
+	it('should not throw an error for argumented effect hooks', () => {
+		const App = () => {
+			const [state] = useState('test');
+			useLayoutEffect(() => 'test', []);
+			useEffect(() => 'test', [state]);
+			return (
+				<p>{state}</p>
+			);
+		};
+		const fn = () => render(<App />, scratch);
+		expect(fn).to.not.throw();
 	});
 
 	it('should print an error on invalid refs', () => {


### PR DESCRIPTION
This debugs the passing of an arguments array to hooks that need it. This avoids nasty endless calling bugs. This throws an error to breaking that endless calling.

Or is this actually a pattern that people want calling an effect on every render, personally it always bites me...

This could potentially be extended to useMemo and useCallback, warning about not providing an arguments array makes it a useless function call.

Warn about hooks in classes, I don't know if this is possible?