### PR TITLE
Add `useDebugValue` hook

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -98,3 +98,11 @@ export function useMemo<T>(factory: () => T, inputs?: Inputs): T;
  * @param context The context you want to use
  */
 export function useContext<T>(context: PreactContext<T>): T;
+
+/**
+ * Customize the displayed value in the devtools panel.
+ *
+ * @param value Custom hook name or object that is passed to formatter
+ * @param formatter Formatter to modify value before sending it to the devtools
+ */
+export function useDebugValue<T>(value: T, formatter?: (value: T) => string | number): void;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -177,6 +177,16 @@ export function useContext(context) {
 	return provider.props.value;
 }
 
+/**
+ * Display a custom label for a custom hook for the devtools panel
+ * @type {<T>(value: T, cb?: (value: T) => string | number) => void}
+ */
+export function useDebugValue(value, formatter) {
+	if (options.useDebugValue) {
+		options.useDebugValue(formatter ? formatter(value) : value);
+	}
+}
+
 // Note: if someone used Component.debounce = requestAnimationFrame,
 // then effects will ALWAYS run on the NEXT frame instead of the current one, incurring a ~16ms delay.
 // Perhaps this is not such a big deal.

--- a/hooks/test/browser/useDebugValue.test.js
+++ b/hooks/test/browser/useDebugValue.test.js
@@ -1,0 +1,72 @@
+import { h, render, options } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { useDebugValue, useState } from '../../src';
+
+/** @jsx h */
+
+describe('useDebugValue', () => {
+
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+		delete options.useDebugValue;
+	});
+
+	it('should do nothing when no options hook is present', () => {
+		function useFoo() {
+			useDebugValue('foo');
+			return useState(0);
+		}
+
+		function App() {
+			let [v] = useFoo();
+			return <div>{v}</div>;
+		}
+
+		expect(() => render(<App />, scratch)).to.not.throw();
+	});
+
+	it('should call options hook with value', () => {
+		let spy = options.useDebugValue = sinon.spy();
+
+		function useFoo() {
+			useDebugValue('foo');
+			return useState(0);
+		}
+
+		function App() {
+			let [v] = useFoo();
+			return <div>{v}</div>;
+		}
+
+		render(<App />, scratch);
+
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith('foo');
+	});
+
+	it('should apply optional formatter', () => {
+		let spy = options.useDebugValue = sinon.spy();
+
+		function useFoo() {
+			useDebugValue('foo', x => x + 'bar');
+			return useState(0);
+		}
+
+		function App() {
+			let [v] = useFoo();
+			return <div>{v}</div>;
+		}
+
+		render(<App />, scratch);
+
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith('foobar');
+	});
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -194,6 +194,7 @@ declare namespace preact {
 		/** Attach a hook that is invoked after a vnode has rendered. */
 		diffed?(vnode: VNode): void;
 		event?(e: Event): void;
+		useDebugValue?(value: string | number): void;
 	}
 
 	const options: Options;


### PR DESCRIPTION
This PR adds the [useDebugValue](https://reactjs.org/docs/hooks-reference.html#usedebugvalue) hook which is only used to customize a hooks value for the devtools.

Fixes part of #1553 .
Adds `+26 B` to `preact/hooks`