### PR TITLE
Revert the lookup on documentView since introduces regression

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -62,7 +62,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	else if (name[0]==='o' && name[1]==='n') {
 		let useCapture = name !== (name=name.replace(/Capture$/, ''));
 		let nameLower = name.toLowerCase();
-		name = (nameLower in dom.ownerDocument.defaultView ? nameLower : name).slice(2);
+		name = (nameLower in dom ? nameLower : name).slice(2);
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -540,7 +540,7 @@ describe('render()', () => {
 		it('should register events not appearing on dom nodes', () => {
 			let onAnimationEnd = () => {};
 
-			render(<div onAnimationEnd={onAnimationEnd} />, scratch);
+			render(<div onanimationend={onAnimationEnd} />, scratch);
 			expect(proto.addEventListener).to.have.been.calledOnce.and.to.have.been.calledWithExactly('animationend', sinon.match.func, false);
 		});
 


### PR DESCRIPTION
With this issue, the lookup on the `documentView` was introduced. The issue is that, the lookup is slower than what we usually had - just lookup on node. So, we should recommend that for global events, that are not on `HTMLElement` prototype, the lowercase format should be used.

Reverts the fix for #1589 
Removes `-16B` 😄 