### PR TITLE
Keep track of childDom between `diffChildren` calls

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -70,7 +70,7 @@ Component.prototype.forceUpdate = function(callback) {
 		const force = callback!==false;
 
 		let mounts = [];
-		dom = diff(dom, parentDom, vnode, vnode, this._context, parentDom.ownerSVGElement!==undefined, null, mounts, this._ancestorComponent, force);
+		dom = diff(dom, parentDom, vnode, vnode, this._context, parentDom.ownerSVGElement!==undefined, null, mounts, this._ancestorComponent, force, dom);
 		if (dom!=null && dom.parentNode!==parentDom) {
 			parentDom.appendChild(dom);
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -18,12 +18,12 @@ import { removeNode } from '../util';
  * which have mounted
  * @param {import('../internal').Component} ancestorComponent The direct parent
  * component to the ones being diffed
- * @param {Node | Text} childDom The current attached DOM
+ * @param {Node | Text} oldDom The current attached DOM
  * element any new dom elements should be placed around. Likely `null` on first
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  */
-export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, childDom) {
+export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom) {
 	let childVNode, i, j, p, index, oldVNode, newDom,
 		nextDom, sibDom, focus;
 
@@ -62,10 +62,10 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			oldChildren[index] = null;
 		}
 
-		nextDom = childDom!=null && childDom.nextSibling;
+		nextDom = oldDom!=null && oldDom.nextSibling;
 
 		// Morph the old element into the new one, but don't append it to the dom yet
-		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, childDom);
+		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
 
 		// Only proceed if the vnode has not been unmounted by `diff()` above.
 		if (childVNode!=null && newDom !=null) {
@@ -81,23 +81,23 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 				// this Fragment's DOM tree.
 				newDom = childVNode._lastDomChild;
 			}
-			else if (excessDomChildren==oldVNode || newDom!=childDom || newDom.parentNode==null) {
+			else if (excessDomChildren==oldVNode || newDom!=oldDom || newDom.parentNode==null) {
 				// NOTE: excessDomChildren==oldVNode above:
 				// This is a compression of excessDomChildren==null && oldVNode==null!
 				// The values only have the same type when `null`.
 
-				outer: if (childDom==null || childDom.parentNode!==parentDom) {
+				outer: if (oldDom==null || oldDom.parentNode!==parentDom) {
 					parentDom.appendChild(newDom);
 				}
 				else {
-					sibDom = childDom;
+					sibDom = oldDom;
 					j = 0;
 					while ((sibDom=sibDom.nextSibling) && j++<oldChildrenLength/2) {
 						if (sibDom===newDom) {
 							break outer;
 						}
 					}
-					parentDom.insertBefore(newDom, childDom);
+					parentDom.insertBefore(newDom, oldDom);
 				}
 			}
 
@@ -106,7 +106,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 				focus.focus();
 			}
 
-			childDom = newDom!=null ? newDom.nextSibling : nextDom;
+			oldDom = newDom!=null ? newDom.nextSibling : nextDom;
 		}
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -18,32 +18,19 @@ import { removeNode } from '../util';
  * which have mounted
  * @param {import('../internal').Component} ancestorComponent The direct parent
  * component to the ones being diffed
+ * @param {Node | Text} childDom The current attached DOM
+ * element any new dom elements should be placed around. Likely `null` on first
+ * render (except when hydrating). Can be a sibling DOM element when diffing
+ * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  */
-export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent) {
+export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, childDom) {
 	let childVNode, i, j, p, index, oldVNode, newDom,
-		nextDom, sibDom, focus,
-		childDom;
+		nextDom, sibDom, focus;
 
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode);
 	let oldChildren = oldParentVNode!=null && oldParentVNode!=EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length;
-
-	for (i = 0; i < oldChildrenLength; i++) {
-		if (oldChildren[i] && oldChildren[i]._dom) {
-			childDom = oldChildren[i]._dom;
-			break;
-		}
-	}
-
-	if (excessDomChildren!=null) {
-		for (i = 0; i < excessDomChildren.length; i++) {
-			if (excessDomChildren[i]!=null) {
-				childDom = excessDomChildren[i];
-				break;
-			}
-		}
-	}
 
 	for (i=0; i<newChildren.length; i++) {
 		childVNode = newChildren[i] = coerceToVNode(newChildren[i]);
@@ -78,7 +65,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 		nextDom = childDom!=null && childDom.nextSibling;
 
 		// Morph the old element into the new one, but don't append it to the dom yet
-		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null);
+		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, childDom);
 
 		// Only proceed if the vnode has not been unmounted by `diff()` above.
 		if (childVNode!=null && newDom !=null) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -55,8 +55,8 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 				dom = newVNode._children[0]._dom;
 
 				// If lastChild is a Fragment, use _lastDomChild, else use _dom
-				let lastChild = newVNode._children[newVNode._children.length - 1];
-				newVNode._lastDomChild = lastChild._lastDomChild || lastChild._dom;
+				p = newVNode._children[newVNode._children.length - 1];
+				newVNode._lastDomChild = p._lastDomChild || p._dom;
 			}
 		}
 		else if (typeof newType==='function') {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -118,6 +118,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 					c.props = newVNode.props;
 					c.state = s;
 					c._dirty = false;
+					newVNode._lastDomChild = oldVNode._lastDomChild;
 					break outer;
 				}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -20,12 +20,12 @@ import options from '../options';
  * mounted components
  * @param {import('../internal').Component | null} ancestorComponent The direct
  * parent component
- * @param {Node | Text} childDom The current attached DOM
+ * @param {Node | Text} oldDom The current attached DOM
  * element any new dom elements should be placed around. Likely `null` on first
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  */
-export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, force, childDom) {
+export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, force, oldDom) {
 
 	// If the previous type doesn't match the new type we drop the whole subtree
 	if (oldVNode==null || newVNode==null || oldVNode.type!==newVNode.type) {
@@ -45,7 +45,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 
 	try {
 		outer: if (oldVNode.type===Fragment || newType===Fragment) {
-			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, c, childDom);
+			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, c, oldDom);
 
 			// Mark dom as empty in case `_children` is any empty array. If it isn't
 			// we'll set `dom` to the correct value just a few lines later.
@@ -148,7 +148,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 				snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
 			}
 
-			c.base = dom = diff(dom, parentDom, vnode, prev, context, isSvg, excessDomChildren, mounts, c, null, childDom);
+			c.base = dom = diff(dom, parentDom, vnode, prev, context, isSvg, excessDomChildren, mounts, c, null, oldDom);
 
 			if (vnode!=null) {
 				// If this component returns a Fragment (or another component that
@@ -284,8 +284,8 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 				dom.multiple = newProps.multiple;
 			}
 
-			const childDom = getFirstChildDom(oldVNode, excessDomChildren);
-			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent, childDom);
+			const oldDom = getFirstOldDom(oldVNode, excessDomChildren);
+			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, ancestorComponent, oldDom);
 			diffProps(dom, newProps, oldProps, isSvg);
 		}
 	}
@@ -396,7 +396,7 @@ function catchErrorInComponent(error, component) {
  * the currently attached DOM elements that are being hydrated
  * @returns {import('../internal').PreactElement | Text | undefined}
  */
-export function getFirstChildDom(oldVNode, excessDomChildren) {
+export function getFirstOldDom(oldVNode, excessDomChildren) {
 
 	/** @type {import('../internal').VNode[]} */
 	let oldChildren = oldVNode!=null && oldVNode!=EMPTY_OBJ && oldVNode._children || EMPTY_ARR;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -53,7 +53,10 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 
 			if (newVNode._children.length) {
 				dom = newVNode._children[0]._dom;
-				newVNode._lastDomChild = newVNode._children[newVNode._children.length - 1]._dom;
+
+				// If lastChild is a Fragment, use _lastDomChild, else use _dom
+				let lastChild = newVNode._children[newVNode._children.length - 1];
+				newVNode._lastDomChild = lastChild._lastDomChild || lastChild._dom;
 			}
 		}
 		else if (typeof newType==='function') {

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ, EMPTY_ARR } from './constants';
-import { commitRoot, getFirstChildDom } from './diff/index';
+import { commitRoot, getFirstOldDom } from './diff/index';
 import { diffChildren } from './diff/children';
 import { createElement, Fragment } from './create-element';
 import options from './options';
@@ -16,10 +16,10 @@ export function render(vnode, parentDom) {
 	vnode = createElement(Fragment, null, [vnode]);
 
 	const excessDomChildren = oldVNode ? null : EMPTY_ARR.slice.call(parentDom.childNodes);
-	const childDom = getFirstChildDom(oldVNode, excessDomChildren);
+	const oldDom = getFirstOldDom(oldVNode, excessDomChildren);
 
 	let mounts = [];
-	diffChildren(parentDom, parentDom._prevVNode = vnode, oldVNode, EMPTY_OBJ, parentDom.ownerSVGElement!==undefined, excessDomChildren, mounts, vnode, childDom);
+	diffChildren(parentDom, parentDom._prevVNode = vnode, oldVNode, EMPTY_OBJ, parentDom.ownerSVGElement!==undefined, excessDomChildren, mounts, vnode, oldDom);
 	commitRoot(mounts, vnode);
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ, EMPTY_ARR } from './constants';
-import { commitRoot } from './diff/index';
+import { commitRoot, getFirstChildDom } from './diff/index';
 import { diffChildren } from './diff/children';
 import { createElement, Fragment } from './create-element';
 import options from './options';
@@ -15,8 +15,11 @@ export function render(vnode, parentDom) {
 	let oldVNode = parentDom._prevVNode;
 	vnode = createElement(Fragment, null, [vnode]);
 
+	const excessDomChildren = oldVNode ? null : EMPTY_ARR.slice.call(parentDom.childNodes);
+	const childDom = getFirstChildDom(oldVNode, excessDomChildren);
+
 	let mounts = [];
-	diffChildren(parentDom, parentDom._prevVNode = vnode, oldVNode, EMPTY_OBJ, parentDom.ownerSVGElement!==undefined, oldVNode ? null : EMPTY_ARR.slice.call(parentDom.childNodes), mounts, vnode);
+	diffChildren(parentDom, parentDom._prevVNode = vnode, oldVNode, EMPTY_OBJ, parentDom.ownerSVGElement!==undefined, excessDomChildren, mounts, vnode, childDom);
 	commitRoot(mounts, vnode);
 }
 

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -98,7 +98,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('hello <span>world</span>');
 	});
 
-	it.skip('should handle reordering', () => {
+	it('should handle reordering components that return Fragments', () => {
 		class X extends Component {
 			render() {
 				return <Fragment>{this.props.children}</Fragment>;
@@ -1113,7 +1113,7 @@ describe('Fragment', () => {
 		], 'rendering from false to true');
 	});
 
-	it.skip('should support moving Fragments between beginning and end', () => {
+	it('should support moving Fragments between beginning and end', () => {
 		const Foo = ({ condition }) => (
 			<ol>
 				{condition ? [
@@ -1179,7 +1179,7 @@ describe('Fragment', () => {
 		]);
 	});
 
-	it.skip('should support conditional beginning and end Fragments', () => {
+	it('should support conditional beginning and end Fragments', () => {
 		const Foo = ({ condition }) => (
 			<ol>
 				{condition ?
@@ -1238,7 +1238,7 @@ describe('Fragment', () => {
 		]);
 	});
 
-	it.skip('should support nested conditional beginning and end Fragments', () => {
+	it('should support nested conditional beginning and end Fragments', () => {
 		const Foo = ({ condition }) => (
 			<ol>
 				{condition ?
@@ -1305,7 +1305,7 @@ describe('Fragment', () => {
 		]);
 	});
 
-	it.skip('should preserve state with reordering in multiple levels with mixed # of Fragment siblings', () => {
+	it('should preserve state with reordering in multiple levels with mixed # of Fragment siblings', () => {
 		// Also fails if the # of divs outside the Fragment equals or exceeds
 		// the # inside the Fragment for both conditions
 		function Foo({ condition }) {
@@ -1373,7 +1373,7 @@ describe('Fragment', () => {
 		], 'rendering from false to true');
 	});
 
-	it.skip('should preserve state with reordering in multiple levels with lots of Fragment siblings', () => {
+	it('should preserve state with reordering in multiple levels with lots of Fragment siblings', () => {
 		// Also fails if the # of divs outside the Fragment equals or exceeds
 		// the # inside the Fragment for both conditions
 		function Foo({ condition }) {

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1006,7 +1006,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
-		expect(scratch.innerHTML).to.equal(html);
+		expect(scratch.innerHTML).to.equal(html, 'initial render of true');
 		expectDomLogToBe([
 			'<li>.appendChild(#text)',
 			'<ol>.appendChild(<li>0)',
@@ -1021,7 +1021,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={false} />,  scratch);
-		expect(scratch.innerHTML).to.equal(html);
+		expect(scratch.innerHTML).to.equal(html, 'rendering from true to false');
 		expectDomLogToBe([
 			'<li>.appendChild(#text)',
 			'<ol>0121.appendChild(<li>2)',
@@ -1033,7 +1033,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
-		expect(scratch.innerHTML).to.equal(html);
+		expect(scratch.innerHTML).to.equal(html, 'rendering from false to true');
 		expectDomLogToBe([
 			'<li>.appendChild(#text)',
 			'<ol>0123.appendChild(<li>1)',
@@ -1076,7 +1076,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
-		expect(scratch.innerHTML).to.equal(htmlForTrue);
+		expect(scratch.innerHTML).to.equal(htmlForTrue, 'initial render of true');
 		expectDomLogToBe([
 			'<li>.appendChild(#text)',
 			'<ol>.appendChild(<li>0)',
@@ -1093,7 +1093,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={false} />,  scratch);
-		expect(scratch.innerHTML).to.equal(htmlForFalse);
+		expect(scratch.innerHTML).to.equal(htmlForFalse, 'rendering from true to false');
 		expectDomLogToBe([
 			'<li>1.remove()',
 			'<li>2.remove()'
@@ -1101,7 +1101,7 @@ describe('Fragment', () => {
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
-		expect(scratch.innerHTML).to.equal(htmlForTrue);
+		expect(scratch.innerHTML).to.equal(htmlForTrue, 'rendering from false to true');
 		expectDomLogToBe([
 			'<li>.appendChild(#text)',
 			'<ol>034.appendChild(<li>1)',
@@ -1562,5 +1562,94 @@ describe('Fragment', () => {
 
 		render(<Foo condition={false} />, scratch);
 		expect(scratch.textContent).to.equal('');
+	});
+
+	it('should support conditionally rendered nested Fragments or null with siblings', () => {
+		const Foo = ({ condition }) => (
+			<ol>
+				<li>0</li>
+				<Fragment>
+					<li>1</li>
+					{condition ? (
+						<Fragment>
+							<li>2</li>
+							<li>3</li>
+						</Fragment>
+					) : null }
+					<li>4</li>
+				</Fragment>
+				<li>5</li>
+			</ol>
+		);
+
+		const htmlForTrue = ol([
+			li('0'),
+			li('1'),
+			li('2'),
+			li('3'),
+			li('4'),
+			li('5')
+		].join(''));
+
+		const htmlForFalse = ol([
+			li('0'),
+			li('1'),
+			li('4'),
+			li('5')
+		].join(''));
+
+		clearLog();
+		render(<Foo condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(htmlForTrue, 'initial render of true');
+		expectDomLogToBe([
+			'<li>.appendChild(#text)',
+			'<ol>.appendChild(<li>0)',
+			'<li>.appendChild(#text)',
+			'<ol>0.appendChild(<li>1)',
+			'<li>.appendChild(#text)',
+			'<ol>01.appendChild(<li>2)',
+			'<li>.appendChild(#text)',
+			'<ol>012.appendChild(<li>3)',
+			'<li>.appendChild(#text)',
+			'<ol>0123.appendChild(<li>4)',
+			'<li>.appendChild(#text)',
+			'<ol>01234.appendChild(<li>5)',
+			'<div>.appendChild(<ol>012345)'
+		], 'initial render of true');
+
+		clearLog();
+		render(<Foo condition={false} />,  scratch);
+		expect(scratch.innerHTML).to.equal(htmlForFalse, 'rendering from true to false');
+		expectDomLogToBe([
+			'<li>2.remove()',
+			'<li>3.remove()'
+		], 'rendering from true to false');
+
+		clearLog();
+		render(<Foo condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(htmlForTrue, 'rendering from false to true');
+		expectDomLogToBe([
+			'<li>.appendChild(#text)',
+			'<ol>0145.insertBefore(<li>2, <li>4)',
+			'<li>.appendChild(#text)',
+			'<ol>01245.insertBefore(<li>3, <li>4)'
+		], 'rendering from false to true');
+	});
+
+	it('should render first child Fragment that wrap null components', () => {
+		const Empty = () => null;
+		const Foo = () => (
+			<ol>
+				<Fragment>
+					<Empty />
+				</Fragment>
+				<li>1</li>
+			</ol>
+		);
+
+		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal(ol([
+			li(1)
+		].join('')));
 	});
 });

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -75,7 +75,7 @@ describe('Fragment', () => {
 
 		// Issue #193: Improve Fragment diff performance
 		// TODO: With this test, the Fragment with just one child will invoke
-		// node.appendChild on a DOM element that is already appened to the `node`.
+		// node.appendChild on a DOM element that is already appended to the `node`.
 		// I think we need the oldParentVNode to get the old first DOM child to
 		// effectively diff the children, because the parentVNode (the Fragment)
 		// comes from the newTree and so won't ever have ._dom set before diffing
@@ -1326,14 +1326,14 @@ describe('Fragment', () => {
 					: null
 				}
 				<li>2</li>
-				<li>2</li>
+				<li>3</li>
 				{condition ?
 					null :
 					<Fragment>
 						<Fragment>
 							<Fragment>
-								<li>3</li>
 								<li>4</li>
+								<li>5</li>
 							</Fragment>
 						</Fragment>
 					</Fragment>
@@ -1345,14 +1345,14 @@ describe('Fragment', () => {
 			li(0),
 			li(1),
 			li(2),
-			li(2)
+			li(3)
 		].join(''));
 
 		const htmlForFalse = ol([
 			li(2),
-			li(2),
 			li(3),
-			li(4)
+			li(4),
+			li(5)
 		].join(''));
 
 		clearLog();
@@ -1363,18 +1363,18 @@ describe('Fragment', () => {
 		render(<Foo condition={false} />, scratch);
 		expect(scratch.innerHTML).to.equal(htmlForFalse, 'rendering from true to false');
 		expectDomLogToBe([
-			'<ol>3122.appendChild(<li>3)',
-			'<ol>4223.appendChild(<li>4)'
+			'<ol>4123.appendChild(<li>4)',
+			'<ol>5234.appendChild(<li>5)'
 		]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
 		expect(scratch.innerHTML).to.equal(htmlForTrue, 'rendering from false to true');
 		expectDomLogToBe([
-			'<ol>2204.insertBefore(<li>0, <li>2)',
-			'<ol>0221.insertBefore(<li>1, <li>2)',
+			'<ol>2305.insertBefore(<li>0, <li>2)',
+			'<ol>0231.insertBefore(<li>1, <li>2)',
 			// TODO: See issue #193 - seems redundant...
-			'<ol>0122.appendChild(<li>2)'
+			'<ol>0132.appendChild(<li>3)'
 		]);
 	});
 

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -37,7 +37,7 @@ describe('Fragment', () => {
 	before(() => {
 		logCall(Element.prototype, 'insertBefore');
 		logCall(Element.prototype, 'appendChild');
-		logCall(Element.prototype, 'remove');
+		logCall(Element.prototype, 'removeChild');
 	});
 
 	beforeEach(() => {
@@ -242,9 +242,6 @@ describe('Fragment', () => {
 		expectDomLogToBe([
 			'<div>.appendChild(#text)',
 			'<div>Hello.insertBefore(<div>Hello, <div>Hello)',
-			// See issue #193 - redundant operations (remove)
-			'<div>Hello.remove()',
-			'<div>Hello.remove()',
 			'<div>Hello.remove()'
 		]);
 
@@ -256,8 +253,6 @@ describe('Fragment', () => {
 		expectDomLogToBe([
 			'<div>.appendChild(#text)',
 			'<div>Hello.appendChild(<div>Hello)',
-			// See issue #193 - redudant operations (remove)
-			'<div>Hello.remove()',
 			'<div>Hello.remove()'
 		]);
 	});
@@ -283,8 +278,6 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
-			// See issue #193 - redundant operations (remove)
-			'<div>Hello.remove()',
 			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
 			'<div>.appendChild(<div>Hello)'
@@ -296,10 +289,6 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
-			// See issue #193 - redudant operations (remove)
-			'<div>Hello.remove()',
-			'<div>Hello.remove()',
-			'<div>Hello.remove()',
 			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
 			'<div>.appendChild(<div>Hello)'
@@ -645,10 +634,7 @@ describe('Fragment', () => {
 			'<div>11Hello.insertBefore(<div>Hello, <span>1)',
 			'<span>.appendChild(#text)',
 			'<div>1Hello1Hello.insertBefore(<span>2, <span>1)',
-			// See issue #193 - redundant operations (remove)
 			'<span>1.remove()',
-			'<span>1.remove()',
-			'<div>Hello.remove()',
 			'<div>Hello.remove()'
 		]);
 
@@ -664,8 +650,6 @@ describe('Fragment', () => {
 			'<div>1Hello21.appendChild(<div>Hello)',
 			'<div>2Hello21Hello.appendChild(<span>2)',
 			'<span>2.remove()',
-			// See issue #193 - redundant operations (remove)
-			'<div>Hello.remove()',
 			'<div>Hello.remove()'
 		]);
 	});
@@ -727,7 +711,9 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal('foobar');
 		expectDomLogToBe([
-			'<div>spamfoobar.appendChild(#text)'
+			'<div>spamfoobar.appendChild(#text)',
+			'#text.remove()',
+			'#text.remove()'
 		]);
 	});
 
@@ -1033,7 +1019,6 @@ describe('Fragment', () => {
 			'<li>.appendChild(#text)',
 			'<ol>01212.appendChild(<li>3)',
 			'<li>1.remove()',
-			'<li>1.remove()',
 			'<li>2.remove()'
 		]);
 
@@ -1101,8 +1086,6 @@ describe('Fragment', () => {
 		render(<Foo condition={false} />,  scratch);
 		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expectDomLogToBe([
-			// see issue #193 - redundant operations (remove)
-			'<li>1.remove()',
 			'<li>1.remove()',
 			'<li>2.remove()'
 		]);
@@ -1517,7 +1500,6 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expectDomLogToBe([
 			'<div>1.remove()',
-			'<div>1.remove()',
 			'<div>2.remove()',
 			'<div>.appendChild(#text)',
 			'<div>.appendChild(<div>3)',
@@ -1532,8 +1514,6 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForTrue);
 		expectDomLogToBe([
 			'<div>34.remove()',
-			'<div>3.remove()',
-			'<div>4.remove()',
 			'<div>.appendChild(#text)',
 			'<div>.appendChild(<div>1)',
 			'<div>.appendChild(#text)',


### PR DESCRIPTION
Improve Fragment correctness by keeping track of the current DOM position being diff'ed between calls to `diffChildren`.

Note: while this does fix a lot of Fragment correctness issues, in some cases it doesn't optimally operate on the DOM and bails out to re-appending all Fragment children. This is a known issue (I'll open that issue) that I'd like to address in a future PR (as it will likely require more/larger changes to `diff`/`diffChildren`).

~~b8bd7b4: +72 B 😬~~
26c359b: +73 B 😬 

Fixes #1325 #1326 #1415 