### PR TITLE
chore: add travis-size-report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,5 @@ script:
   - npm run build
   - COVERAGE=true npm run test
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info;
+
+after_success: sizereport --config

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "prop-types": "^15.7.2",
     "sinon": "^6.1.3",
     "sinon-chai": "^3.0.0",
+    "travis-size-report": "^1.0.1",
     "typescript": "^3.0.1",
     "webpack": "^4.3.0"
   },

--- a/sizereport.config.js
+++ b/sizereport.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	repo: 'developit/preact',
-	path: ['./{compat,debug,hooks,}/dist/**/!(*.js.map)'],
+	path: ['./{compat,debug,hooks,}/dist/**/!(*.map)'],
 	branch: 'master'
 };

--- a/sizereport.config.js
+++ b/sizereport.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	repo: 'developit/preact',
-	path: ['dist/*', 'compat/dist/*', 'debug/dist/*', 'hooks/dist/*'],
+	path: ['./{compat,debug,hooks,}/dist/**/!(*.js.map)'],
 	branch: 'master'
 };

--- a/sizereport.config.js
+++ b/sizereport.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	repo: 'developit/preact',
+	path: ['dist/*', 'compat/dist/*', 'debug/dist/*', 'hooks/dist/*'],
+	branch: 'master'
+};


### PR DESCRIPTION
Adding travis-size-report to keep our bundlesizes in check for each PR so we don't have to do it manually.

https://github.com/developit/microbundle/pull/392