### PR TITLE
Better Integration for TypeScript + Preact + Unistore

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -273,24 +273,30 @@ export namespace JSXInternal {
 	interface PathAttributes {
 		d: string;
 	}
+	
+	type EventHandlers<E extends Event> = EventHandler<E> | UnistoreEventHandler<any, E>;
 
 	interface EventHandler<E extends Event> {
 		(event: E): void;
 	}
 
-	type ClipboardEventHandler = EventHandler<ClipboardEvent>;
-	type CompositionEventHandler = EventHandler<CompositionEvent>;
-	type DragEventHandler = EventHandler<DragEvent>;
-	type FocusEventHandler = EventHandler<FocusEvent>;
-	type KeyboardEventHandler = EventHandler<KeyboardEvent>;
-	type MouseEventHandler = EventHandler<MouseEvent>;
-	type TouchEventHandler = EventHandler<TouchEvent>;
-	type UIEventHandler = EventHandler<UIEvent>;
-	type WheelEventHandler = EventHandler<WheelEvent>;
-	type AnimationEventHandler = EventHandler<AnimationEvent>;
-	type TransitionEventHandler = EventHandler<TransitionEvent>;
-	type GenericEventHandler = EventHandler<Event>;
-	type PointerEventHandler = EventHandler<PointerEvent>;
+	interface UnistoreEventHandler<K extends any, E extends Event> {
+		(state: K, event: E) : Promise<Partial<K>> | Partial<K> | void;
+	}
+
+	type ClipboardEventHandler = EventHandlers<ClipboardEvent>;
+	type CompositionEventHandler = EventHandlers<CompositionEvent>;
+	type DragEventHandler = EventHandlers<DragEvent>;
+	type FocusEventHandler = EventHandlers<FocusEvent>;
+	type KeyboardEventHandler = EventHandlers<KeyboardEvent>;
+	type MouseEventHandler = EventHandlers<MouseEvent>;
+	type TouchEventHandler = EventHandlers<TouchEvent>;
+	type UIEventHandler = EventHandlers<UIEvent>;
+	type WheelEventHandler = EventHandlers<WheelEvent>;
+	type AnimationEventHandler = EventHandlers<AnimationEvent>;
+	type TransitionEventHandler = EventHandlers<TransitionEvent>;
+	type GenericEventHandler = EventHandlers<Event>;
+	type PointerEventHandler = EventHandlers<PointerEvent>;
 
 	interface DOMAttributes extends preact.PreactDOMAttributes {
 		// Image Events


### PR DESCRIPTION
I write PoC program with TypeScript, Preact, Unistore(Preact & Unistore is great!)

I happened TypeScript error. Because type definition of onClick is like below(in jsx.d.ts):
```typescript
onClick?: MouseEventHandler;
type MouseEventHandler = EventHandler<MouseEvent>;
interface EventHandler<E extends Event> {
		(event: E): void;
}
```
So onClick accepts function that has 1 argument, and the type is MouseEvent.
But Integrate with unistore, first argument of function is State object.

TypeScript compile error:
![jsxerror](https://user-images.githubusercontent.com/625124/56795726-0871f500-684c-11e9-9799-622c50f4e411.png)

Sample code is here: https://github.com/yokotaso/preact-unistore-typescript-integration

I suggest to add UnistoreEventHandler for unistore.