### PR TITLE
(chore) Pin the babel-plugin-istanbul version to fix the tests running locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "babel-cli": "^6.24.1",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
-    "babel-plugin-istanbul": "^5.0.1",
+    "babel-plugin-istanbul": "5.0.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -2001,8 +2001,8 @@ describe('Lifecycle methods', () => {
 		});
 
 		it('should be called when child fails in render', () => {
-			// eslint-disable-next-line react/require-render-return
 			class ThrowErr extends Component {
+				// eslint-disable-next-line react/require-render-return
 				render() {
 					throw new Error('Error!');
 				}
@@ -2497,8 +2497,8 @@ describe('Lifecycle methods', () => {
 		});
 
 		it('should be called when child fails in render', () => {
-			// eslint-disable-next-line react/require-render-return
 			class ThrowErr extends Component {
+				// eslint-disable-next-line react/require-render-return
 				render() {
 					throw new Error('Error!');
 				}


### PR DESCRIPTION
As discussed previously, I'm having issues running the `test:karma` tests and also, seems like the `eslint` had something to say about the _empty render_. Got the issue with the tests, pointing to the `babel-plugin-istanbul@^5.0.1`.

The follow-up here should be enabling greenkeeper. Right @developit?