### PR TITLE
Fix _lastDomChild disregarding placeholders

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -52,8 +52,13 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				newVNode._dom = newVNode._children[0]._dom;
 
 				// If the last child is a Fragment, use _lastDomChild, else use _dom
-				p = newVNode._children[newVNode._children.length - 1];
-				newVNode._lastDomChild = p && (p._lastDomChild || p._dom);
+				// We have no guarantee that the last child rendered something into the
+				// dom, so we iterate backwards to find the last child with a dom node.
+				for (let i = newVNode._children.length; i--;) {
+					p = newVNode._children[i];
+					newVNode._lastDomChild = p && (p._lastDomChild || p._dom);
+					if (newVNode._lastDomChild) break;
+				}
 			}
 		}
 		else if (typeof newType==='function') {

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1836,4 +1836,38 @@ describe('Fragment', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal(successHtml);
 	});
+
+	it('should use the last dom node for _lastDomChild', () => {
+		let Noop = () => null;
+		let update;
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				update = () => this.setState({ items: ['A', 'B', 'C'] });
+				this.state = {
+					items: null
+				};
+			}
+
+			render() {
+				return (
+					<div>
+						{this.state.items && (
+							<Fragment>
+								{this.state.items.map(v => <div>{v}</div>)}
+								<Noop />
+							</Fragment>
+						)}
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.textContent).to.equal('');
+
+		update();
+		rerender();
+		expect(scratch.textContent).to.equal('ABC');
+	});
 });


### PR DESCRIPTION
Issue was that we always assumed that the last child of a `Fragment` rendered a DOM node. This is not true for many components and even less with #1440 . This PR changes it so that we search the `_children` array backwards until we find a non-null DOM node.

Fixes #1586 .
Adds `+17 B` :tada: 