### PR TITLE
Fix hoisting of components without DOM

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -93,7 +93,7 @@ export function coerceToVNode(possibleVNode) {
 	}
 
 	// Clone vnode if it has already been used. ceviche/#57
-	if (possibleVNode._dom!=null) {
+	if (possibleVNode._dom!=null || possibleVNode._component!=null) {
 		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.text, possibleVNode.key, null);
 		vnode._dom = possibleVNode._dom;
 		return vnode;


### PR DESCRIPTION
@localvoid was right on the money. We were missing a check in `coerceToVNode` which only checked for `vnodes` with a `_dom`. But we actually need that same logic for components, too.

Fixes #1323 .
Adds `+2 B`.