### PR TITLE
(fix) Add support for global event handlers like animation and transition

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -73,7 +73,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	else if (name[0]==='o' && name[1]==='n') {
 		let useCapture = name !== (name=name.replace(/Capture$/, ''));
 		let nameLower = name.toLowerCase();
-		name = (nameLower in dom ? nameLower : name).substring(2);
+		name = (nameLower in window ? nameLower : name).substring(2);
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -73,7 +73,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	else if (name[0]==='o' && name[1]==='n') {
 		let useCapture = name !== (name=name.replace(/Capture$/, ''));
 		let nameLower = name.toLowerCase();
-		name = (nameLower in window ? nameLower : name).substring(2);
+		name = (nameLower in self ? nameLower : name).substring(2);
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -572,6 +572,13 @@ describe('render()', () => {
 			expect(click).not.to.have.been.called;
 		});
 
+		it('should register events not appearing on dom nodes', () => {
+			let onAnimationEnd = () => {};
+
+			render(<div onAnimationEnd={onAnimationEnd} />, scratch);
+			expect(proto.addEventListener).to.have.been.calledOnce.and.to.have.been.calledWithExactly('animationend', sinon.match.func, false);
+		});
+
 		// Skip test if browser doesn't support passive events
 		if (supportsPassiveEvents()) {
 			it('should use capturing for event props ending with *Capture', () => {


### PR DESCRIPTION
Instead for looking into the `dom` reference widen the lookup on the window instead. That means, supporting Global Event Handlers as well. Like `animation` or `transition`.

Fixes #1589 
~~Adds +5B~~
Adds +3B