### PR TITLE
(chore) - remove focusElement

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -44,7 +44,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 		if (excessDomChildren!=null) {
 			for (i = 0; oldDom==null && i < excessDomChildren.length; i++) {
 				oldDom = excessDomChildren[i];
-				oldChild = excessDomChildren[i];
 			}
 		}
 		else {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -25,7 +25,7 @@ import { removeNode } from '../util';
  */
 export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom) {
 	let childVNode, i, j, p, index, oldVNode, newDom,
-		nextDom, sibDom, focus;
+		nextDom, sibDom;
 
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode, true);
 	let oldChildren = oldParentVNode!=null && oldParentVNode!=EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR;
@@ -98,12 +98,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 
 		// Only proceed if the vnode has not been unmounted by `diff()` above.
 		if (childVNode!=null && newDom !=null) {
-			// Store focus in case moving children around changes it. Note that we
-			// can't just check once for every tree, because we have no way to
-			// differentiate wether the focus was reset by the user in a lifecycle
-			// hook or by reordering dom nodes.
-			focus = document.activeElement;
-
 			if (childVNode._lastDomChild != null) {
 				// Only Fragments or components that return Fragment like VNodes will
 				// have a non-null _lastDomChild. Continue the diff from the end of
@@ -128,11 +122,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 					}
 					parentDom.insertBefore(newDom, oldDom);
 				}
-			}
-
-			// Restore focus if it was changed
-			if (focus!==document.activeElement) {
-				focus.focus();
 			}
 
 			oldDom = newDom!=null ? newDom.nextSibling : nextDom;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -98,6 +98,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 		}
 
 		nextDom = oldDom!=null && oldDom.nextSibling;
+
 		// Morph the old element into the new one, but don't append it to the dom yet
 		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
 
@@ -113,6 +114,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 				// NOTE: excessDomChildren==oldVNode above:
 				// This is a compression of excessDomChildren==null && oldVNode==null!
 				// The values only have the same type when `null`.
+
 				outer: if (oldDom==null || oldDom.parentNode!==parentDom) {
 					parentDom.appendChild(newDom);
 				}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -31,6 +31,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	let oldChildren = oldParentVNode!=null && oldParentVNode!=EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length;
+	let oldChild;
 
 	// Only in very specific places should this logic be invoked (top level `render` and `diffElementNodes`).
 	// I'm using `EMPTY_OBJ` to signal when `diffChildren` is invoked in these situations. I can't use `null`
@@ -42,6 +43,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			for (i = 0; i < excessDomChildren.length; i++) {
 				if (excessDomChildren[i]!=null) {
 					oldDom = excessDomChildren[i];
+					oldChild = excessDomChildren[i];
 					break;
 				}
 			}
@@ -50,6 +52,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			for (i = 0; i < oldChildrenLength; i++) {
 				if (oldChildren[i] && oldChildren[i]._dom) {
 					oldDom = oldChildren[i]._dom;
+					oldChild = oldChildren[i];
 					break;
 				}
 			}
@@ -74,6 +77,9 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 					if (p!=null) {
 						if (childVNode.key==null && p.key==null ? (childVNode.type === p.type) : (childVNode.key === p.key)) {
 							index = j;
+							if (oldChildrenLength !== newChildren.length && p.type !== (oldChild && oldChild.type)) {
+								oldDom = p._dom;
+							}
 							break;
 						}
 					}
@@ -92,7 +98,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 		}
 
 		nextDom = oldDom!=null && oldDom.nextSibling;
-
 		// Morph the old element into the new one, but don't append it to the dom yet
 		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
 
@@ -108,7 +113,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 				// NOTE: excessDomChildren==oldVNode above:
 				// This is a compression of excessDomChildren==null && oldVNode==null!
 				// The values only have the same type when `null`.
-
 				outer: if (oldDom==null || oldDom.parentNode!==parentDom) {
 					parentDom.appendChild(newDom);
 				}
@@ -123,7 +127,6 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 					parentDom.insertBefore(newDom, oldDom);
 				}
 			}
-
 			oldDom = newDom!=null ? newDom.nextSibling : nextDom;
 		}
 	}

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -54,7 +54,7 @@ describe('focus', () => {
 		teardown(scratch);
 	});
 
-	it('should maintain focus when swapping elements', () => {
+	it.skip('should maintain focus when swapping elements', () => {
 		render((
 			<List>
 				<Input />

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -5,7 +5,7 @@ import { div, span, input as inputStr } from '../_util/dom';
 /* eslint-disable react/jsx-boolean-value */
 
 /** @jsx h */
-describe('focus', () => {
+describe.only('focus', () => {
 
 	/** @type {HTMLDivElement} */
 	let scratch;
@@ -106,7 +106,7 @@ describe('focus', () => {
 	it('should maintain focus when adding children around input', () => {
 		render((
 			<List>
-				<Input />
+				<Input key="5" />
 			</List>
 		), scratch);
 
@@ -114,8 +114,8 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem>1</ListItem>
-				<Input />
+				<ListItem key="1">1</ListItem>
+				<Input key="5" />
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling before');
@@ -124,9 +124,9 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem>1</ListItem>
-				<Input />
-				<ListItem>2</ListItem>
+				<ListItem key="1">1</ListItem>
+				<Input key="5" />
+				<ListItem key="2">2</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling after');
@@ -135,23 +135,25 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem>1</ListItem>
-				<Input />
-				<ListItem>2</ListItem>
-				<ListItem>3</ListItem>
+				<ListItem key="1">1</ListItem>
+				<Input key="5" />
+				<ListItem key="2">2</ListItem>
+				<ListItem key="3">3</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling after again');
 
 		input = focusInput();
 
+		console.log('last test');
+
 		render((
 			<List>
-				<ListItem>0</ListItem>
-				<ListItem>1</ListItem>
-				<Input />
-				<ListItem>2</ListItem>
-				<ListItem>3</ListItem>
+				<ListItem key="0">0</ListItem>
+				<ListItem key="1">1</ListItem>
+				<Input key="5" />
+				<ListItem key="2">2</ListItem>
+				<ListItem key="3">3</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling before again');

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -106,7 +106,7 @@ describe('focus', () => {
 	it('should maintain focus when adding children around input', () => {
 		render((
 			<List>
-				<Input key="5" />
+				<Input />
 			</List>
 		), scratch);
 
@@ -114,8 +114,8 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem key="1">1</ListItem>
-				<Input key="5" />
+				<ListItem>1</ListItem>
+				<Input />
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling before');
@@ -124,9 +124,9 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem key="1">1</ListItem>
-				<Input key="5" />
-				<ListItem key="2">2</ListItem>
+				<ListItem>1</ListItem>
+				<Input />
+				<ListItem>2</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling after');
@@ -135,10 +135,10 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem key="1">1</ListItem>
-				<Input key="5" />
-				<ListItem key="2">2</ListItem>
-				<ListItem key="3">3</ListItem>
+				<ListItem>1</ListItem>
+				<Input />
+				<ListItem>2</ListItem>
+				<ListItem>3</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling after again');
@@ -147,11 +147,11 @@ describe('focus', () => {
 
 		render((
 			<List>
-				<ListItem key="0">0</ListItem>
-				<ListItem key="1">1</ListItem>
-				<Input key="5" />
-				<ListItem key="2">2</ListItem>
-				<ListItem key="3">3</ListItem>
+				<ListItem>0</ListItem>
+				<ListItem>1</ListItem>
+				<Input />
+				<ListItem>2</ListItem>
+				<ListItem>3</ListItem>
 			</List>
 		), scratch);
 		validateFocus(input, 'insert sibling before again');

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -5,7 +5,7 @@ import { div, span, input as inputStr } from '../_util/dom';
 /* eslint-disable react/jsx-boolean-value */
 
 /** @jsx h */
-describe.only('focus', () => {
+describe('focus', () => {
 
 	/** @type {HTMLDivElement} */
 	let scratch;
@@ -144,8 +144,6 @@ describe.only('focus', () => {
 		validateFocus(input, 'insert sibling after again');
 
 		input = focusInput();
-
-		console.log('last test');
 
 		render((
 			<List>


### PR DESCRIPTION
Adding items in react: https://codesandbox.io/s/748j0p3jpj
Swapping in react: https://codesandbox.io/s/olq48z68r5

So the first we should support, which also feels obviosu to me personally but the second not so much.

The odd thing is that it only  fails when you insert a second thing above

So add one before --> works
Add one after --> works
Add one after previous --> works
Add one after the first step --> fails

Size of core stays the same
Seems to give a significant performance increase