### PR TITLE
Disable travis' email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 
+notifications:
+  email: false
+
 language: node_js
 
 node_js:


### PR DESCRIPTION
We decided that they are too spammy. Many of us visit this repo multiple times a day so we are very aware of the current build status anyway. On top of that we were notified that forks do receive quite a lot of emails from Travis from us. We're worried that this may scare of new contributors, so the decision was made to disable email notifications for now.