### PR TITLE
(feat) - replaceNode parameter

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -10,13 +10,27 @@ import options from './options';
  * @param {import('./internal').PreactElement} parentDom The DOM element to
  * render into
  */
-export function render(vnode, parentDom) {
+export function render(vnode, parentDom, replaceNode) {
 	if (options.root) options.root(vnode, parentDom);
 	let oldVNode = parentDom._prevVNode;
 	vnode = createElement(Fragment, null, [vnode]);
 
 	let mounts = [];
-	diffChildren(parentDom, parentDom._prevVNode = vnode, oldVNode, EMPTY_OBJ, parentDom.ownerSVGElement!==undefined, oldVNode ? null : EMPTY_ARR.slice.call(parentDom.childNodes), mounts, vnode, EMPTY_OBJ);
+	diffChildren(
+		parentDom,
+		replaceNode ? vnode : (parentDom._prevVNode = vnode),
+		replaceNode ? undefined : oldVNode,
+		EMPTY_OBJ,
+		parentDom.ownerSVGElement !== undefined,
+		replaceNode
+			? [replaceNode]
+			: oldVNode
+				? null
+				: EMPTY_ARR.slice.call(parentDom.childNodes),
+		mounts,
+		vnode,
+		replaceNode || EMPTY_OBJ
+	);
 	commitRoot(mounts, vnode);
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -9,6 +9,8 @@ import options from './options';
  * @param {import('./index').ComponentChild} vnode The virtual node to render
  * @param {import('./internal').PreactElement} parentDom The DOM element to
  * render into
+ * @param {import('./dom').PreactElement} [replaceNode] Attempt to re-use an
+ * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
 	if (options.root) options.root(vnode, parentDom);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -913,7 +913,6 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<div>foo</div>');
 	});
 
-<<<<<<< HEAD
 	// see preact/#1327
 	it('should not reuse unkeyed components', () => {
 		class X extends Component {
@@ -967,7 +966,7 @@ describe('render()', () => {
 
 		expect(scratch.textContent).to.equal('01');
 	});
-=======
+
 	describe('replaceNode parameter', () => {
 
 		function appendChildToScratch(id) {
@@ -1007,5 +1006,4 @@ describe('render()', () => {
 		});
 	});
 
->>>>>>> Adds 8.x replaceNode to render api
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -913,6 +913,7 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<div>foo</div>');
 	});
 
+<<<<<<< HEAD
 	// see preact/#1327
 	it('should not reuse unkeyed components', () => {
 		class X extends Component {
@@ -966,4 +967,45 @@ describe('render()', () => {
 
 		expect(scratch.textContent).to.equal('01');
 	});
+=======
+	describe('replaceNode parameter', () => {
+
+		function appendChildToScratch(id) {
+			const child = document.createElement('div');
+			child.id = id;
+			scratch.appendChild(child);
+		}
+
+		beforeEach(() => {
+			['a', 'b', 'c'].forEach(id => appendChildToScratch(id));
+		});
+
+		it('should use replaceNode as render root and not inject into it', () => {
+			const childA = scratch.querySelector('#a');
+			render(<div id="a">contents</div>, scratch, childA);
+			expect(scratch.querySelector('#a')).to.equal(childA);
+			expect(childA.innerHTML).to.equal('contents');
+		});
+
+		it('should not remove siblings of replaceNode', () => {
+			const childA = scratch.querySelector('#a');
+			render(<div id="a" />, scratch, childA);
+			expect(scratch.innerHTML).to.equal('<div id="a"></div><div id="b"></div><div id="c"></div>');
+		});
+		
+		it('should render multiple render roots in one parentDom', () => {
+			const childA = scratch.querySelector('#a');
+			const childB = scratch.querySelector('#b');
+			const childC = scratch.querySelector('#c');
+			const expectedA = '<div id="a">childA</div>';
+			const expectedB = '<div id="b">childB</div>';
+			const expectedC = '<div id="c">childC</div>';
+			render(<div id="a">childA</div>, scratch, childA);
+			render(<div id="b">childB</div>, scratch, childB);
+			render(<div id="c">childC</div>, scratch, childC);
+			expect(scratch.innerHTML).to.equal(`${expectedA}${expectedB}${expectedC}`);
+		});
+	});
+
+>>>>>>> Adds 8.x replaceNode to render api
 });


### PR DESCRIPTION
This implementation brings back the third _optional_ parameter `replaceNode` from `8.x`

> `render(component, containerNode, [replaceNode])`

https://preactjs.com/guide/api-reference#preact-render-

With this parameter you can provide child node in your parent DOM that will be used as render root. It does not replace other children inside the parent and it will hydrate the provided node and not just replace it, the DOM nodes remain the same.

I made a more comprehensive infographic to describe why I see this as useful

https://gist.github.com/LukasBombach/884319d5430a3fb85f3b4385d7a31c89

You can try out a working usage in this repo: https://github.com/spring-media/pool-attendant (See [index.partial.hydration.js](https://github.com/spring-media/pool-attendant/blob/master/packages/app/src/index.partial.hydration.js))

ADDS: 16B to core