### PR TITLE
Code golf diffChildren size down by 33 B ⛳️

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -94,7 +94,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			nextDom = oldDom!=null && oldDom.nextSibling;
 
 			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
+			newDom = diff(oldVNode && oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
 
 			// Only proceed if the vnode has not been unmounted by `diff()` above.
 			if (newDom!=null) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -28,7 +28,9 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 		nextDom, sibDom, focus;
 
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode, true);
-	let oldChildren = oldParentVNode!=null && oldParentVNode!=EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR;
+	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
+	// as EMPTY_OBJ._children should be `undefined`.
+	let oldChildren = oldParentVNode!=null && oldParentVNode._children || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -39,19 +39,13 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	if (oldDom == EMPTY_OBJ) {
 		oldDom = null;
 		if (excessDomChildren!=null) {
-			for (i = 0; i < excessDomChildren.length; i++) {
-				if (excessDomChildren[i]!=null) {
-					oldDom = excessDomChildren[i];
-					break;
-				}
+			for (i = 0; oldDom==null && i < excessDomChildren.length; i++) {
+				oldDom = excessDomChildren[i];
 			}
 		}
 		else {
-			for (i = 0; i < oldChildrenLength; i++) {
-				if (oldChildren[i] && oldChildren[i]._dom) {
-					oldDom = oldChildren[i]._dom;
-					break;
-				}
+			for (i = 0; oldDom==null && i < oldChildrenLength; i++) {
+				oldDom = oldChildren[i] && oldChildren[i]._dom;
 			}
 		}
 	}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -58,13 +58,14 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 
 	for (i=0; i<newChildren.length; i++) {
 		childVNode = newChildren[i] = coerceToVNode(newChildren[i]);
-		oldVNode = index = null;
-
-		// Check if we find a corresponding element in oldChildren and store the
-		// index where the element was found.
-		p = oldChildren[i];
-
+		
 		if (childVNode!=null) {
+			oldVNode = index = null;
+
+			// Check if we find a corresponding element in oldChildren and store the
+			// index where the element was found.
+			p = oldChildren[i];
+
 			if (p===null || (p != null && (childVNode.key==null && p.key==null ? (childVNode.type === p.type) : (childVNode.key === p.key)))) {
 				index = i;
 			}
@@ -79,63 +80,63 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 					}
 				}
 			}
-		}
 
-		// If we have found a corresponding old element we store it in a variable
-		// and delete it from the array. That way the next iteration can skip this
-		// element.
-		if (index!=null) {
-			oldVNode = oldChildren[index];
-			// We can't use `null` here because that is reserved for empty
-			// placeholders (holes)
-			oldChildren[index] = undefined;
-		}
-
-		nextDom = oldDom!=null && oldDom.nextSibling;
-
-		// Morph the old element into the new one, but don't append it to the dom yet
-		newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
-
-		// Only proceed if the vnode has not been unmounted by `diff()` above.
-		if (childVNode!=null && newDom !=null) {
-			// Store focus in case moving children around changes it. Note that we
-			// can't just check once for every tree, because we have no way to
-			// differentiate wether the focus was reset by the user in a lifecycle
-			// hook or by reordering dom nodes.
-			focus = document.activeElement;
-
-			if (childVNode._lastDomChild != null) {
-				// Only Fragments or components that return Fragment like VNodes will
-				// have a non-null _lastDomChild. Continue the diff from the end of
-				// this Fragment's DOM tree.
-				newDom = childVNode._lastDomChild;
+			// If we have found a corresponding old element we store it in a variable
+			// and delete it from the array. That way the next iteration can skip this
+			// element.
+			if (index!=null) {
+				oldVNode = oldChildren[index];
+				// We can't use `null` here because that is reserved for empty
+				// placeholders (holes)
+				oldChildren[index] = undefined;
 			}
-			else if (excessDomChildren==oldVNode || newDom!=oldDom || newDom.parentNode==null) {
-				// NOTE: excessDomChildren==oldVNode above:
-				// This is a compression of excessDomChildren==null && oldVNode==null!
-				// The values only have the same type when `null`.
 
-				outer: if (oldDom==null || oldDom.parentNode!==parentDom) {
-					parentDom.appendChild(newDom);
+			nextDom = oldDom!=null && oldDom.nextSibling;
+
+			// Morph the old element into the new one, but don't append it to the dom yet
+			newDom = diff(oldVNode==null ? null : oldVNode._dom, parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
+
+			// Only proceed if the vnode has not been unmounted by `diff()` above.
+			if (newDom!=null) {
+				// Store focus in case moving children around changes it. Note that we
+				// can't just check once for every tree, because we have no way to
+				// differentiate wether the focus was reset by the user in a lifecycle
+				// hook or by reordering dom nodes.
+				focus = document.activeElement;
+
+				if (childVNode._lastDomChild != null) {
+					// Only Fragments or components that return Fragment like VNodes will
+					// have a non-null _lastDomChild. Continue the diff from the end of
+					// this Fragment's DOM tree.
+					newDom = childVNode._lastDomChild;
 				}
-				else {
-					sibDom = oldDom;
-					j = 0;
-					while ((sibDom=sibDom.nextSibling) && j++<oldChildrenLength/2) {
-						if (sibDom===newDom) {
-							break outer;
-						}
+				else if (excessDomChildren==oldVNode || newDom!=oldDom || newDom.parentNode==null) {
+					// NOTE: excessDomChildren==oldVNode above:
+					// This is a compression of excessDomChildren==null && oldVNode==null!
+					// The values only have the same type when `null`.
+
+					outer: if (oldDom==null || oldDom.parentNode!==parentDom) {
+						parentDom.appendChild(newDom);
 					}
-					parentDom.insertBefore(newDom, oldDom);
+					else {
+						sibDom = oldDom;
+						j = 0;
+						while ((sibDom=sibDom.nextSibling) && j++<oldChildrenLength/2) {
+							if (sibDom===newDom) {
+								break outer;
+							}
+						}
+						parentDom.insertBefore(newDom, oldDom);
+					}
 				}
-			}
 
-			// Restore focus if it was changed
-			if (focus!==document.activeElement) {
-				focus.focus();
-			}
+				// Restore focus if it was changed
+				if (focus!==document.activeElement) {
+					focus.focus();
+				}
 
-			oldDom = newDom!=null ? newDom.nextSibling : nextDom;
+				oldDom = newDom!=null ? newDom.nextSibling : nextDom;
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request reduces the gzipped code size by 33 bytes by progressively refactoring `diffChildren`. The commits are roughly in an increasing order of weirdness, so just some of them can be cherry-picked if needed.

 * 65dfda6, d676eba Do pretty run-of-the mill refactoring to avoid comparisons (-9 B)
 * 5a9ad93 Avoids two `break` statements (-7 B)
 * f9bc8c5 Refactors out local variables `p` and `index`, with hopefully sufficient comments explaining the logic (-13 B)
 * 7b3606d Compresses code by assuming that `EMPTY_OBJ._children` is `undefined` (-4 B)

These changes conflict a bit with @andrewiggins's #1578, sorry about that.