### PR TITLE
Fix stale DOM with async preact-router

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -70,7 +70,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 			if (oldVNode._component) {
 				c = newVNode._component = oldVNode._component;
 				clearProcessingException = c._processingException;
-				newVNode._dom = oldVNode._dom;
+				dom = newVNode._dom = oldVNode._dom;
 			}
 			else {
 				// Instantiate the new component


### PR DESCRIPTION
This PR fixes an issue that is most noticeable with the `Async` component in our cli. The issue is that the previous page is not unmounted correctly when switching routes. When this happens the vnode's `_dom` property is wrong. The changes fix this problem, but I still haven't found a way to turn it into a decent test case.

Adds `+1 B` :tada: 

**EDIT:** Found a test case that reproduces the exact issue :tada: 