### PR TITLE
Fix nodes with different keys being reused

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -28,7 +28,7 @@ import options from '../options';
 export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, force, oldDom) {
 
 	// If the previous type doesn't match the new type we drop the whole subtree
-	if (oldVNode==null || newVNode==null || oldVNode.type!==newVNode.type) {
+	if (oldVNode==null || newVNode==null || oldVNode.type!==newVNode.type || oldVNode.key!==newVNode.key) {
 		if (oldVNode!=null) unmount(oldVNode, ancestorComponent);
 		if (newVNode==null) return null;
 		dom = null;

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -558,7 +558,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 	});
 
-	it.skip('should not preserve state of children when the keys are different', () => {
+	it('should not preserve state of children when the keys are different', () => {
 		function Foo({ condition }) {
 			return condition ? (
 				<Fragment key="a">
@@ -584,7 +584,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 	});
 
-	it.skip('should not preserve state between unkeyed and keyed fragment', () => {
+	it('should not preserve state between unkeyed and keyed fragment', () => {
 		function Foo({ condition }) {
 			return condition ? (
 				<Fragment key="a">

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -298,7 +298,7 @@ describe('keys', () => {
 		]);
 	});
 
-	it.skip('should not preserve state when a component\'s keys are different', () => {
+	it('should not preserve state when a component\'s keys are different', () => {
 		const Stateful = createStateful('Stateful');
 
 		function Foo({ condition }) {
@@ -318,7 +318,7 @@ describe('keys', () => {
 		expect(ops).to.deep.equal(['Unmount Stateful', 'Mount Stateful'], 'switching keys 2');
 	});
 
-	it.skip('should not preserve state between an unkeyed and keyed component', () => {
+	it('should not preserve state between an unkeyed and keyed component', () => {
 		// React and Preact v8 behavior: https://codesandbox.io/s/57prmy5mx
 
 		const Stateful = createStateful('Stateful');


### PR DESCRIPTION
This PR fixes an issue where `components` would be reused even when their key is different.

Adds `+6 B` :tada:  