### PR TITLE
Fix: Remove props.key even when key === 0 or key === ""

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -30,9 +30,9 @@ export function createElement(type, props, children) {
 		}
 	}
 	let ref = props.ref;
-	if (ref) delete props.ref;
 	let key = props.key;
-	if (key) delete props.key;
+	if (ref!=null) delete props.ref;
+	if (key!=null) delete props.key;
 
 	return createVNode(type, props, key, ref);
 }

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -48,11 +48,23 @@ describe('createElement(jsx)', () => {
 		expect(<div key="1" />).to.have.property('key', '1');
 	});
 
+	it('should not set VNode#props.key property', () => {
+		expect(<div />).to.not.have.nested.property('props.key');
+		expect(<div key="1" />).to.not.have.nested.property('props.key');
+		expect(<div key={0} />).to.not.have.nested.property('props.key');
+		expect(<div key={''} />).to.not.have.nested.property('props.key');
+	});
+
 	it('should set VNode#ref property', () => {
 		expect(<div />).to.have.property('ref').that.is.undefined;
 		expect(<div a="a" />).to.have.property('ref').that.is.undefined;
 		const emptyFunction = () => {};
 		expect(<div ref={emptyFunction} />).to.have.property('ref', emptyFunction);
+	});
+
+	it('should not set VNode#props.ref property', () => {
+		expect(<div />).to.not.have.nested.property('props.ref');
+		expect(<div ref={() => {}} />).to.not.have.nested.property('props.ref');
 	});
 
 	it('should have ordered VNode properties', () => {


### PR DESCRIPTION
This pull request fixes a case where a component may have `props.key` set when `key === 0` or `key === ""`.

Added tests for `props.key` removal (as well as `props.ref` removal as that code got also changed a bit).

As luck would have it this also cuts down `preact.js.gz` size by 1 byte :)