### PR TITLE
(chore) - support __source for jsx-sourcemaps

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -140,10 +140,12 @@ export function initDebug() {
 	};
 
 	options.vnode = (vnode) => {
+		let source;
 		if (vnode.props && vnode.props.__source) {
-			vnode.__source = vnode.props.__source;
+			source = vnode.props.__source;
 			delete vnode.props.__source;
 		}
+		vnode.__source = source;
 		Object.defineProperties(vnode, deprecatedAttributes);
 		if (oldVnode) oldVnode(vnode);
 	};

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -140,6 +140,10 @@ export function initDebug() {
 	};
 
 	options.vnode = (vnode) => {
+		if (vnode.props && vnode.props.__source) {
+			vnode.__source = vnode.props.__source;
+			delete vnode.props.__source;
+		}
 		Object.defineProperties(vnode, deprecatedAttributes);
 		if (oldVnode) oldVnode(vnode);
 	};

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -82,6 +82,20 @@ describe('debug', () => {
 		expect(fn).to.throw(/createElement/);
 	});
 
+	it('should add __source to the vnode in debug mode.', () => {
+		const vnode = h("div", {
+			__source: {
+				fileName: 'div.jsx',
+				lineNumber: 3
+			}
+		});
+		expect(vnode.__source).to.deep.equal({
+			fileName: 'div.jsx',
+			lineNumber: 3
+		})
+		expect(vnode.props.__source).to.be.undefined
+	});
+
 	it('should throw an error when using a hook outside a render', () => {
 		class App extends Component {
 			componentWillMount() {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -83,7 +83,7 @@ describe('debug', () => {
 	});
 
 	it('should add __source to the vnode in debug mode.', () => {
-		const vnode = h("div", {
+		const vnode = h('div', {
 			__source: {
 				fileName: 'div.jsx',
 				lineNumber: 3
@@ -92,8 +92,8 @@ describe('debug', () => {
 		expect(vnode.__source).to.deep.equal({
 			fileName: 'div.jsx',
 			lineNumber: 3
-		})
-		expect(vnode.props.__source).to.be.undefined
+		});
+		expect(vnode.props.__source).to.be.undefined;
 	});
 
 	it('should throw an error when using a hook outside a render', () => {


### PR DESCRIPTION
Support https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx-source.html

Fixes: https://github.com/developit/preact/issues/1571

How do we want to incorporate this in our debug messages?