### PR TITLE
Add support for arrays in class prop

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -34,7 +34,10 @@ let CAMEL_REG = /-?(?=[A-Z])/g;
  */
 function setProperty(dom, name, value, oldValue, isSvg) {
 	let v;
-	if (name==='class' || name==='className') name = isSvg ? 'class' : 'className';
+	if (name==='class' || name==='className') {
+		name = isSvg ? 'class' : 'className';
+		value = Array.isArray(value) ? value.filter(i => !!i).join(' ') : value;
+	}
 
 	if (name==='style') {
 


### PR DESCRIPTION
A small convenience feature to make it easier to dynamically add CSS classes.
Example:

```
const LAYOUT_CLASS = 'layout-flex-column';
const isMobile = window.matchMedia('(max-width: 640px)').matches;

<div class={[
  'panel',
  LAYOUT_CLASS,
  isMobile && 'mobile',
]}></div>
```

Will be rendered as:

```
On desktop:
<div class="panel layout-flex-column"></div>

On mobile:
<div class="panel layout-flex-column mobile"></div>
```

**Adds: 37B to core**