### PR TITLE
Provide simplified checkPropTypes implementation

### DIFF
--- a/debug/package.json
+++ b/debug/package.json
@@ -12,9 +12,6 @@
   "mangle": {
     "regex": "^(?!_renderer)^_"
   },
-  "dependencies": {
-    "prop-types": "^15.6.2"
-  },
   "peerDependencies": {
     "preact": "^10.0.0-alpha.0"
   }

--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -1,28 +1,24 @@
 
-if (process.env.NODE_ENV !== 'production') {
-  var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
-      loggedTypeFailures = {};
-}
+var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
+    loggedTypeFailures = {};
 
 export function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
-  if (process.env.NODE_ENV !== 'production') {
-    Object.keys(typeSpecs).forEach((typeSpecName) => {
-      let error;
-      try {
-        error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
-      } catch (e) {
-        error = e;
+  Object.keys(typeSpecs).forEach((typeSpecName) => {
+    let error;
+    try {
+      error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+    } catch (e) {
+      error = e;
+    }
+    if (error && !(error.message in loggedTypeFailures)) {
+      loggedTypeFailures[error.message] = true;
+      
+      let errorReport = `Failed ${location} type: ${error.message}${getStack && getStack() || ''}`;
+      if (typeof console !== 'undefined') {
+        console.error(errorReport);
+      } else {
+        throw new Error(errorReport);
       }
-      if (error && !(error.message in loggedTypeFailures)) {
-        loggedTypeFailures[error.message] = true;
-        
-        let errorReport = `Failed ${location} type: ${error.message}${getStack && getStack() || ''}`;
-        if (typeof console !== 'undefined') {
-          console.error(errorReport);
-        } else {
-          throw new Error(errorReport);
-        }
-      }
-    });
-  }
+    }
+  });
 }

--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -12,13 +12,7 @@ export function checkPropTypes(typeSpecs, values, location, componentName, getSt
     }
     if (error && !(error.message in loggedTypeFailures)) {
       loggedTypeFailures[error.message] = true;
-      
-      let errorReport = `Failed ${location} type: ${error.message}${getStack && getStack() || ''}`;
-      if (typeof console !== 'undefined') {
-        console.error(errorReport);
-      } else {
-        throw new Error(errorReport);
-      }
+      console.error(`Failed ${location} type: ${error.message}${getStack && getStack() || ''}`);
     }
   });
 }

--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -1,0 +1,28 @@
+
+if (process.env.NODE_ENV !== 'production') {
+  var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
+      loggedTypeFailures = {};
+}
+
+export function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+  if (process.env.NODE_ENV !== 'production') {
+    Object.keys(typeSpecs).forEach((typeSpecName) => {
+      let error;
+      try {
+        error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
+      } catch (e) {
+        error = e;
+      }
+      if (error && !(error.message in loggedTypeFailures)) {
+        loggedTypeFailures[error.message] = true;
+        
+        let errorReport = `Failed ${location} type: ${error.message}${getStack && getStack() || ''}`;
+        if (typeof console !== 'undefined') {
+          console.error(errorReport);
+        } else {
+          throw new Error(errorReport);
+        }
+      }
+    });
+  }
+}

--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -1,6 +1,6 @@
+const ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 
-var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
-    loggedTypeFailures = {};
+let loggedTypeFailures = {};
 
 export function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
   Object.keys(typeSpecs).forEach((typeSpecName) => {

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -1,4 +1,4 @@
-import { checkPropTypes } from 'prop-types';
+import { checkPropTypes } from './check-props';
 import { getDisplayName } from './devtools/custom';
 import { options, toChildArray } from 'preact';
 import { ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } from './constants';

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -1,6 +1,6 @@
 import { createElement as h, options, render, createRef, Component, Fragment } from 'preact';
 import { useState, useEffect, useLayoutEffect, useMemo, useCallback } from 'preact/hooks';
-import { setupScratch, teardown, clearOptions } from '../../../test/_util/helpers';
+import { setupScratch, teardown, clearOptions, serializeHtml } from '../../../test/_util/helpers';
 import { serializeVNode, initDebug } from '../../src/debug';
 import * as PropTypes from 'prop-types';
 
@@ -323,6 +323,22 @@ describe('debug', () => {
 
 			expect(console.error).to.be.calledOnce;
 			expect(errors[0].includes('required')).to.equal(true);
+		});
+
+		it('should render with error logged when validator gets signal and throws exception', () => {
+			function Baz(props) {
+				return <h1>{props.unhappy}</h1>;
+			}
+
+			Baz.propTypes = {
+				unhappy: function alwaysThrows(obj, key) { if (obj[key] === 'signal') throw Error("got prop"); }
+			};
+
+			render(<Baz unhappy={'signal'} />, scratch);
+
+			expect(console.error).to.be.calledOnce;
+			expect(errors[0].includes('got prop')).to.equal(true);
+			expect(serializeHtml(scratch)).to.equal('<h1>signal</h1>');
 		});
 
 		it('should not print to console when types are correct', () => {

--- a/package.json
+++ b/package.json
@@ -90,9 +90,6 @@
     "url": "https://github.com/developit/preact/issues"
   },
   "homepage": "https://github.com/developit/preact",
-  "dependencies": {
-    "prop-types": "^15.6.2"
-  },
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "microbundle": "^0.11.0",
     "mocha": "^5.2.0",
     "npm-run-all": "^4.0.0",
+    "prop-types": "^15.7.2",
     "sinon": "^6.1.3",
     "sinon-chai": "^3.0.0",
     "typescript": "^3.0.1",


### PR DESCRIPTION
This is intended to fix #1496.

I've once again removed the top-level dependency on `prop-types`. In its place, I've provided a fairly simplified implementation of `checkPropTypes` based on just the core of the original.

Questions/disclosures:

- [x] I don't use propTypes myself so I haven't so much as kicked the tires on this in the real world, just ran `npm rm -r node_modules && npm install && npm test` when done. [Resolved: now more tests/familiarity]
- [x] The file "debug/test/browser/debug.test.js" still needs the real 'prop-types'; I'm assuming that it *will* have that via "debug/package.json" somehow when the tests are run? If not, then I imagine the simplest fix would be to make `prop-types` a top-level **dev**Dependency. [Resolved: added as top-level devDependency]
- [x] The original version was ± ES3. I've replaced a `for (var typeSpecName in typeSpecs) if (typeSpecs.hasOwnProperty(typeSpecName)) {` loop with `Object.keys(typeSpecs).forEach((typeSpecName) => {` which is ES7 (but could trivially become ES5) [Resolved: handled by dist build]
- [x] …there's still some `vars` though to keep the `process.env.NODE_ENV` code stripping stuff simple. [Resolved: didn't need NODE_ENV here.]
- [x] The original version does its own validation on both the typeSpec function and its return value, essentially validating the validators and printing helpful messages if it finds them wanting. I've removed that and just let the raw fallout get logged instead. [Resolved: won't fix]
- [x] I wasn't sure whether the implementation belonged in `debug/src` (next to e.g. "constants.js") or in `debug/src/devtools` (next to e.g. "custom.js") so I just went with the parent folder. [Resolved: debug/ was correct]