### PR TITLE
(feat) - useImperativeHandle

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -66,6 +66,16 @@ type EffectCallback = () => (void | (() => void));
  */
 export function useEffect(effect: EffectCallback, inputs?: Inputs): void;
 
+type CreateHandle = () => object;
+
+/**
+ * @param ref The ref that will be mutated
+ * @param create The function that will be executed to get the value that will be attached to
+ * ref.current
+ * @param inputs If present, effect will only activate if the values in the list change (using ===).
+ */
+export function useImperativeHandle(ref: Ref, create: CreateHandle, inputs?: Inputs): void;
+
 /**
  * Accepts a function that contains imperative, possibly effectful code.
  * Use this to read layout from the DOM and synchronously re-render.

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -138,6 +138,14 @@ export function useRef(initialValue) {
 	return state._value;
 }
 
+export function useImperativeHandle(ref, createHandle, args) {
+	const state = getHookState(currentIndex++);
+	if (argsChanged(state._args, args)) {
+		state._args = args;
+		ref.current = createHandle();
+	}
+}
+
 /**
  * @param {() => any} callback
  * @param {any[]} args

--- a/hooks/test/browser/useImperativeHandle.test.js
+++ b/hooks/test/browser/useImperativeHandle.test.js
@@ -1,0 +1,52 @@
+import { createElement as h, render } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { useImperativeHandle, useRef } from '../../src';
+
+/** @jsx h */
+
+
+describe('useImperativeHandle', () => {
+
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('Mutates given ref', () => {
+		let ref;
+
+		function Comp() {
+			ref = useRef({});
+			useImperativeHandle(ref, () => ({ test: () => 'test' }), []);
+			return <p>Test</p>;
+		}
+
+		render(<Comp />, scratch);
+		expect(ref.current).to.have.property('test');
+		expect(ref.current.test()).to.equal('test');
+	});
+
+	it('Updates given ref with args', () => {
+		let ref;
+
+		function Comp({ a }) {
+			ref = useRef({});
+			useImperativeHandle(ref, () => ({ test: () => 'test' + a }), [a]);
+			return <p>Test</p>;
+		}
+
+		render(<Comp a={0} />, scratch);
+		expect(ref.current).to.have.property('test');
+		expect(ref.current.test()).to.equal('test0');
+
+		render(<Comp a={1} />, scratch);
+		expect(ref.current).to.have.property('test');
+		expect(ref.current.test()).to.equal('test1');
+	});
+});


### PR DESCRIPTION
The implementation is quite simplistic, in all honesty we could debug that there are no callback refs being passed etc but we never do this so....

It seems that in React they just override the value so I did the same thing: https://reactjs.org/docs/hooks-reference.html#useimperativehandle

Fixes: https://github.com/developit/preact/issues/1553