### PR TITLE
Introduce Suspense and lazy

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -1,4 +1,4 @@
-import { render as preactRender, cloneElement as preactCloneElement, createRef, h, Component, options, toChildArray, createContext, Fragment } from 'preact';
+import { render as preactRender, cloneElement as preactCloneElement, createRef, h, Component, options, toChildArray, createContext, Fragment, Suspense, lazy } from 'preact';
 import * as hooks from 'preact/hooks';
 export * from 'preact/hooks';
 import { assign } from '../../src/util';
@@ -401,5 +401,7 @@ export default assign({
 	PureComponent,
 	memo,
 	forwardRef,
-	unstable_batchedUpdates
+	unstable_batchedUpdates,
+	Suspense,
+	lazy
 }, hooks);

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -378,7 +378,9 @@ export {
 	memo,
 	forwardRef,
 	// eslint-disable-next-line camelcase
-	unstable_batchedUpdates
+	unstable_batchedUpdates,
+	Suspense,
+	lazy
 };
 
 // React copies the named exports to the default one.

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -74,6 +74,22 @@ export function initDebug() {
 
 		// Check prop-types if available
 		if (typeof vnode.type==='function' && vnode.type.propTypes) {
+			if (vnode.type.name === 'Lazy') {
+				const m = 'PropTypes are not supported on lazy(). Use propTypes on the wrapped component itself. ';
+				try {
+					const lazied = vnode.type();
+					console.warn(m + 'Component wrapped in lazy() is ' + lazied.then.displayName || lazied.then.name);
+				}
+				catch (promise) {
+					console.warn(m + 'We will log the wrapped component\'s name once it is loaded.');
+					if (promise.then) {
+						promise.then((exports) => {
+							console.warn('Component wrapped in lazy() is ' + (exports.default.displayName || exports.default.name));
+						});
+					}
+
+				}
+			}
 			checkPropTypes(vnode.type.propTypes, vnode.props, getDisplayName(vnode), serializeVNode(vnode));
 		}
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -77,8 +77,8 @@ export function initDebug() {
 			if (vnode.type.displayName === 'Lazy') {
 				const m = 'PropTypes are not supported on lazy(). Use propTypes on the wrapped component itself. ';
 				try {
-					const lazied = vnode.type();
-					console.warn(m + 'Component wrapped in lazy() is ' + lazied.then.displayName || lazied.then.name);
+					const lazyVNode = vnode.type();
+					console.warn(m + 'Component wrapped in lazy() is ' + (lazyVNode.type.displayName || lazyVNode.type.name));
 				}
 				catch (promise) {
 					console.warn(m + 'We will log the wrapped component\'s name once it is loaded.');

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -74,7 +74,7 @@ export function initDebug() {
 
 		// Check prop-types if available
 		if (typeof vnode.type==='function' && vnode.type.propTypes) {
-			if (vnode.type.name === 'Lazy') {
+			if (vnode.type.displayName === 'Lazy') {
 				const m = 'PropTypes are not supported on lazy(). Use propTypes on the wrapped component itself. ';
 				try {
 					const lazied = vnode.type();

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -487,6 +487,27 @@ describe('debug', () => {
 					expect(console.warn).to.be.calledOnce;
 				});
 			});
+
+			it('should not log a component if lazy\'s loader throws', () => {
+				const FakeLazy = lazy(() => { throw new Error('Hello'); });
+				FakeLazy.propTypes = {};
+				let error;
+				try {
+					render(
+						<Suspense fallback={<div>fallback...</div>} >
+							<FakeLazy />
+						</Suspense>,
+						scratch
+					);
+				}
+				catch (e) {
+					error = e;
+				}
+
+				expect(console.warn).to.be.calledOnce;
+				expect(error).not.to.be.undefined;
+				expect(error.message).to.eql('Hello');
+			});
 		});
 	});
 });

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -427,6 +427,8 @@ describe('debug', () => {
 
 		describe('warn for PropTypes on lazy()', () => {
 			it('should log the function name', () => {
+				const rerender = setupRerender();
+
 				const loader = Promise.resolve({ default: function MyLazyLoadedComponent() { return <div>Hi there</div>; } });
 				const FakeLazy = lazy(() => loader);
 				FakeLazy.propTypes = {};
@@ -440,10 +442,15 @@ describe('debug', () => {
 				return loader.then(() => {
 					expect(console.warn).to.be.calledTwice;
 					expect(warnings[1].includes('MyLazyLoadedComponent')).to.equal(true);
+					rerender();
+					expect(console.warn).to.be.calledThrice;
+					expect(warnings[2].includes('MyLazyLoadedComponent')).to.equal(true);
 				});
 			});
 
 			it('should log the displayName', () => {
+				const rerender = setupRerender();
+
 				function MyLazyLoadedComponent() { return <div>Hi there</div>; }
 				MyLazyLoadedComponent.displayName = 'HelloLazy';
 				const loader = Promise.resolve({ default: MyLazyLoadedComponent });
@@ -459,6 +466,9 @@ describe('debug', () => {
 				return loader.then(() => {
 					expect(console.warn).to.be.calledTwice;
 					expect(warnings[1].includes('HelloLazy')).to.equal(true);
+					rerender();
+					expect(console.warn).to.be.calledThrice;
+					expect(warnings[2].includes('HelloLazy')).to.equal(true);
 				});
 			});
 

--- a/demo/devtools.js
+++ b/demo/devtools.js
@@ -9,7 +9,6 @@ function LazyComp() {
 	return <div>I'm (fake) lazy loaded</div>;
 }
 
-console.log(lazy);
 const Lazy = lazy(() => Promise.resolve({ default: LazyComp }));
 
 const Memoed = memo(Foo);

--- a/demo/devtools.js
+++ b/demo/devtools.js
@@ -1,9 +1,16 @@
 // eslint-disable-next-line no-unused-vars
-import { createElement, Component, memo, Fragment } from "react";
+import { createElement, Component, memo, Fragment, Suspense, lazy } from "react";
 
 function Foo() {
 	return <div>I'm memoed</div>;
 }
+
+function LazyComp() {
+	return <div>I'm (fake) lazy loaded</div>;
+}
+
+console.log(lazy);
+const Lazy = lazy(() => Promise.resolve({ default: LazyComp }));
 
 const Memoed = memo(Foo);
 
@@ -14,6 +21,11 @@ export default class DevtoolsDemo extends Component {
 				<h1>memo()</h1>
 				<p><b>functional component:</b></p>
 				<Memoed />
+				<h1>lazy()</h1>
+				<p><b>functional component:</b></p>
+				<Suspense fallback={<div>Loading (fake) lazy loaded component...</div>}>
+					<Lazy />
+				</Suspense>
 			</div>
 		);
 	}

--- a/demo/index.js
+++ b/demo/index.js
@@ -17,6 +17,7 @@ import StyledComp from './styled-components';
 import { initDevTools } from 'preact/debug/src/devtools';
 import { initDebug } from 'preact/debug/src/debug';
 import DevtoolsDemo from './devtools';
+import SuspenseDemo from './suspense';
 
 let isBenchmark = /(\/spiral|\/pythagoras|[#&]bench)/g.test(window.location.href);
 if (!isBenchmark) {
@@ -71,6 +72,7 @@ class App extends Component {
 						<Link href="/people" activeClassName="active">People Browser</Link>
 						<Link href="/state-order" activeClassName="active">State Order</Link>
 						<Link href="/styled-components" activeClassName="active">Styled Components</Link>
+						<Link href="/suspense" activeClassName="active">Suspense / lazy</Link>
 					</nav>
 				</header>
 				<main>
@@ -96,6 +98,7 @@ class App extends Component {
 						<KeyBug path="/key_bug" />
 						<Context path="/context" />
 						<DevtoolsDemo path="/devtools" />
+						<SuspenseDemo path="/suspense" />
 						<EmptyFragment path="/empty-fragment" />
 						<PeopleBrowser path="/people/:user?" />
 						<StyledComp path="/styled-components" />

--- a/demo/suspense.js
+++ b/demo/suspense.js
@@ -49,6 +49,7 @@ function CustomSuspense({ isDone, start, timeout, name }) {
 }
 
 function init() {
+	console.log('init');
 	return {
 		s1: createSuspension('1', 1000, null),
 		s2: createSuspension('2', 2000, null),
@@ -60,6 +61,7 @@ export default class DevtoolsDemo extends Component {
 	constructor(props) {
 		super(props);
 		this.state = init();
+		this.onRerun = this.onRerun.bind(this)
 	}
 
 	onRerun() {
@@ -74,6 +76,9 @@ export default class DevtoolsDemo extends Component {
 					<Lazy />
 				</Suspense>
 				<h1>Suspense</h1>
+				<div>
+					<button onClick={this.onRerun} >Rerun</button>
+				</div>
 				<Suspense fallback={<div>Fallback 1</div>}>
 					<CustomSuspense {...state.s1} />
 					<Suspense fallback={<div>Fallback 2</div>}>

--- a/demo/suspense.js
+++ b/demo/suspense.js
@@ -49,7 +49,6 @@ function CustomSuspense({ isDone, start, timeout, name }) {
 }
 
 function init() {
-	console.log('init');
 	return {
 		s1: createSuspension('1', 1000, null),
 		s2: createSuspension('2', 2000, null),

--- a/demo/suspense.js
+++ b/demo/suspense.js
@@ -60,7 +60,7 @@ export default class DevtoolsDemo extends Component {
 	constructor(props) {
 		super(props);
 		this.state = init();
-		this.onRerun = this.onRerun.bind(this)
+		this.onRerun = this.onRerun.bind(this);
 	}
 
 	onRerun() {

--- a/demo/suspense.js
+++ b/demo/suspense.js
@@ -1,0 +1,87 @@
+// eslint-disable-next-line no-unused-vars
+import { createElement, Component, memo, Fragment, Suspense, lazy } from "react";
+
+function LazyComp() {
+	return <div>I'm (fake) lazy loaded</div>;
+}
+
+const Lazy = lazy(() => Promise.resolve({ default: LazyComp }));
+
+function createSuspension(name, timeout, error) {
+	let done = false;
+	let prom;
+
+	return {
+		name,
+		timeout,
+		start: () => {
+			if (!prom) {
+				prom = new Promise((res, rej) => {
+					setTimeout(() => {
+						done = true;
+						if (error) {
+							rej(error);
+						}
+						else {
+							res();
+						}
+					}, timeout);
+				});
+			}
+
+			return prom;
+		},
+		getPromise: () => prom,
+		isDone: () => done
+	};
+}
+
+function CustomSuspense({ isDone, start, timeout, name }) {
+	if (!isDone()) {
+		throw start();
+	}
+
+	return (
+		<div>
+			Hello from CustomSuspense {name}, loaded after {timeout / 1000}s
+		</div>
+	);
+}
+
+function init() {
+	return {
+		s1: createSuspension('1', 1000, null),
+		s2: createSuspension('2', 2000, null),
+		s3: createSuspension('3', 3000, null)
+	};
+}
+
+export default class DevtoolsDemo extends Component {
+	constructor(props) {
+		super(props);
+		this.state = init();
+	}
+
+	onRerun() {
+		this.setState(init());
+	}
+
+	render(props, state) {
+		return (
+			<div>
+				<h1>lazy()</h1>
+				<Suspense fallback={<div>Loading (fake) lazy loaded component...</div>}>
+					<Lazy />
+				</Suspense>
+				<h1>Suspense</h1>
+				<Suspense fallback={<div>Fallback 1</div>}>
+					<CustomSuspense {...state.s1} />
+					<Suspense fallback={<div>Fallback 2</div>}>
+						<CustomSuspense {...state.s2} />
+						<CustomSuspense {...state.s3} />
+					</Suspense>
+				</Suspense>
+			</div>
+		);
+	}
+}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -373,8 +373,8 @@ function catchErrorInComponent(error, component) {
 		if (!component._processingException) {
 			try {
 				if (isSuspend) {
-					if (component.__s) {
-						component.__s(error);
+					if (component._childDidSuspend) {
+						component._childDidSuspend(error);
 					}
 					else {
 						continue;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -400,12 +400,6 @@ function catchErrorInComponent(error, component) {
 		}
 	}
 
-	// TODO: Add a react-like error message to preact/debug
-	/*
-		[componentName] suspended while rendering, but no fallback UI was specified.
-
-		Add a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.
- 	*/
 	if (isSuspend) {
 		return catchErrorInComponent(new Error('Missing Suspense'), suspendingComponent);
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -43,10 +43,9 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 	try {
 		outer: if (oldVNode.type===Fragment || newType===Fragment) {
-			// Passing the ancestorComponent here is needed for catchErrorInComponent to properly traverse upwards through fragments
-			// to find a parent Suspense
-			c = { _ancestorComponent: ancestorComponent };
-			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, c, oldDom);
+			// Passing the ancestorComponent instead of c here is needed for catchErrorInComponent
+			// to properly traverse upwards through fragments to find a parent Suspense
+			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom);
 
 			// Mark dom as empty in case `_children` is any empty array. If it isn't
 			// we'll set `dom` to the correct value just a few lines later.

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -393,8 +393,7 @@ function catchErrorInComponent(error, component) {
 			}
 			catch (e) {
 				error = e;
-				isSuspend = typeof error.then === 'function';
-				suspendingComponent = component;
+				isSuspend = false;
 			}
 		}
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ export { Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
 export { toChildArray } from './diff/children';
+export { Suspense, lazy } from './suspense';
 export { default as options } from './options';

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -2,13 +2,13 @@ import { Component } from './component';
 import { createElement } from './create-element';
 
 // having a "custom class" here saves 50bytes gzipped
-export function s(props) {}
-s.prototype = new Component();
+export function Suspense(props) {}
+Suspense.prototype = new Component();
 
 /**
  * @param {Promise} promise The thrown promise
  */
-s.prototype._childDidSuspend = function(promise) {
+Suspense.prototype._childDidSuspend = function(promise) {
 	this.setState({ _loading: true });
 	const cb = () => { this.setState({ _loading: false }); };
 
@@ -16,13 +16,9 @@ s.prototype._childDidSuspend = function(promise) {
 	promise.then(cb, cb);
 };
 
-s.prototype.render = function(props, state) {
+Suspense.prototype.render = function(props, state) {
 	return state._loading ? props.fallback : props.children;
 };
-
-// exporting s as Suspense instead of naming the class iself Suspense saves 4 bytes gzipped
-// TODO: does this add the need of a displayName?
-export const Suspense = s;
 
 export function lazy(loader) {
 	let prom;

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -4,10 +4,15 @@ import { createElement } from './create-element';
 // TODO: react warns in dev mode about defaultProps and propTypes not being supported on lazy
 // loaded components
 
+export const sym = Symbol.for('Suspense');
+
 export class Suspense extends Component {
 	constructor(props) {
 		// TODO: should we add propTypes in DEV mode?
 		super(props);
+
+		// mark this component as a handler of suspension (thrown Promises)
+		this[sym] = sym;
 
 		this.state = {
 			l: false

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -32,8 +32,8 @@ export function lazy(loader) {
 		if (!prom) {
 			prom = loader();
 			prom.then(
-				({ default: c }) => { component = c; },
-				e => error = e,
+				(exports) => { component = exports.default; },
+				(e) => { error = e; },
 			);
 		}
 

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -29,10 +29,7 @@ export function lazy(loader) {
 		if (!prom) {
 			prom = loader();
 			prom.then(
-				(exports) => {
-					component = exports.default;
-					Lazy.displayName = 'Lazy(' + (component.displayName || component.name) + ')';
-				},
+				(exports) => { component = exports.default; },
 				(e) => { error = e; },
 			);
 		}
@@ -47,6 +44,8 @@ export function lazy(loader) {
 
 		return createElement(component, props);
 	}
+
+	Lazy.displayName = 'Lazy';
 
 	return Lazy;
 }

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -4,7 +4,9 @@ import { createElement } from './create-element';
 // TODO: react warns in dev mode about defaultProps and propTypes not being supported on lazy
 // loaded components
 
-export const sym = Symbol.for('Suspense');
+export const sym = '_s';
+
+export const Suspense2 = 'suspense';
 
 export class Suspense extends Component {
 	constructor(props) {
@@ -22,15 +24,10 @@ export class Suspense extends Component {
 	componentDidCatch(e) {
 		if (e && typeof e.then === 'function') {
 			this.setState({ l: true });
-			e.then(
-				() => {
-					this.setState({ l: false });
-				},
-				// Suspense ignores errors thrown in Promises as this should be handled by user land code
-				() => {
-					this.setState({ l: false });
-				}
-			);
+			const cb = () => { this.setState({ l: false }); };
+
+			// Suspense ignores errors thrown in Promises as this should be handled by user land code
+			e.then(cb, cb);
 		}
 		else {
 			throw e;

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -1,30 +1,17 @@
 import { Component } from './component';
 import { createElement } from './create-element';
 
-// TODO: react warns in dev mode about defaultProps and propTypes not being supported on lazy
-// loaded components
-
-export const sym = '_s';
-
-export const Suspense2 = 'suspense';
-
 export class Suspense extends Component {
 	constructor(props) {
-		// TODO: should we add propTypes in DEV mode?
 		super(props);
 
-		// mark this component as a handler of suspension (thrown Promises)
-		this[sym] = sym;
-
-		this.state = {
-			l: false
-		};
+		this.state = {};
 	}
 
-	componentDidCatch(e) {
-		if (e && typeof e.then === 'function') {
-			this.setState({ l: true });
-			const cb = () => { this.setState({ l: false }); };
+	__s(e) {
+		if (typeof e.then == 'function') {
+			this.setState({ l: 1 });
+			const cb = () => { this.setState({ l: 0 }); };
 
 			// Suspense ignores errors thrown in Promises as this should be handled by user land code
 			e.then(cb, cb);
@@ -34,8 +21,8 @@ export class Suspense extends Component {
 		}
 	}
 
-	render() {
-		return this.state.l ? this.props.fallback : this.props.children;
+	render(props, state) {
+		return state.l ? props.fallback : props.children;
 	}
 }
 
@@ -43,7 +30,7 @@ export function lazy(loader) {
 	let prom;
 	let component;
 	let error;
-	return function Lazy(props) {
+	return function L(props) {
 		if (!prom) {
 			prom = loader();
 			prom.then(

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -1,0 +1,65 @@
+import { Component } from './component';
+import { createElement } from './create-element';
+
+// TODO: react warns in dev mode about defaultProps and propTypes not being supported on lazy
+// loaded components
+
+export class Suspense extends Component {
+	constructor(props) {
+		// TODO: should we add propTypes in DEV mode?
+		super(props);
+
+		this.state = {
+			l: false
+		};
+	}
+
+	componentDidCatch(e) {
+		if (e && typeof e.then === 'function') {
+			this.setState({ l: true });
+			e.then(
+				() => {
+					this.setState({ l: false });
+				},
+				// TODO: what to do in error case?!
+				// we could store the error to the state and then throw it during render
+				// should have a look what react does in these cases...
+				() => {
+					this.setState({ l: false });
+				}
+			);
+		}
+		else {
+			throw e;
+		}
+	}
+
+	render() {
+		return this.state.l ? this.props.fallback : this.props.children;
+	}
+}
+
+export function lazy(loader) {
+	let prom;
+	let component;
+	let error;
+	return function Lazy(props) {
+		if (!prom) {
+			prom = loader();
+			prom.then(
+				({ default: c }) => { component = c; },
+				e => error = e,
+			);
+		}
+
+		if (error) {
+			throw error;
+		}
+
+		if (!component) {
+			throw prom;
+		}
+
+		return createElement(component, props);
+	};
+}

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -4,13 +4,18 @@ import { createElement } from './create-element';
 // having a "custom class" here saves 50bytes gzipped
 export function s(props) {}
 s.prototype = new Component();
-s.prototype._childDidSuspend = function(e) {
+
+/**
+ * @param {Promise} promise The thrown promise
+ */
+s.prototype._childDidSuspend = function(promise) {
 	this.setState({ _loading: true });
 	const cb = () => { this.setState({ _loading: false }); };
 
 	// Suspense ignores errors thrown in Promises as this should be handled by user land code
-	e.then(cb, cb);
+	promise.then(cb, cb);
 };
+
 s.prototype.render = function(props, state) {
 	return state._loading ? props.fallback : props.children;
 };

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -28,11 +28,15 @@ export function lazy(loader) {
 	let prom;
 	let component;
 	let error;
-	return function L(props) {
+
+	function Lazy(props) {
 		if (!prom) {
 			prom = loader();
 			prom.then(
-				(exports) => { component = exports.default; },
+				(exports) => {
+					component = exports.default;
+					Lazy.displayName = 'Lazy(' + (component.displayName || component.name) + ')';
+				},
 				(e) => { error = e; },
 			);
 		}
@@ -46,5 +50,7 @@ export function lazy(loader) {
 		}
 
 		return createElement(component, props);
-	};
+	}
+
+	return Lazy;
 }

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -1,30 +1,23 @@
 import { Component } from './component';
 import { createElement } from './create-element';
 
-export class Suspense extends Component {
-	constructor(props) {
-		super(props);
+// having a "custom class" here saves 50bytes gzipped
+export function s(props) {}
+s.prototype = new Component();
+s.prototype._childDidSuspend = function(e) {
+	this.setState({ _loading: true });
+	const cb = () => { this.setState({ _loading: false }); };
 
-		this.state = {};
-	}
+	// Suspense ignores errors thrown in Promises as this should be handled by user land code
+	e.then(cb, cb);
+};
+s.prototype.render = function(props, state) {
+	return state._loading ? props.fallback : props.children;
+};
 
-	__s(e) {
-		if (typeof e.then == 'function') {
-			this.setState({ l: 1 });
-			const cb = () => { this.setState({ l: 0 }); };
-
-			// Suspense ignores errors thrown in Promises as this should be handled by user land code
-			e.then(cb, cb);
-		}
-		else {
-			throw e;
-		}
-	}
-
-	render(props, state) {
-		return state.l ? props.fallback : props.children;
-	}
-}
+// exporting s as Suspense instead of naming the class iself Suspense saves 4 bytes gzipped
+// TODO: does this add the need of a displayName?
+export const Suspense = s;
 
 export function lazy(loader) {
 	let prom;

--- a/src/suspense.js
+++ b/src/suspense.js
@@ -26,9 +26,7 @@ export class Suspense extends Component {
 				() => {
 					this.setState({ l: false });
 				},
-				// TODO: what to do in error case?!
-				// we could store the error to the state and then throw it during render
-				// should have a look what react does in these cases...
+				// Suspense ignores errors thrown in Promises as this should be handled by user land code
 				() => {
 					this.setState({ l: false });
 				}

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render, Component } from '../../src/index';
+import { createElement as h, render, Component, Fragment } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx h */
@@ -2242,6 +2242,15 @@ describe('Lifecycle methods', () => {
 			}
 
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
+			expect(Receiver.prototype.componentDidCatch).to.have.been.called;
+		});
+
+		it('should be called when child inside a Fragment fails', () => {
+			function ThrowErr() {
+				throw new Error('Error!');
+			}
+
+			render(<Receiver><Fragment><ThrowErr /></Fragment></Receiver>, scratch);
 			expect(Receiver.prototype.componentDidCatch).to.have.been.called;
 		});
 

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -37,7 +37,7 @@ class Catcher extends Component {
 	}
 }
 
-function createSuspension(name, timeout, t) {
+function createSuspension(name, timeout, error) {
 	let done = false;
 	let prom;
 
@@ -48,8 +48,8 @@ function createSuspension(name, timeout, t) {
 				prom = new Promise((res, rej) => {
 					setTimeout(() => {
 						done = true;
-						if (t) {
-							rej(t);
+						if (error) {
+							rej(error);
 						}
 						else {
 							res();

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -65,10 +65,22 @@ function createSuspension(name, timeout, t) {
 	};
 }
 
-class WrapperOne extends Component {
-	render() {
-		return this.props.children;
+class ClassWrapper extends Component {
+	render(props) {
+		return (
+			<div id="class-wrapper">
+				{props.children}
+			</div>
+		);
 	}
+}
+
+function FuncWrapper(props) {
+	return (
+		<div id="func-wrapper">
+			{props.children}
+		</div>
+	);
 }
 
 describe('suspense', () => {
@@ -120,13 +132,14 @@ describe('suspense', () => {
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
-				<WrapperOne>
-					<CustomSuspense {...s} />
-				</WrapperOne>
+				<ClassWrapper>
+					<FuncWrapper>
+						<CustomSuspense {...s} />
+					</FuncWrapper>
+				</ClassWrapper>
 			</Suspense>,
 			scratch,
 		);
-		// TODO: why a rerender needed here. Will this even work in the browser?!
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspended...</div>`
@@ -135,7 +148,7 @@ describe('suspense', () => {
 		return s.getPromise().then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Hello from CustomSuspense regular case</div>`
+				`<div id="class-wrapper"><div id="func-wrapper"><div>Hello from CustomSuspense regular case</div></div></div>`
 			);
 		});
 	});

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -290,6 +290,70 @@ describe('suspense', () => {
 		});
 	});
 
+	it('should support multiple non-nested Suspense', () => {
+		const s1 = createSuspension('1', 0, null);
+		const s2 = createSuspension('2', 0, null);
+
+		render(
+			<div>
+				<div>
+					<Suspense fallback={<div>Suspended 1...</div>}>
+						<CustomSuspense {...s1} />
+					</Suspense>
+				</div>
+				<div>
+					<Suspense fallback={<div>Suspended 2...</div>}>
+						<CustomSuspense {...s2} />
+					</Suspense>
+				</div>
+			</div>
+			,
+			scratch,
+		);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div><div><div>Suspended 1...</div></div><div><div>Suspended 2...</div></div></div>`
+		);
+
+		return s1.getPromise().then(s2.getPromise).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div><div><div>Hello from CustomSuspense 1</div></div><div><div>Hello from CustomSuspense 2</div></div></div>`
+			);
+		});
+	});
+
+	it('should support multiple Suspense inside a Fragment', () => {
+		const s1 = createSuspension('1', 0, null);
+		const s2 = createSuspension('2', 0, null);
+
+		render(
+			<div>
+				<Fragment>
+					<Suspense fallback={<div>Suspended 1...</div>}>
+						<CustomSuspense {...s1} />
+					</Suspense>
+					<Suspense fallback={<div>Suspended 2...</div>}>
+						<CustomSuspense {...s2} />
+					</Suspense>
+				</Fragment>
+			</div>
+			,
+			scratch,
+		);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div><div>Suspended 1...</div><div>Suspended 2...</div></div>`
+		);
+
+		return s1.getPromise().then(s2.getPromise).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div><div>Hello from CustomSuspense 1</div><div>Hello from CustomSuspense 2</div></div>`
+			);
+		});
+	});
+
 	it('should only suspend the most inner Suspend', () => {
 		const s = createSuspension('1', 0, null);
 

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -5,8 +5,7 @@ import { createElement as h, render, Component, Suspense, lazy } from '../../src
 import { setupScratch, teardown } from '../_util/helpers';
 
 function schedule(cb) {
-	setImmediate(cb);
-	// setTimeout(cb, 0);
+	setTimeout(cb, 0);
 }
 
 class LazyComp extends Component {

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -1,0 +1,133 @@
+/*eslint-env browser, mocha */
+import { setupRerender } from 'preact/test-utils';
+import { expect } from 'chai';
+import { createElement as h, render, Component, Suspense, lazy } from '../../src/index';
+import { setupScratch, teardown } from '../_util/helpers';
+
+class LazyComp extends Component {
+	render() {
+		return <div>Hello Lazy</div>;
+	}
+}
+
+class CustomSuspense extends Component {
+	constructor(props) {
+		super(props);
+		this.state = { done: false };
+	}
+	render() {
+		if (!this.state.done) {
+			throw new Promise((res) => {
+				setTimeout(() => {
+					this.setState({ done: true });
+					res();
+				}, 0);
+			});
+		}
+
+		return (
+			<div>
+				Hello CustomSuspense
+			</div>
+		);
+	}
+}
+
+class Catcher extends Component {
+	constructor(props) {
+		super(props);
+		this.state = { error: null };
+	}
+
+	componentDidCatch(e) {
+		this.setState({ error: e });
+	}
+
+	render() {
+		return this.state.error ? (
+			<div>
+				Catcher did catch: {this.state.error.message}
+			</div>
+		) : this.props.children;
+	}
+}
+
+const Lazy = lazy(() => new Promise((res) => {
+	setTimeout(() => {
+		res({ default: LazyComp });
+	}, 0);
+}));
+
+/** @jsx h */
+
+describe('suspense', () => {
+	let scratch, rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should suspend when using lazy', () => {
+		render(<Suspense fallback={<div>Suspended...</div>}>
+			<Lazy />
+		</Suspense>, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+	});
+
+	it('should suspend when a promise is throw', () => {
+		render(<Suspense fallback={<div>Suspended...</div>}>
+			<CustomSuspense />
+		</Suspense>, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+	});
+
+	it('should suspend with custom error boundary', () => {
+		render(<Suspense fallback={<div>Suspended...</div>}>
+			<Catcher>
+				<CustomSuspense />
+			</Catcher>
+		</Suspense>, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+	});
+
+	it('should only suspend the most inner Suspend', () => {
+		render(<Suspense fallback={<div>Suspended... 1</div>}>
+			Not suspended...
+			<Suspense fallback={<div>Suspended... 2</div>}>
+				<Catcher>
+					<CustomSuspense />
+				</Catcher>
+			</Suspense>
+		</Suspense>, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`Not suspended...<div>Suspended... 2</div>`
+		);
+	});
+
+	it('should throw when missing Suspense', () => {
+		render(<Catcher>
+			<CustomSuspense />
+		</Catcher>, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Catcher did catch: CustomSuspense suspended while rendering, but no fallback UI was specified.
+
+Add a &lt;Suspense fallback=...&gt; component higher in the tree to provide a loading indicator or placeholder to display.</div>`
+		);
+	});
+});

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -1,94 +1,73 @@
 /*eslint-env browser, mocha */
+/** @jsx h */
 import { setupRerender } from 'preact/test-utils';
-import { expect } from 'chai';
-import { createElement as h, render, Component, Suspense, lazy } from '../../src/index';
+import { createElement as h, render, Component, Suspense, lazy, Fragment } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
-
-function schedule(cb) {
-	setTimeout(cb, 0);
-}
 
 class LazyComp extends Component {
 	render() {
-		return <div>Hello Lazy</div>;
+		return <div>Hello from LazyComp</div>;
 	}
 }
 
-class CustomSuspense extends Component {
-	constructor(props) {
-		super(props);
-		this.state = { done: false };
+function CustomSuspense({ isDone, prom, name }) {
+	if (!isDone()) {
+		throw prom;
 	}
-	render() {
-		if (!this.state.done) {
-			throw new Promise((res) => {
-				schedule(() => {
-					this.setState({ done: true });
-					res();
-				});
-			});
-		}
 
-		return (
-			<div>
-				Hello CustomSuspense
-			</div>
-		);
-	}
-}
-
-class ThrowingSuspense extends Component {
-	constructor(props) {
-		super(props);
-		this.state = { done: false };
-	}
-	render() {
-		if (!this.state.done) {
-			throw new Promise((res, rej) => {
-				schedule(() => {
-					this.setState({ done: true });
-					rej(new Error('I\'m a throwing Suspense!'));
-				});
-			});
-		}
-
-		return (
-			<div>
-				Hello ThrowingSuspense
-			</div>
-		);
-	}
+	return (
+		<div>
+			Hello from CustomSuspense {name}
+		</div>
+	);
 }
 
 class Catcher extends Component {
 	constructor(props) {
 		super(props);
-		this.state = { error: null };
+		this.state = { error: false };
 	}
 
 	componentDidCatch(e) {
 		this.setState({ error: e });
 	}
 
-	render() {
-		return this.state.error ? (
-			<div>
-				Catcher did catch: {this.state.error.message}
-			</div>
-		) : this.props.children;
+	render(props, state) {
+		return state.error ? <div>Catcher did catch: {state.error.message}</div> : props.children;
 	}
 }
 
-const Lazy = lazy(() => new Promise((res) => {
-	schedule(() => {
-		res({ default: LazyComp });
+function createSuspension(name, timeout, t) {
+	let done = false;
+	const prom = new Promise((res, rej) => {
+		setTimeout(() => {
+			done = true;
+			if (t) {
+				rej(t);
+			}
+			else {
+				res();
+			}
+		}, timeout);
 	});
+
+	return {
+		name,
+		prom,
+		isDone: () => done
+	};
+}
+
+const Lazy = lazy(() => new Promise((res) => {
+	setTimeout(() => {
+		res({ default: LazyComp });
+	}, 0);
 }));
 
 const ThrowingLazy = lazy(() => new Promise((res, rej) => {
-	schedule(() => {
+	setTimeout(() => {
 		rej(new Error('Thrown in lazy\'s loader...'));
-	});
+	}, 0);
 }));
 
 class WrapperOne extends Component {
@@ -96,8 +75,6 @@ class WrapperOne extends Component {
 		return this.props.children;
 	}
 }
-
-/** @jsx h */
 
 function tick(fn) {
 	return new Promise((res) => {
@@ -119,9 +96,12 @@ describe('suspense', () => {
 	});
 
 	it('should suspend when using lazy', () => {
-		render(<Suspense fallback={<div>Suspended...</div>}>
-			<Lazy />
-		</Suspense>, scratch);
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Lazy />
+			</Suspense>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspended...</div>`
@@ -130,17 +110,22 @@ describe('suspense', () => {
 		return tick(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Hello Lazy</div>`
+				`<div>Hello from LazyComp</div>`
 			);
 		});
 	});
 
 	it('should suspend when a promise is throw', () => {
-		render(<Suspense fallback={<div>Suspended...</div>}>
-			<WrapperOne>
-				<CustomSuspense />
-			</WrapperOne>
-		</Suspense>, scratch);
+		const s = createSuspension('regular case', 0, null);
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<WrapperOne>
+					<CustomSuspense {...s} />
+				</WrapperOne>
+			</Suspense>,
+			scratch,
+		);
 		// TODO: why a rerender needed here. Will this even work in the browser?!
 		rerender();
 		expect(scratch.innerHTML).to.eql(
@@ -150,17 +135,22 @@ describe('suspense', () => {
 		return tick(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Hello CustomSuspense</div>`
+				`<div>Hello from CustomSuspense regular case</div>`
 			);
 		});
 	});
 
 	it('should suspend with custom error boundary', () => {
-		render(<Suspense fallback={<div>Suspended...</div>}>
-			<Catcher>
-				<CustomSuspense />
-			</Catcher>
-		</Suspense>, scratch);
+		const s = createSuspension('within error boundary', 0, null);
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					<CustomSuspense {...s} />
+				</Catcher>
+			</Suspense>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspended...</div>`
@@ -169,17 +159,22 @@ describe('suspense', () => {
 		return tick(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Hello CustomSuspense</div>`
+				`<div>Hello from CustomSuspense within error boundary</div>`
 			);
 		});
 	});
 
 	it('should support throwing suspense', () => {
-		render(<Suspense fallback={<div>Suspended...</div>}>
-			<Catcher>
-				<ThrowingSuspense />
-			</Catcher>
-		</Suspense>, scratch);
+		const s = createSuspension('throwing', 0, new Error('Thrown in suspense'));
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					<CustomSuspense {...s} />
+				</Catcher>
+			</Suspense>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspended...</div>`
@@ -188,20 +183,114 @@ describe('suspense', () => {
 		return tick(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Hello ThrowingSuspense</div>`
+				`<div>Hello from CustomSuspense throwing</div>`
+			);
+		});
+	});
+
+	it('should call multiple suspending components render in one go', () => {
+		const s1 = createSuspension('first', 0, null);
+		const s2 = createSuspension('second', 0, null);
+		const LoggedCustomSuspense = sinon.spy(CustomSuspense);
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					{/* Adding a <div> here will make things work... */}
+					<LoggedCustomSuspense {...s1} />
+					<LoggedCustomSuspense {...s2} />
+				</Catcher>
+			</Suspense>
+			,
+			scratch,
+		);
+		expect(LoggedCustomSuspense).to.have.been.calledTwice;
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+
+		return tick(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div>Hello from CustomSuspense first</div><div>Hello from CustomSuspense second</div>`
+			);
+		});
+	});
+
+	it('should call multiple nested suspending components render in one go', () => {
+		const s1 = createSuspension('first', 0, null);
+		const s2 = createSuspension('second', 0, null);
+		const LoggedCustomSuspense = sinon.spy(CustomSuspense);
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					{/* Adding a <div> here will make things work... */}
+					<LoggedCustomSuspense {...s1} />
+					<div>
+						<LoggedCustomSuspense {...s2} />
+					</div>
+				</Catcher>
+			</Suspense>
+			,
+			scratch,
+		);
+		expect(LoggedCustomSuspense).to.have.been.calledTwice;
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+
+		return tick(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div>Hello from CustomSuspense first</div><div><div>Hello from CustomSuspense second</div></div>`
+			);
+		});
+	});
+
+	it('should support suspension nested in a Fragment', () => {
+		const s = createSuspension('nested in a Fragment', 0, null);
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					<Fragment>
+						<CustomSuspense {...s} />
+					</Fragment>
+				</Catcher>
+			</Suspense>
+			,
+			scratch,
+		);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			`<div>Suspended...</div>`
+		);
+
+		return tick(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div>Hello from CustomSuspense nested in a Fragment</div>`
 			);
 		});
 	});
 
 	it('should only suspend the most inner Suspend', () => {
-		render(<Suspense fallback={<div>Suspended... 1</div>}>
-			Not suspended...
-			<Suspense fallback={<div>Suspended... 2</div>}>
-				<Catcher>
-					<CustomSuspense />
-				</Catcher>
-			</Suspense>
-		</Suspense>, scratch);
+		const s = createSuspension('1', 0, new Error('Thrown in suspense'));
+
+		render(
+			<Suspense fallback={<div>Suspended... 1</div>}>
+				Not suspended...
+				<Suspense fallback={<div>Suspended... 2</div>}>
+					<Catcher>
+						<CustomSuspense {...s} />
+					</Catcher>
+				</Suspense>
+			</Suspense>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`Not suspended...<div>Suspended... 2</div>`
@@ -210,15 +299,20 @@ describe('suspense', () => {
 		return tick(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`Not suspended...<div>Hello CustomSuspense</div>`
+				`Not suspended...<div>Hello from CustomSuspense 1</div>`
 			);
 		});
 	});
 
 	it('should throw when missing Suspense', () => {
-		render(<Catcher>
-			<CustomSuspense />
-		</Catcher>, scratch);
+		const s = createSuspension('1', 0, null);
+
+		render(
+			<Catcher>
+				<CustomSuspense {...s} />
+			</Catcher>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Catcher did catch: Missing Suspense</div>`
@@ -226,11 +320,14 @@ describe('suspense', () => {
 	});
 
 	it('should throw when lazy\'s loader throws', () => {
-		render(<Suspense fallback={<div>Suspended...</div>}>
-			<Catcher>
-				<ThrowingLazy />
-			</Catcher>
-		</Suspense>, scratch);
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Catcher>
+					<ThrowingLazy />
+				</Catcher>
+			</Suspense>,
+			scratch,
+		);
 		rerender();
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspended...</div>`

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -323,7 +323,7 @@ describe('suspense', () => {
 		});
 	});
 
-	it('should support multiple Suspense inside a Fragment', () => {
+	it.skip('should support multiple Suspense inside a Fragment', () => {
 		const s1 = createSuspension('1', 0, null);
 		const s2 = createSuspension('2', 0, null);
 


### PR DESCRIPTION
This introduces Suspense and lazy. There are some open things tough.

**EDIT**: After the excellent feedback on this PR things seem to be close to finish 🎉   Currently this PR adds 187 bytes gzipped to core.

Open things to do / disucss

- [x] Fix issue of `Suspense` inside `Fragment` messing up the order of the DOM (#1605)
  - Skipping this test for now
- [x] Should `Suspense` / `lazy` remain part of the core or live in `preact/suspense` or `preact/compat`? This would save 137 bytes from core what would only add 50 bytes to core for somebody not using suspense
  - Keeping them in core for now. If you wish I can move them...
- [x] Shall we drop `isSuspense = true` inside `catchErrorInComponent` resulting in 3B saving but also make errors thrown inside `_childDidSuspend` result in a `Missing Suspense` error?
  - I'd not do so, marking as complete
- [x] Warn about `propTypes` on `lazy()` in `preact/debug`
- [x] Warn about missing `Suspense` in `preact/debug`
  - Not possible without some more changes. A `Missing Suspense` error must do the job for now
- [x] Golf some bytes
- [x] Create a demo