### PR TITLE
(feat) - prevent json injection

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -31,7 +31,8 @@
       "$_context": "__n",
       "$_defaultValue": "__p",
       "$_id": "__c",
-      "$_parentDom": "__P"
+			"$_parentDom": "__P",
+			"$_self": "_"
     }
   }
 }

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -62,7 +62,7 @@ export function createVNode(type, props, text, key, ref) {
 		_lastDomChild: null,
 		_component: null
 	};
-	vnode._ = vnode;
+	vnode._self = vnode;
 
 	if (options.vnode) options.vnode(vnode);
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -62,6 +62,7 @@ export function createVNode(type, props, text, key, ref) {
 		_lastDomChild: null,
 		_component: null
 	};
+	vnode._ = vnode;
 
 	if (options.vnode) options.vnode(vnode);
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -22,7 +22,6 @@ import options from '../options';
  * parent component
  */
 export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, force) {
-
 	// If the previous type doesn't match the new type we drop the whole subtree
 	if (oldVNode==null || newVNode==null || oldVNode.type!==newVNode.type) {
 		if (oldVNode!=null) unmount(oldVNode, ancestorComponent);
@@ -30,6 +29,11 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 		dom = null;
 		oldVNode = EMPTY_OBJ;
 	}
+
+	// When passing through createElement it assignes the object
+	// ref on _, to prevent JSON Injection we check if this attribute
+	// is equal.
+	if (newVNode._!==newVNode) return null;
 
 	if (options.diff) options.diff(newVNode);
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -30,10 +30,10 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 		oldVNode = EMPTY_OBJ;
 	}
 
-	// When passing through createElement it assignes the object
-	// ref on _, to prevent JSON Injection we check if this attribute
+	// When passing through createElement it assigns the object
+	// ref on _self, to prevent JSON Injection we check if this attribute
 	// is equal.
-	if (newVNode._!==newVNode) return null;
+	if (newVNode._self!==newVNode) return null;
 
 	if (options.diff) options.diff(newVNode);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,6 +28,7 @@ declare namespace preact {
 		 * Default value: `-1`
 		 */
 		endTime?: number;
+		_: VNode;
 	}
 
 	//

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,6 @@ declare namespace preact {
 		 * Default value: `-1`
 		 */
 		endTime?: number;
-		_: VNode;
 	}
 
 	//

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -65,6 +65,12 @@ describe('render()', () => {
 		);
 	});
 
+	it('should not render when detecting JSON-injection', () => {
+		const vnode = JSON.parse('{"type":"span","children":"Malicious"}');
+		render(vnode, scratch);
+		expect(scratch.firstChild).to.be.null;
+	});
+
 	it('should create empty nodes (<* />)', () => {
 		render(<div />, scratch);
 		expect(scratch.childNodes).to.have.length(1);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -179,10 +179,9 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
-	it.skip('should throw an error on function children', () => {
-		expect(
-			() => render(<div>{() => {}}</div>, scratch)
-		).to.throw();
+	it('should not render children when using function children', () => {
+		render(<div>{() => {}}</div>, scratch);
+		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
 	it('should render NaN as text content', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -179,7 +179,7 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
-	it('should throw an error on function children', () => {
+	it.skip('should throw an error on function children', () => {
 		expect(
 			() => render(<div>{() => {}}</div>, scratch)
 		).to.throw();

--- a/test/browser/toChildArray.test.js
+++ b/test/browser/toChildArray.test.js
@@ -59,7 +59,7 @@ describe('props.children', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
-	it('throws an error if given a function child', () => {
+	it.skip('throws an error if given a function child', () => {
 		const child = num => num.toFixed(2);
 		expect(
 			() => render(<Foo>{child}</Foo>, scratch)

--- a/test/browser/toChildArray.test.js
+++ b/test/browser/toChildArray.test.js
@@ -59,11 +59,10 @@ describe('props.children', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
-	it.skip('throws an error if given a function child', () => {
+	it('should skip a function child', () => {
 		const child = num => num.toFixed(2);
-		expect(
-			() => render(<Foo>{child}</Foo>, scratch)
-		).to.throw();
+		render(<Foo>{child}</Foo>, scratch);
+		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
 	it('returns an array containing a VNode with a text child', () => {

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -32,6 +32,11 @@ describe('createElement(jsx)', () => {
 		expect(<Test />).to.have.property('type', Test);
 	});
 
+	it('should set VNode._ property to prevent json injection', () => {
+		const vnode = <span />;
+		expect(vnode._).to.equal(vnode);
+	});
+
 	it('should set VNode#props property', () => {
 		const props = {};
 		expect(h('div', props)).to.have.property('props', props);

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -32,9 +32,9 @@ describe('createElement(jsx)', () => {
 		expect(<Test />).to.have.property('type', Test);
 	});
 
-	it('should set VNode._ property to prevent json injection', () => {
+	it('should set VNode._self property to prevent json injection', () => {
 		const vnode = <span />;
-		expect(vnode._).to.equal(vnode);
+		expect(vnode._self).to.equal(vnode);
 	});
 
 	it('should set VNode#props property', () => {


### PR DESCRIPTION
Some tests are now skipped since functions won't pass through the new `_` assignment. I opted for this above __proto__ since proto is in essence deprecated and would probably require a lot of changing in how we work in /debug.

This adds a property on vnode that tracks itself, noone can insert an object with the same ref so this will prevent JSON Injection.

TEST2: __proto__ overrides component.constructor implying that catchErrorInComponent stops working. I could really be approaching this wrong but this is what I conclude after testing it with __proto__ instead of _ with obj ref.

ADDS: 12B to core