### PR TITLE
(feat) - warn about deprecated properties

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -7,6 +7,7 @@ export function initDebug() {
 	/* eslint-disable no-console */
 	let oldBeforeDiff = options.diff;
 	let oldDiffed = options.diffed;
+	let oldVnode = options.vnode;
 
 	options.root = (vnode, parentNode) => {
 		if (!parentNode) {
@@ -96,6 +97,26 @@ export function initDebug() {
 		}
 
 		if (oldBeforeDiff) oldBeforeDiff(vnode);
+	};
+
+	const warn = (property, err) => ({
+		get() {
+			throw new Error(`getting vnode.${property} is deprecated, ${err}`);
+		},
+		set() {
+			throw new Error(`setting vnode.${property} is not allowed, ${err}`);
+		}
+	});
+
+	const deprecatedAttributes = {
+		nodeName: warn('nodeName', 'use vnode.type'),
+		attributes: warn('attributes', 'use vnode.props'),
+		children: warn('children', 'use vnode.props.children')
+	};
+
+	options.vnode = (vnode) => {
+		Object.defineProperties(vnode, deprecatedAttributes);
+		if (oldVnode) oldVnode(vnode);
 	};
 
 	options.diffed = (vnode) => {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -119,6 +119,24 @@ describe('debug', () => {
 		expect(fn).to.throw(/createElement/);
 	});
 
+
+	it('Should throw errors when accessing certain attributes', () => {
+		let Foo = () => <div />;
+		const oldOptionsVnode = options.vnode;
+		options.vnode = (vnode) => {
+			oldOptionsVnode(vnode);
+			expect(() => vnode).to.not.throw();
+			expect(() => vnode.attributes).to.throw(/use vnode.props/);
+			expect(() => vnode.nodeName).to.throw(/use vnode.type/);
+			expect(() => vnode.children).to.throw(/use vnode.props.children/);
+			expect(() => vnode.attributes = {}).to.throw(/use vnode.props/);
+			expect(() => vnode.nodeName = 'test').to.throw(/use vnode.type/);
+			expect(() => vnode.children = [<div />]).to.throw(/use vnode.props.children/);
+		};
+		render(<Foo />, scratch);
+		options.vnode = oldOptionsVnode;
+	});
+
 	it('should print an error when component is an array', () => {
 		let fn = () => render(h([<div />]), scratch);
 		expect(fn).to.throw(/createElement/);


### PR DESCRIPTION
Credits to @developit for the idea.

This warns about trying to access certain props and throws upon trying to set them.