### PR TITLE
(chore) - warn about missing preact-render-to-string dependency

### DIFF
--- a/compat/server.js
+++ b/compat/server.js
@@ -5,7 +5,7 @@ try {
 } catch (e) {
 	throw new Error(
 		'You seem to be missing the "preact-render-to-string" dependency.\n' +
-		'You can add this by using "npm install --save preact-render-to-string".'
+		'You can add this by using "npm install --save preact-render-to-string@next".'
 	)
 }
 

--- a/compat/server.js
+++ b/compat/server.js
@@ -1,5 +1,13 @@
 /* eslint-disable */
-var renderToString = dep(require('preact-render-to-string'));
+var renderToString
+try {
+	renderToString = dep(require('preact-render-to-string'));
+} catch (e) {
+	throw new Error(
+		'You seem to be missing the "preact-render-to-string" dependency.\n' +
+		'You can add this by using "npm install --save preact-render-to-string".'
+	)
+}
 
 function dep(obj) { return obj['default'] || obj; }
 


### PR DESCRIPTION
When preact-render-to-string, preact-compat/server throws a cryptic error.

This is meant to solve that by wrapping the require it with try catch.

Fixes: https://github.com/developit/preact/issues/1601

Will try and do some more in-depth testing if this can result in erroneous errors but I don't think so.