### PR TITLE
Order issue when setState changes vnode type in Fragment

### DIFF
--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1870,4 +1870,50 @@ describe('Fragment', () => {
 		rerender();
 		expect(scratch.textContent).to.equal('ABC');
 	});
+
+	it('setState should work inside a fragment when changing vnode.type returned by render', () => {
+		let s;
+
+		class SetState extends Component {
+			constructor(props) {
+				super(props);
+				s = new Promise((res) => {
+					setTimeout(() => {
+						this.setState({ change: true });
+						res();
+					}, 0);
+				});
+			}
+
+			render() {
+				return this.state.change ? (
+					<section>I'm a section now</section>
+				) : (
+					<div>I'm a div</div>
+				);
+			}
+
+		}
+
+		render(
+			<div>
+				<div>START</div>
+				<SetState />
+				<div>END</div>
+			</div>
+			,
+			scratch,
+		);
+
+		expect(scratch.innerHTML).to.eql(
+			`<div><div>START</div><div>I'm a div</div><div>END</div></div>`
+		);
+
+		return s.then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(
+				`<div><div>START</div><section>I'm a section now</section><div>END</div></div>`
+			);
+		});
+	});
 });


### PR DESCRIPTION
This PR adds a test to showcase the ordering issue after setState when I was implementing #1593 

As I don't have time to find a fix now I'll just open the PR with the test showcasing the bug. If nobody is faster than me I'll look into this tomorrow.