### PR TITLE
(chore) - only warn once about argumentless effects

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -8,6 +8,7 @@ export function initDebug() {
 	let oldBeforeDiff = options.diff;
 	let oldDiffed = options.diffed;
 	let oldVnode = options.vnode;
+	const warnedComponents = { useEffect: {}, useLayoutEffect: {} };
 
 	options.root = (vnode, parentNode) => {
 		if (!parentNode) {
@@ -157,7 +158,8 @@ export function initDebug() {
 			});
 			if (hooks._pendingEffects.length > 0) {
 				hooks._pendingEffects.forEach((effect) => {
-					if (!effect._args || !Array.isArray(effect._args)) {
+					if ((!effect._args || !Array.isArray(effect._args)) && !warnedComponents.useEffect[vnode.type]) {
+						warnedComponents.useEffect[vnode.type] = true;
 						/* istanbul ignore next */
 						console.warn('You should provide an array of arguments as the second argument to the "useEffect" hook.\n\n' +
 							'Not doing so will invoke this effect on every render.\n\n' +
@@ -167,7 +169,8 @@ export function initDebug() {
 			}
 			if (hooks._pendingLayoutEffects.length > 0) {
 				hooks._pendingLayoutEffects.forEach((layoutEffect) => {
-					if (!layoutEffect._args || !Array.isArray(layoutEffect._args)) {
+					if ((!layoutEffect._args || !Array.isArray(layoutEffect._args)) && !warnedComponents.useLayoutEffect[vnode.type]) {
+						warnedComponents.useLayoutEffect[vnode.type] = true;
 						/* istanbul ignore next */
 						console.warn('You should provide an array of arguments as the second argument to the "useLayoutEffect" hook.\n\n' +
 							'Not doing so will invoke this effect on every render.\n\n' +

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -111,6 +111,8 @@ describe('debug', () => {
 		};
 		render(<App />, scratch);
 		expect(warnings[0]).to.match(/You should provide an array of arguments/);
+		render(<App />, scratch);
+		expect(warnings[1]).to.be.undefined;
 	});
 
 	it('should warn for argumentless useLayoutEffect hooks', () => {
@@ -123,6 +125,8 @@ describe('debug', () => {
 		};
 		render(<App />, scratch);
 		expect(warnings[0]).to.match(/You should provide an array of arguments/);
+		render(<App />, scratch);
+		expect(warnings[1]).to.be.undefined;
 	});
 
 	it('should not warn for argumented effect hooks', () => {
@@ -370,7 +374,7 @@ describe('debug', () => {
 			}
 
 			Baz.propTypes = {
-				unhappy: function alwaysThrows(obj, key) { if (obj[key] === 'signal') throw Error("got prop"); }
+				unhappy: function alwaysThrows(obj, key) { if (obj[key] === 'signal') throw Error('got prop'); }
 			};
 
 			render(<Baz unhappy={'signal'} />, scratch);


### PR DESCRIPTION
Fixes: https://github.com/developit/preact/issues/1624

Serves as a middle ground since this in theory causes a lot of issues, people could be endlessly calling an API etc.