### PR TITLE
Add clear button to demo logger

### DIFF
--- a/demo/logger.js
+++ b/demo/logger.js
@@ -67,13 +67,19 @@ export default function logger(logStats, logConsole) {
 
 		lock = true;
 		root = document.createElement('table');
-		root.style.cssText = 'position: fixed; right: 0; top: 0; z-index:999; background: #000; font-size: 12px; color: #FFF; opacity: 0.9; white-space: nowrap; pointer-events: none;';
+		root.style.cssText = 'position: fixed; right: 0; top: 0; z-index:999; background: #000; font-size: 12px; color: #FFF; opacity: 0.9; white-space: nowrap;';
 		let header = document.createElement('thead');
-		header.innerHTML = '<tr><td colspan="2">Stats</td></tr>';
+		header.innerHTML = '<tr><td colspan="2">Stats <button id="clear-logs">clear</button></td></tr>';
 		root.tableBody = document.createElement('tbody');
 		root.appendChild(root.tableBody);
 		root.appendChild(header);
 		document.documentElement.appendChild(root);
+		let btn = document.getElementById('clear-logs');
+		btn.addEventListener('click', () => {
+			for (let key in calls) {
+				calls[key] = 0;
+			}
+		});
 		lock = false;
 	}
 


### PR DESCRIPTION
This PR adds a clear button to our logger inside our demo app. This is useful when checking DOM mutations caused by a single user action. Previously one would need to keep the previous values in mind to be able to make any meaningful conclusions.

![clear_logger](https://user-images.githubusercontent.com/1062408/55666908-75016180-5855-11e9-8051-db7e154fc970.png)
