### PR TITLE
Code golf preact.js.gz size down by 53 B ⛳️

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -27,7 +27,7 @@ export function createContext(defaultValue) {
 			return ctx;
 		};
 		comp.shouldComponentUpdate = props => {
-			subs.map(c => {
+			subs.some(c => {
 				// Check if still mounted
 				if (c._parentDom) {
 					c.context = props.value;

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -7,49 +7,44 @@ export let i = 0;
  * @param {any} defaultValue
  */
 export function createContext(defaultValue) {
-	let context = {
+	const ctx = {};
+
+	const context = {
 		_id: '__cC' + i++,
-		_defaultValue: defaultValue
+		_defaultValue: defaultValue,
+		Consumer(props, context) {
+			return props.children(context);
+		},
+		Provider(props) {
+			if (!this.getChildContext) {
+				const subs = [];
+				this.getChildContext = () => {
+					ctx[context._id] = this;
+					return ctx;
+				};
+				this.shouldComponentUpdate = props => {
+					subs.some(c => {
+						// Check if still mounted
+						if (c._parentDom) {
+							c.context = props.value;
+							enqueueRender(c);
+						}
+					});
+				};
+				this.sub = (c) => {
+					subs.push(c);
+					let old = c.componentWillUnmount;
+					c.componentWillUnmount = () => {
+						subs.splice(subs.indexOf(c), 1);
+						old && old();
+					};
+				};
+			}
+			return props.children;
+		}
 	};
 
-	function Consumer(props, context) {
-		return props.children(context);
-	}
-	Consumer.contextType = context;
-	context.Consumer = Consumer;
-
-	let ctx = {};
-
-	function initProvider(comp) {
-		const subs = [];
-		comp.getChildContext = () => {
-			ctx[context._id] = comp;
-			return ctx;
-		};
-		comp.shouldComponentUpdate = props => {
-			subs.some(c => {
-				// Check if still mounted
-				if (c._parentDom) {
-					c.context = props.value;
-					enqueueRender(c);
-				}
-			});
-		};
-		comp.sub = (c) => {
-			subs.push(c);
-			let old = c.componentWillUnmount;
-			c.componentWillUnmount = () => {
-				subs.splice(subs.indexOf(c), 1);
-				old && old();
-			};
-		};
-	}
-
-	function Provider(props) {
-		if (!this.getChildContext) initProvider(this);
-		return props.children;
-	}
-	context.Provider = Provider;
+	context.Consumer.contextType = context;
 
 	return context;
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -102,10 +102,9 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 						parentDom.appendChild(newDom);
 					}
 					else {
-						sibDom = oldDom;
-						j = 0;
-						while ((sibDom=sibDom.nextSibling) && j++<oldChildrenLength/2) {
-							if (sibDom===newDom) {
+						// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
+						for (sibDom=oldDom, j=0; (sibDom=sibDom.nextSibling) && j<oldChildrenLength; j+=2) {
+							if (sibDom==newDom) {
 								break outer;
 							}
 						}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -29,7 +29,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode, true);
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
-	let oldChildren = oldParentVNode!=null && oldParentVNode._children || EMPTY_ARR;
+	let oldChildren = (oldParentVNode && oldParentVNode._children) || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length;
 	let oldChild;
@@ -41,12 +41,12 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	if (oldDom == EMPTY_OBJ) {
 		oldDom = null;
 		if (excessDomChildren!=null) {
-			for (i = 0; oldDom==null && i < excessDomChildren.length; i++) {
+			for (i = 0; !oldDom && i < excessDomChildren.length; i++) {
 				oldDom = excessDomChildren[i];
 			}
 		}
 		else {
-			for (i = 0; oldDom==null && i < oldChildrenLength; i++) {
+			for (i = 0; !oldDom && i < oldChildrenLength; i++) {
 				oldDom = oldChildren[i] && oldChildren[i]._dom;
 				oldChild = oldChildren[i];
 			}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -63,7 +63,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			// (holes).
 			oldVNode = oldChildren[i];
 
-			if (oldVNode===null || (oldVNode != null && (childVNode.key==null && oldVNode.key==null ? (childVNode.type === oldVNode.type) : (childVNode.key === oldVNode.key)))) {
+			if (oldVNode===null || (oldVNode && (oldVNode.key!=null ? (childVNode.key === oldVNode.key) : (childVNode.key==null && childVNode.type === oldVNode.type)))) {
 				oldChildren[i] = undefined;
 			}
 			else {
@@ -71,7 +71,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 				// so after this loop oldVNode == null or oldVNode is a valid value.
 				for (j=0; j<oldChildrenLength; j++) {
 					oldVNode = oldChildren[j];
-					if (oldVNode!=null && (childVNode.key==null && oldVNode.key==null ? (childVNode.type === oldVNode.type) : (childVNode.key === oldVNode.key))) {
+					if (oldVNode && (oldVNode.key!=null ? (childVNode.key === oldVNode.key) : (childVNode.key==null && childVNode.type === oldVNode.type))) {
 						oldChildren[j] = undefined;
 						if (oldChildrenLength !== newChildren.length && oldVNode.type !== (oldChild && oldChild.type)) {
 							oldDom = oldVNode._dom;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -57,8 +57,9 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				// dom, so we iterate backwards to find the last child with a dom node.
 				while (i--) {
 					tmp = newVNode._children[i];
-					newVNode._lastDomChild = tmp && (tmp._lastDomChild || tmp._dom);
-					if (newVNode._lastDomChild) break;
+					if (newVNode._lastDomChild = (tmp && (tmp._lastDomChild || tmp._dom))) {
+						break;
+					}
 				}
 			}
 		}
@@ -163,7 +164,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			c._parentDom = parentDom;
 
-			if (newVNode.ref) applyRef(newVNode.ref, c, ancestorComponent);
+			if (tmp = newVNode.ref) applyRef(tmp, c, ancestorComponent);
 
 			while (tmp=c._renderCallbacks.pop()) tmp.call(c);
 
@@ -176,8 +177,8 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		else {
 			newVNode._dom = diffElementNodes(oldVNode._dom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent);
 
-			if (newVNode.ref && (oldVNode.ref !== newVNode.ref)) {
-				applyRef(newVNode.ref, newVNode._dom, ancestorComponent);
+			if ((tmp = newVNode.ref) && (oldVNode.ref !== tmp)) {
+				applyRef(tmp, newVNode._dom, ancestorComponent);
 			}
 		}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -31,7 +31,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		oldVNode = EMPTY_OBJ;
 	}
 
-	let c, tmp, isNew = false, oldProps, oldState, snapshot,
+	let c, tmp, isNew, oldProps, oldState, snapshot,
 		newType = newVNode.type, clearProcessingException;
 
 	// When passing through createElement it assigns the object

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -31,15 +31,15 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		oldVNode = EMPTY_OBJ;
 	}
 
+	let c, tmp, isNew = false, oldProps, oldState, snapshot,
+		newType = newVNode.type, clearProcessingException;
+
 	// When passing through createElement it assigns the object
 	// ref on _self, to prevent JSON Injection we check if this attribute
 	// is equal.
 	if (newVNode._self!==newVNode) return null;
 
-	if (options.diff) options.diff(newVNode);
-
-	let c, p, isNew = false, oldProps, oldState, snapshot,
-		newType = newVNode.type, clearProcessingException;
+	if (tmp = options.diff) tmp(newVNode);
 
 	try {
 		outer: if (oldVNode.type===Fragment || newType===Fragment) {
@@ -55,8 +55,8 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				// We have no guarantee that the last child rendered something into the
 				// dom, so we iterate backwards to find the last child with a dom node.
 				for (let i = newVNode._children.length; i--;) {
-					p = newVNode._children[i];
-					newVNode._lastDomChild = p && (p._lastDomChild || p._dom);
+					tmp = newVNode._children[i];
+					newVNode._lastDomChild = tmp && (tmp._lastDomChild || tmp._dom);
 					if (newVNode._lastDomChild) break;
 				}
 			}
@@ -136,7 +136,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			c.props = newVNode.props;
 			c.state = c._nextState;
 
-			if (options.render) options.render(newVNode);
+			if (tmp = options.render) tmp(newVNode);
 
 			let prev = c._prevVNode || null;
 			c._dirty = false;
@@ -164,7 +164,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			if (newVNode.ref) applyRef(newVNode.ref, c, ancestorComponent);
 
-			while (p=c._renderCallbacks.pop()) p.call(c);
+			while (tmp=c._renderCallbacks.pop()) tmp.call(c);
 
 			// Don't call componentDidUpdate on mount or when we bailed out via
 			// `shouldComponentUpdate`
@@ -184,7 +184,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			c._pendingError = c._processingException = null;
 		}
 
-		if (options.diffed) options.diffed(newVNode);
+		if (tmp = options.diffed) tmp(newVNode);
 	}
 	catch (e) {
 		catchErrorInComponent(e, ancestorComponent);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -48,13 +48,14 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			// Mark dom as empty in case `_children` is any empty array. If it isn't
 			// we'll set `dom` to the correct value just a few lines later.
 
-			if (newVNode._children.length && newVNode._children[0]!=null) {
-				newVNode._dom = newVNode._children[0]._dom;
+			let i = newVNode._children.length;
+			if (i && (tmp=newVNode._children[0]) != null) {
+				newVNode._dom = tmp._dom;
 
 				// If the last child is a Fragment, use _lastDomChild, else use _dom
 				// We have no guarantee that the last child rendered something into the
 				// dom, so we iterate backwards to find the last child with a dom node.
-				for (let i = newVNode._children.length; i--;) {
+				while (i--) {
 					tmp = newVNode._children[i];
 					newVNode._lastDomChild = tmp && (tmp._lastDomChild || tmp._dom);
 					if (newVNode._lastDomChild) break;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -67,9 +67,9 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			// Necessary for createContext api. Setting this property will pass
 			// the context value as `this.context` just for this component.
-			let cxType = newType.contextType;
-			let provider = cxType && context[cxType._id];
-			let cctx = cxType != null ? (provider ? provider.props.value : cxType._defaultValue) : context;
+			tmp = newType.contextType;
+			let provider = tmp && context[tmp._id];
+			let cctx = tmp ? (provider ? provider.props.value : tmp._defaultValue) : context;
 
 			// Get component and set it to `c`
 			if (oldVNode._component) {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -21,7 +21,7 @@ export function diffProps(dom, newProps, oldProps, isSvg) {
 	}
 
 	for (i in oldProps) {
-		if (i!=='children' && i!=='key' && (!newProps || !(i in newProps))) {
+		if (i!=='children' && i!=='key' && !(i in newProps)) {
 			setProperty(dom, i, null, oldProps[i], isSvg);
 		}
 	}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -24,7 +24,8 @@ export function diffProps(dom, newProps, oldProps, isSvg) {
 	}
 }
 
-let CAMEL_REG = /-?(?=[A-Z])/g;
+const CAMEL_REG = /-?(?=[A-Z])/g;
+const XLINK_NS = 'http://www.w3.org/1999/xlink';
 
 /**
  * Set a property value on a DOM node
@@ -86,13 +87,21 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	else if (name!=='list' && name!=='tagName' && !isSvg && (name in dom)) {
 		dom[name] = value==null ? '' : value;
 	}
-	else if (value==null || value===false) {
-		if (name!==(name = name.replace(/^xlink:?/, ''))) dom.removeAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase());
-		else dom.removeAttribute(name);
-	}
 	else if (typeof value!=='function') {
-		if (name!==(name = name.replace(/^xlink:?/, ''))) dom.setAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase(), value);
-		else dom.setAttribute(name, value);
+		if (name!==(name = name.replace(/^xlink:?/, ''))) {
+			if (value==null || value===false) {
+				dom.removeAttributeNS(XLINK_NS, name.toLowerCase());
+			}
+			else {
+				dom.setAttributeNS(XLINK_NS, name.toLowerCase(), value);
+			}
+		}
+		else if (value==null || value===false) {
+			dom.removeAttribute(name);
+		}
+		else {
+			dom.setAttribute(name, value);
+		}
 	}
 }
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -36,8 +36,7 @@ const XLINK_NS = 'http://www.w3.org/1999/xlink';
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node or not
  */
 function setProperty(dom, name, value, oldValue, isSvg) {
-	let v;
-	if (name==='class' || name==='className') name = isSvg ? 'class' : 'className';
+	name = isSvg ? (name==='className' ? 'class' : name) : (name==='class' ? 'className' : name);
 
 	if (name==='style') {
 
@@ -60,7 +59,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 				}
 			}
 			for (let i in value) {
-				v = value[i];
+				const v = value[i];
 				if (oldValue==null || v!==oldValue[i]) {
 					s.setProperty(i.replace(CAMEL_REG, '-'), typeof v==='number' && IS_NON_DIMENSIONAL.test(i)===false ? (v + 'px') : v);
 				}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -10,14 +10,17 @@ import options from '../options';
  * @param {boolean} isSvg Whether or not this node is an SVG node
  */
 export function diffProps(dom, newProps, oldProps, isSvg) {
-	let keys = Object.keys(newProps).sort();
-	for (let i = 0; i < keys.length; i++) {
-		if (keys[i]!=='children' && keys[i]!=='key' && (!oldProps || ((keys[i]==='value' || keys[i]==='checked') ? dom : oldProps)[keys[i]]!==newProps[keys[i]])) {
-			setProperty(dom, keys[i], newProps[keys[i]], oldProps[keys[i]], isSvg);
+	let i;
+	
+	const keys = Object.keys(newProps).sort();
+	for (i = 0; i < keys.length; i++) {
+		const k = keys[i];
+		if (k!=='children' && k!=='key' && (!oldProps || ((k==='value' || k==='checked') ? dom : oldProps)[k]!==newProps[k])) {
+			setProperty(dom, k, newProps[k], oldProps[k], isSvg);
 		}
 	}
 
-	for (let i in oldProps) {
+	for (i in oldProps) {
 		if (i!=='children' && i!=='key' && (!newProps || !(i in newProps))) {
 			setProperty(dom, i, null, oldProps[i], isSvg);
 		}


### PR DESCRIPTION
This pull request applies a bunch of small code modifications that seem to reduce the overall bundle size. Here's a rough outline of the changes:

 * 276850e, 5e78b34, 37ce351, 07b42de mostly move around loop invariants to compress the code.
 * 3ec3829, d32aa17, 82f4cca reuse local variables etc. to avoid repetition.
 * 3f71109 replaces an `Array#map` call with [`Array#some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) that:
    1. should be just as supported as `Array#map` but doesn't collect all callback results to an array like `Array#map`
    1. seems to compress better than `Array#forEach`
 * 76529b7 reorganizes `createContext` extensively, getting rid of local variable and function declarations.
 * 7e53dd2 removes a superfluous check from diffProps - `newProps`'s falsyness is checked although that shouldn't be possible at that point.
 * 04646b6 doesn't explictly init `isNew` to `false`, as its default `undefined` value is sufficient.
 * The rest of the commits mostly reorder code or modify `if (x!=null)` checks to `if (x)` when appropriate.

The performance _seems_ to stay on the same level with master. I used Chrome 74, MacOS 10.14.4 and https://github.com/mathieuancelin/js-repaint-perfs for testing, so YMMV.

The size impact compared to the master is:

|bundle file|master|random-opts|delta|
|-|-|-|-|
|preact.js.gz|3548 B|3495 B|-53 B|
|preact.js.br|3242 B|3201 B|-41 B|
|preact.module.js.gz|3566 B|3517 B|-49 B|
|preact.module.js.br|3265 B|3224 B|-41 B|
|preact.umd.js.gz|3604 B|3561 B|-43 B|
|preact.umd.js.br|3293 B|3255 B|-38 B|