### PR TITLE
TS: Use same type naming as @types/react

### DIFF
--- a/demo/people/router.tsx
+++ b/demo/people/router.tsx
@@ -1,4 +1,4 @@
-import { ComponentChild, ComponentFactory, createContext, FunctionalComponent, h } from "preact"
+import { ComponentChild, ComponentFactory, createContext, FunctionalComponent, h, JSX } from "preact"
 import { useCallback, useContext, useEffect, useMemo, useState } from "preact/hooks"
 
 export type RouterData = {

--- a/demo/people/store.ts
+++ b/demo/people/store.ts
@@ -51,7 +51,8 @@ const Store = types
 
 export type StoreType = Instance<typeof Store>
 export const store = Store.create({
-  usersOrder: "name",
+	usersOrder: "name",
+	users: []
 })
 
 // const { Provider, Consumer } = createContext<StoreType>(undefined as any)

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"experimentalDecorators": true,
+		"jsx": "react",
+		"jsxFactory": "h",
+		"baseUrl": ".",
+		"target": "es2018",
+		"module": "es2015",
+		"moduleResolution": "node",
+		"paths": {
+			"preact/hooks": ["../hooks/src/index.js"],
+			"preact": ["../src/index.js"],
+		}
+	}
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ declare namespace preact {
 	// -----------------------------------
 
 	interface VNode<P = {}> {
-		type: ComponentFactory<P> | string | null;
+		type: ComponentType<P> | string | null;
 		props: P & { children: ComponentChildren } | null;
 		text: string | number | null;
 		key: Key;
@@ -63,15 +63,15 @@ declare namespace preact {
 		P & Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }
 	>;
 
-	type ComponentFactory<P = {}> = ComponentConstructor<P> | FunctionalComponent<P>;
+	type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
-	interface FunctionalComponent<P = {}> {
+	interface FunctionComponent<P = {}> {
 		(props: RenderableProps<P>, context?: any): VNode<any> | null;
 		displayName?: string;
 		defaultProps?: Partial<P>;
 	}
 
-	interface ComponentConstructor<P = {}, S = {}> {
+	interface ComponentClass<P = {}, S = {}> {
 		new (props: P, context?: any): Component<P, S>;
 		displayName?: string;
 		defaultProps?: Partial<P>;
@@ -80,7 +80,7 @@ declare namespace preact {
 	}
 
 	// Type alias for a component instance considered generally, whether stateless or stateful.
-	type AnyComponent<P = {}, S = {}> = FunctionalComponent<P> | Component<P, S>;
+	type AnyComponent<P = {}, S = {}> = FunctionComponent<P> | Component<P, S>;
 
 	interface Component<P = {}, S = {}> {
 		componentWillMount?(): void;
@@ -100,7 +100,7 @@ declare namespace preact {
 
 		static displayName?: string;
 		static defaultProps?: any;
-		static contextType?: PreactContext<any>;
+		static contextType?: Context<any>;
 
 		// Static members cannot reference class type parameters. This is not
 		// supported in TypeScript. Reusing the same type arguments from `Component`
@@ -140,7 +140,7 @@ declare namespace preact {
 		...children: ComponentChildren[]
 	): VNode<any>;
 	function createElement<P>(
-		type: ComponentFactory<P>,
+		type: ComponentType<P>,
 		props: Attributes & P | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
@@ -166,7 +166,7 @@ declare namespace preact {
 	// -----------------------------------
 
 	// TODO: Revisit what the public type of this is...
-	const Fragment: ComponentConstructor<{}, {}>;
+	const Fragment: ComponentClass<{}, {}>;
 
 	//
 	// Preact options
@@ -204,19 +204,19 @@ declare namespace preact {
 	//
 	// Context
 	// -----------------------------------
-	interface PreactConsumer<T> extends FunctionalComponent<{
+	interface Consumer<T> extends FunctionComponent<{
 		children: (value: T) => ComponentChildren
 	}> {}
 
-	interface PreactProvider<T> extends FunctionalComponent<{
+	interface Provider<T> extends FunctionComponent<{
 		value: T,
 		children: ComponentChildren
 	}> {}
 
-	interface PreactContext<T> {
-		Consumer: PreactConsumer<T>;
-		Provider: PreactProvider<T>;
+	interface Context<T> {
+		Consumer: Consumer<T>;
+		Provider: Provider<T>;
 	}
 
-	function createContext<T>(defaultValue: T): PreactContext<T>;
+	function createContext<T>(defaultValue: T): Context<T>;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,12 +64,14 @@ declare namespace preact {
 	>;
 
 	type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+	type ComponentFactory<P = {}> = ComponentType<P>;
 
 	interface FunctionComponent<P = {}> {
 		(props: RenderableProps<P>, context?: any): VNode<any> | null;
 		displayName?: string;
 		defaultProps?: Partial<P>;
 	}
+	interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
 
 	interface ComponentClass<P = {}, S = {}> {
 		new (props: P, context?: any): Component<P, S>;
@@ -78,6 +80,7 @@ declare namespace preact {
 		getDerivedStateFromProps?(props: Readonly<P>, state: Readonly<S>): Partial<S>;
 		getDerivedStateFromError?(error: any): Partial<S>;
 	}
+	interface ComponentConstructor<P = {}, S = {}> extends ComponentClass<P, S> {}
 
 	// Type alias for a component instance considered generally, whether stateless or stateful.
 	type AnyComponent<P = {}, S = {}> = FunctionComponent<P> | Component<P, S>;
@@ -207,16 +210,19 @@ declare namespace preact {
 	interface Consumer<T> extends FunctionComponent<{
 		children: (value: T) => ComponentChildren
 	}> {}
+	interface PreactConsumer<T> extends Consumer<T> {}
 
 	interface Provider<T> extends FunctionComponent<{
 		value: T,
 		children: ComponentChildren
 	}> {}
+	interface PreactProvider<T> extends Provider<T> {}
 
 	interface Context<T> {
 		Consumer: Consumer<T>;
 		Provider: Provider<T>;
 	}
+	interface PreactContext<T> extends Context<T> {}
 
 	function createContext<T>(defaultValue: T): Context<T>;
 }

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,13 +1,13 @@
 import * as preact from "./index";
 
-export interface FunctionalComponent<P = {}> extends preact.FunctionalComponent<P> {
+export interface FunctionalComponent<P = {}> extends preact.FunctionComponent<P> {
 	// Define getDerivedStateFromProps as undefined on FunctionalComponent
 	// to get rid of some errors in `diff()`
 	getDerivedStateFromProps?: undefined;
 }
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above
-export type ComponentFactory<P> = preact.ComponentConstructor<P> | FunctionalComponent<P>;
+export type ComponentFactory<P> = preact.ComponentClass<P> | FunctionalComponent<P>;
 
 export interface PreactElement extends HTMLElement {
 	_prevVNode?: VNode<any> | null;
@@ -38,7 +38,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
-	constructor: preact.ComponentFactory<P>;
+	constructor: preact.ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
 	base?: PreactElement | null;
 
@@ -59,7 +59,7 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	_processingException?: Component<any, any> | null;
 }
 
-export interface PreactContext extends preact.PreactContext<any> {
+export interface PreactContext extends preact.Context<any> {
 	_id: string;
 	_defaultValue: any;
 }


### PR DESCRIPTION
This makes copy & pasting react components that are written in TypeScript easier.

Fixes #1518 .