### PR TITLE
(fix) - event.persist should be a function, not an object

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -14,7 +14,7 @@ let oldEventHook = options.event;
 options.event = e => {
 	/* istanbul ignore next */
 	if (oldEventHook) e = oldEventHook(e);
-	e.persist = Object;
+	e.persist = () => {};
 	e.nativeEvent = e;
 	return e;
 };

--- a/compat/test/browser/compat.test.js
+++ b/compat/test/browser/compat.test.js
@@ -22,6 +22,7 @@ describe('imported compat in preact', () => {
 
 		expect(spy).to.be.calledOnce;
 		expect(spy.args[0][0]).to.haveOwnProperty('persist');
+		expect(typeof spy.args[0][0].persist).to.equal('function');
 		expect(spy.args[0][0]).to.haveOwnProperty('nativeEvent');
 	});
 


### PR DESCRIPTION
According to: https://reactjs.org/docs/events.html#event-pooling
e.persist should be a function and not an object.

Fixes: https://github.com/developit/preact/issues/1497