### PR TITLE
(fix) - prevent crash when there is no last DOM child node

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -60,7 +60,7 @@ export function diff(dom, parentDom, newVNode, oldVNode, context, isSvg, excessD
 
 				// If the last child is a Fragment, use _lastDomChild, else use _dom
 				p = newVNode._children[newVNode._children.length - 1];
-				newVNode._lastDomChild = p._lastDomChild || p._dom;
+				newVNode._lastDomChild = p && (p._lastDomChild || p._dom);
 			}
 		}
 		else if (typeof newType==='function') {

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -98,7 +98,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('hello <span>world</span>');
 	});
 
-	it('should not crash with null as last child', () => {
+	it.only('should not crash with null as last child', () => {
 		let fn = () => {
 			render((
 				<Fragment>
@@ -107,6 +107,17 @@ describe('Fragment', () => {
 				</Fragment>
 			), scratch);
 		};
+		expect(fn).not.to.throw();
+		expect(scratch.innerHTML).to.equal('<span>world</span>');
+
+		render((
+			<Fragment>
+				<span>world</span>
+				<p>Hello</p>
+			</Fragment>
+		), scratch);
+		expect(scratch.innerHTML).to.equal('<span>world</span><p>Hello</p>');
+
 		expect(fn).not.to.throw();
 		expect(scratch.innerHTML).to.equal('<span>world</span>');
 

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -98,6 +98,27 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('hello <span>world</span>');
 	});
 
+	it('should not crash with null as last child', () => {
+		let fn = () => {
+			render((
+				<Fragment>
+					<span>world</span>
+					{null}
+				</Fragment>
+			), scratch);
+		};
+		expect(fn).not.to.throw();
+		expect(scratch.innerHTML).to.equal('<span>world</span>');
+		render((
+			<Fragment>
+				<span>world</span>
+				{null}
+				<span>world</span>
+			</Fragment>
+		), scratch);
+		expect(scratch.innerHTML).to.equal('<span>world</span><span>world</span>');
+	});
+
 	it('should handle reordering components that return Fragments #1325', () => {
 		class X extends Component {
 			render() {

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -109,6 +109,7 @@ describe('Fragment', () => {
 		};
 		expect(fn).not.to.throw();
 		expect(scratch.innerHTML).to.equal('<span>world</span>');
+
 		render((
 			<Fragment>
 				<span>world</span>
@@ -117,6 +118,15 @@ describe('Fragment', () => {
 			</Fragment>
 		), scratch);
 		expect(scratch.innerHTML).to.equal('<span>world</span><span>world</span>');
+
+		render((
+			<Fragment>
+				<span>world</span>
+				Hello
+				<span>world</span>
+			</Fragment>
+		), scratch);
+		expect(scratch.innerHTML).to.equal('<span>world</span>Hello<span>world</span>');
 	});
 
 	it('should handle reordering components that return Fragments #1325', () => {

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -98,7 +98,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('hello <span>world</span>');
 	});
 
-	it.only('should not crash with null as last child', () => {
+	it('should not crash with null as last child', () => {
 		let fn = () => {
 			render((
 				<Fragment>


### PR DESCRIPTION
Fixes: https://github.com/developit/preact/issues/1567

Adds 1B to core