### PR TITLE
(tests) - act should be able to track and flush the full queue and all subsequent queues

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -220,12 +220,14 @@ if (typeof window !== 'undefined') {
 function handleEffects(effects) {
 	effects.forEach(invokeCleanup);
 	effects.forEach(invokeEffect);
+	if (options.effects) {
+		effects.forEach(hook => options.effects = options.effects.filter(h => h!==hook));
+	}
 	return [];
 }
 
 function invokeCleanup(hook) {
 	if (hook._cleanup) hook._cleanup();
-	if (options.effects) options.effects = options.effects.filter(h => h!==hook)
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -102,7 +102,6 @@ export function useReducer(reducer, initialState, init) {
  * @param {any[]} args
  */
 export function useEffect(callback, args) {
-
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++);
 	if (argsChanged(state._args, args)) {
@@ -226,6 +225,7 @@ function handleEffects(effects) {
 
 function invokeCleanup(hook) {
 	if (hook._cleanup) hook._cleanup();
+	if (options.effects) options.effects = options.effects.filter(h => h!==hook)
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -102,6 +102,7 @@ export function useReducer(reducer, initialState, init) {
  * @param {any[]} args
  */
 export function useEffect(callback, args) {
+
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++);
 	if (argsChanged(state._args, args)) {
@@ -109,7 +110,7 @@ export function useEffect(callback, args) {
 		state._args = args;
 
 		currentComponent.__hooks._pendingEffects.push(state);
-		if (Array.isArray(options.effects)) options.effects.push(state)
+		if (Array.isArray(options.effects)) options.effects.push(state);
 		afterPaint(currentComponent);
 	}
 }
@@ -125,7 +126,7 @@ export function useLayoutEffect(callback, args) {
 	if (argsChanged(state._args, args)) {
 		state._value = callback;
 		state._args = args;
-		if (Array.isArray(options.effects)) options.effects.push(state)
+		if (Array.isArray(options.effects)) options.effects.push(state);
 		currentComponent.__hooks._pendingLayoutEffects.push(state);
 	}
 }

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -110,6 +110,7 @@ export function useEffect(callback, args) {
 		state._args = args;
 
 		currentComponent.__hooks._pendingEffects.push(state);
+		if (Array.isArray(options.effects)) options.effects.push(state)
 		afterPaint(currentComponent);
 	}
 }
@@ -125,7 +126,7 @@ export function useLayoutEffect(callback, args) {
 	if (argsChanged(state._args, args)) {
 		state._value = callback;
 		state._args = args;
-
+		if (Array.isArray(options.effects)) options.effects.push(state)
 		currentComponent.__hooks._pendingLayoutEffects.push(state);
 	}
 }

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -22,9 +22,7 @@ export function act(cb) {
 	cb();
 	if (flush) {
 		// State COULD be built up flush it.
-		console.log(options.effects);
 		while(options.effects.length > 0) {
-			options.effects = [];
 			flush();
 			rerender();
 		}

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -16,13 +16,13 @@ export function act(cb) {
 	const rerender = setupRerender();
 	let flush;
 	// Override requestAnimationFrame so we can flush pending hooks.
-	options.requestAnimationFrame = (fc) => flush = fc
+	options.requestAnimationFrame = (fc) => flush = fc;
 	// Execute the callback we were passed.
 	cb();
 	rerender();
 	if (flush) {
 		// State COULD be built up flush it.
-		while(options.effects.length > 0) {
+		while (options.effects.length > 0) {
 			flush();
 			rerender();
 		}

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -1,7 +1,5 @@
 import { options } from 'preact';
 
-options.effects = [];
-
 /**
  * Setup a rerender function that will drain the queue of pending renders
  * @returns {() => void}
@@ -13,13 +11,15 @@ export function setupRerender() {
 }
 
 export function act(cb) {
+	options.effects = [];
 	const previousRequestAnimationFrame = options.requestAnimationFrame;
 	const rerender = setupRerender();
 	let flush;
 	// Override requestAnimationFrame so we can flush pending hooks.
-	options.requestAnimationFrame = (fc) => flush = fc;
+	options.requestAnimationFrame = (fc) => flush = fc
 	// Execute the callback we were passed.
 	cb();
+	rerender();
 	if (flush) {
 		// State COULD be built up flush it.
 		while(options.effects.length > 0) {
@@ -27,6 +27,7 @@ export function act(cb) {
 			rerender();
 		}
 	}
+	options.effects = undefined;
 	options.requestAnimationFrame = previousRequestAnimationFrame;
 }
 

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -21,12 +21,11 @@ export function act(cb) {
 	// Execute the callback we were passed.
 	cb();
 	if (flush) {
-	// State COULD be built up flush it.
-		let tempEffects = [];
+		// State COULD be built up flush it.
+		console.log(options.effects);
 		while(options.effects.length > 0) {
-			const tempEffects =
-			flush();
 			options.effects = [];
+			flush();
 			rerender();
 		}
 	}

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -1,5 +1,7 @@
 import { options } from 'preact';
 
+options.effects = [];
+
 /**
  * Setup a rerender function that will drain the queue of pending renders
  * @returns {() => void}
@@ -18,15 +20,15 @@ export function act(cb) {
 	options.requestAnimationFrame = (fc) => flush = fc;
 	// Execute the callback we were passed.
 	cb();
+	if (flush) {
 	// State COULD be built up flush it.
-	if (flush) {
-		flush();
-	}
-	rerender();
-	// If rerendering with new state has triggered effects
-	// flush them aswell since options.raf will have repopulated this.
-	if (flush) {
-		flush();
+		let tempEffects = [];
+		while(options.effects.length > 0) {
+			const tempEffects =
+			flush();
+			options.effects = [];
+			rerender();
+		}
 	}
 	options.requestAnimationFrame = previousRequestAnimationFrame;
 }

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -65,7 +65,6 @@ describe('act', () => {
 		const spy2 = sinon.spy();
 		function StateContainer() {
 			const [count, setCount] = useState(0);
-			console.log('render', count);
 			useEffect(() => {
 				if (count===1) {
 					spy();

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -66,14 +66,16 @@ describe('act', () => {
 		function StateContainer() {
 			const [count, setCount] = useState(0);
 			useEffect(() => {
+				spy();
 				if (count===1) {
-					spy();
 					setCount(() => 2);
 				}
 			}, [count]);
 			useEffect(() => {
 				if (count === 2) {
 					spy2();
+					setCount(() => 4)
+					return () => setCount(() => 3)
 				}
 			}, [count]);
 			return (
@@ -83,7 +85,6 @@ describe('act', () => {
 				</div>
 			);
 		}
-
 		act(() => render(<StateContainer />, scratch));
 		expect(spy).to.be.calledOnce;
 		expect(scratch.textContent).to.include('Count: 0');
@@ -91,9 +92,9 @@ describe('act', () => {
 			const button = scratch.querySelector('button');
 			button.click();
 		});
-		expect(spy).to.be.calledTwice;
+		expect(spy.callCount).to.equal(5);
 		expect(spy2).to.be.calledOnce;
-		expect(scratch.textContent).to.include('Count: 2');
+		expect(scratch.textContent).to.include('Count: 3');
 	});
 
 	it('should drain the queue of hooks', () => {

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -74,8 +74,8 @@ describe('act', () => {
 			useEffect(() => {
 				if (count === 2) {
 					spy2();
-					setCount(() => 4)
-					return () => setCount(() => 3)
+					setCount(() => 4);
+					return () => setCount(() => 3);
 				}
 			}, [count]);
 			return (

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -60,6 +60,43 @@ describe('act', () => {
 		expect(scratch.textContent).to.include('Count: 1');
 	});
 
+	it.only('should flush series of hooks', () => {
+		const spy = sinon.spy();
+		const spy2 = sinon.spy();
+		function StateContainer() {
+			const [count, setCount] = useState(0);
+			console.log('render', count);
+			useEffect(() => {
+				if (count===1) {
+					spy();
+					setCount(() => 2);
+				}
+			}, [count]);
+			useEffect(() => {
+				if (count === 2) {
+					spy2();
+				}
+			}, [count]);
+			return (
+				<div>
+					<p>Count: {count}</p>
+					<button onClick={() => setCount(c => c + 1)} />
+				</div>
+			);
+		}
+
+		act(() => render(<StateContainer />, scratch));
+		expect(spy).to.be.calledOnce;
+		expect(scratch.textContent).to.include('Count: 0');
+		act(() => {
+			const button = scratch.querySelector('button');
+			button.click();
+		});
+		expect(spy).to.be.calledTwice;
+		expect(spy2).to.be.calledOnce;
+		expect(scratch.textContent).to.include('Count: 2');
+	});
+
 	it('should drain the queue of hooks', () => {
 		const spy = sinon.spy();
 		function StateContainer() {

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -60,7 +60,7 @@ describe('act', () => {
 		expect(scratch.textContent).to.include('Count: 1');
 	});
 
-	it.only('should flush series of hooks', () => {
+	it('should flush series of hooks', () => {
 		const spy = sinon.spy();
 		const spy2 = sinon.spy();
 		function StateContainer() {


### PR DESCRIPTION
While reasoning about our current testing approach I found a critical flaw. What happens when for example you type in an input -> this triggers a validation -> this sets state. A series of hooks get executed and well our current approach in act has no way of following these up.

This is why I introduced a global array in options, named effects. Every queued effect will be pushed and will be removed when we're invoking/cleaning up. This makes for a consistent testing method.