### PR TITLE
Store text node's text content as VNode.props instead of VNode.text

### DIFF
--- a/debug/src/devtools/custom.js
+++ b/debug/src/devtools/custom.js
@@ -82,13 +82,13 @@ export function getData(vnode) {
 		ref: vnode.ref || null,
 		key: vnode.key || null,
 		updater,
-		text: vnode.type===null ? vnode.props.data : null,
+		text: vnode.type===null ? vnode.props : null,
 		state: c!=null && c instanceof Component ? c.state : null,
 		props: vnode.props,
 		// The devtools inline text children if they are the only child
 		children: vnode.type!==null
 			? children!=null && children.length==1 && children[0].type===null
-				? children[0].props.data
+				? children[0].props
 				: children
 			: null,
 		publicInstance: getInstance(vnode),

--- a/debug/src/devtools/custom.js
+++ b/debug/src/devtools/custom.js
@@ -82,13 +82,13 @@ export function getData(vnode) {
 		ref: vnode.ref || null,
 		key: vnode.key || null,
 		updater,
-		text: vnode.text,
+		text: vnode.type===null ? vnode.props.data : null,
 		state: c!=null && c instanceof Component ? c.state : null,
 		props: vnode.props,
 		// The devtools inline text children if they are the only child
-		children: vnode.text==null
-			? children!=null && children.length==1 && children[0].text!=null
-				? children[0].text
+		children: vnode.type!==null
+			? children!=null && children.length==1 && children[0].type===null
+				? children[0].props.data
 				: children
 			: null,
 		publicInstance: getInstance(vnode),

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -20,7 +20,7 @@ function serialize(events) {
 		type: x.type,
 		component: x.internalInstance.type!==null
 			? getDisplayName(x.internalInstance)
-			: '#text: ' + x.internalInstance.props.data
+			: '#text: ' + x.internalInstance.props
 	}));
 }
 

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -18,9 +18,9 @@ import { memo, forwardRef, createPortal } from '../../../compat/src';
 function serialize(events) {
 	return events.filter(x => x.type!='updateProfileTimes').map(x => ({
 		type: x.type,
-		component: x.internalInstance.type!=null
+		component: x.internalInstance.type!==null
 			? getDisplayName(x.internalInstance)
-			: '#text: ' + x.internalInstance.text
+			: '#text: ' + x.internalInstance.props.data
 	}));
 }
 

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -11,5 +11,5 @@ import { createVNode } from './create-element';
 export function cloneElement(vnode, props) {
 	props = assign(assign({}, vnode.props), props);
 	if (arguments.length>2) props.children = EMPTY_ARR.slice.call(arguments, 2);
-	return createVNode(vnode.type, props, null, props.key || vnode.key, props.ref || vnode.ref);
+	return createVNode(vnode.type, props, props.key || vnode.key, props.ref || vnode.ref);
 }

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -34,29 +34,26 @@ export function createElement(type, props, children) {
 	let key = props.key;
 	if (key) delete props.key;
 
-	return createVNode(type, props, null, key, ref);
+	return createVNode(type, props, key, ref);
 }
 
 /**
  * Create a VNode (used internally by Preact)
  * @param {import('./internal').VNode["type"]} type The node name or Component
  * Constructor for this virtual node
- * @param {object | null} props The properites of this virtual node
- * @param {string | number} text If this virtual node represents a text node,
- * this is the text of the node
- * @param {string |number | null} key The key for this virtual node, used when
+ * @param {object | null} props The properites of this virtual node.
+ * @param {string | number | null} key The key for this virtual node, used when
  * diffing it against its children
  * @param {import('./internal').VNode["ref"]} ref The ref property that will
  * receive a reference to its created child
  * @returns {import('./internal').VNode}
  */
-export function createVNode(type, props, text, key, ref) {
+export function createVNode(type, props, key, ref) {
 	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
 	// Do not inline into createElement and coerceToVNode!
 	const vnode = {
 		type,
 		props,
-		text,
 		key,
 		ref,
 		_children: null,
@@ -87,7 +84,7 @@ export /* istanbul ignore next */ function Fragment() { }
 export function coerceToVNode(possibleVNode) {
 	if (possibleVNode == null || typeof possibleVNode === 'boolean') return null;
 	if (typeof possibleVNode === 'string' || typeof possibleVNode === 'number') {
-		return createVNode(null, null, possibleVNode, null, null);
+		return createVNode(null, { data: possibleVNode }, null, null);
 	}
 
 	if (Array.isArray(possibleVNode)) {
@@ -96,7 +93,7 @@ export function coerceToVNode(possibleVNode) {
 
 	// Clone vnode if it has already been used. ceviche/#57
 	if (possibleVNode._dom!=null || possibleVNode._component!=null) {
-		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.text, possibleVNode.key, null);
+		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.key, null);
 		vnode._dom = possibleVNode._dom;
 		return vnode;
 	}

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -41,7 +41,8 @@ export function createElement(type, props, children) {
  * Create a VNode (used internally by Preact)
  * @param {import('./internal').VNode["type"]} type The node name or Component
  * Constructor for this virtual node
- * @param {object | null} props The properites of this virtual node.
+ * @param {object | string | number | null} props The properites of this virtual node.
+ * If this virtual node represents a text node, this is the text of the node (string or number).
  * @param {string | number | null} key The key for this virtual node, used when
  * diffing it against its children
  * @param {import('./internal').VNode["ref"]} ref The ref property that will
@@ -84,7 +85,7 @@ export /* istanbul ignore next */ function Fragment() { }
 export function coerceToVNode(possibleVNode) {
 	if (possibleVNode == null || typeof possibleVNode === 'boolean') return null;
 	if (typeof possibleVNode === 'string' || typeof possibleVNode === 'number') {
-		return createVNode(null, { data: possibleVNode }, null, null);
+		return createVNode(null, possibleVNode, null, null);
 	}
 
 	if (Array.isArray(possibleVNode)) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,6 @@ declare namespace preact {
 	interface VNode<P = {}> {
 		type: ComponentType<P> | string | null;
 		props: P & { children: ComponentChildren } | null;
-		text: string | number | null;
 		key: Key;
 		ref: Ref<any> | null;
 		/**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,7 +12,7 @@ declare namespace preact {
 
 	interface VNode<P = {}> {
 		type: ComponentType<P> | string | null;
-		props: P & { children: ComponentChildren } | null;
+		props: P & { children: ComponentChildren } | string | number | null;
 		key: Key;
 		ref: Ref<any> | null;
 		/**

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -42,10 +42,6 @@ describe('createElement(jsx)', () => {
 		expect(h('div', props).props).to.deep.equal(props);
 	});
 
-	it('should set VNode#text property', () => {
-		expect(<div />).to.have.property('text', null);
-	});
-
 	it('should set VNode#key property', () => {
 		expect(<div />).to.have.property('key').that.is.undefined;
 		expect(<div a="a" />).to.have.property('key').that.is.undefined;
@@ -60,7 +56,7 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should have ordered VNode properties', () => {
-		expect(Object.keys(<div />).filter(key => !/^_/.test(key))).to.deep.equal(['type', 'props', 'text', 'key', 'ref']);
+		expect(Object.keys(<div />).filter(key => !/^_/.test(key))).to.deep.equal(['type', 'props', 'key', 'ref']);
 	});
 
 	it('should preserve raw props', () => {

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -25,7 +25,7 @@ describe("VNode", () => {
 	it("is returned by h", () => {
 		const actual = <div className="wow"/>;
 		expect(actual).to.include.all.keys(
-			"type", "props", "text", "key"
+			"type", "props", "key"
 		);
 	});
 


### PR DESCRIPTION
This pull request modifies how text VNodes are represented internally. Instead of storing a text node's text content as `vnode.text` the content string is stored as `vnode.props`. This _should_ be ok, as previously text nodes have had `null` as `.props`, and non-text nodes have `null` as `.text`.

Text node handling is still circuited when diffing, and the performance seems to stay on the same level with master. I used Chrome 74, MacOS 10.14.4 and https://github.com/mathieuancelin/js-repaint-perfs for testing, so YMMV.

These changes bring the preact.js.gz bundle size down by 28 bytes.

Some tests had to be modified accordingly. One now-irrelevant test got removed altogether. The devtools integration code also required some modifications - all devtools tests are passing, but I haven't actually tried to run the code with React devtools.