### PR TITLE
Better suspense

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function(config) {
 
 		files: [
 			{ pattern: 'test/polyfills.js', watched: false },
-			{ pattern: config.grep || '{debug,hooks,compat,test-utils,}/test/{browser,shared}/**.test.js', watched: false }
+			{ pattern: config.grep || '{debug,hooks,compat,test-utils,}/test/{browser,shared}/suspense.test.js', watched: false }
 		],
 
 		preprocessors: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function(config) {
 
 		files: [
 			{ pattern: 'test/polyfills.js', watched: false },
-			{ pattern: config.grep || '{debug,hooks,compat,test-utils,}/test/{browser,shared}/suspense.test.js', watched: false }
+			{ pattern: config.grep || '{debug,hooks,compat,test-utils,}/test/{browser,shared}/**.js', watched: false }
 		],
 
 		preprocessors: {

--- a/src/component.js
+++ b/src/component.js
@@ -71,7 +71,8 @@ Component.prototype.forceUpdate = function(callback) {
 		const force = callback!==false;
 
 		let mounts = [];
-		dom = diff(parentDom, vnode, vnode, this._context, parentDom.ownerSVGElement!==undefined, null, mounts, this._ancestorComponent, force, dom);
+		console.log('_suspendChildDom', this._suspendChildDom);
+		dom = diff(parentDom, vnode, vnode, this._context, parentDom.ownerSVGElement!==undefined, null, mounts, this._ancestorComponent, force, dom, null, undefined, this._suspendChildDom);
 		if (dom!=null && dom.parentNode!==parentDom) {
 			parentDom.appendChild(dom);
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -23,7 +23,8 @@ import { removeNode } from '../util';
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  */
-export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom) {
+export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom, isSuspended, indent) {
+	console.log(indent, 'diffChildren of ', newParentVNode && newParentVNode.type && (newParentVNode.type.displayName || newParentVNode.type.name || newParentVNode.type));
 	let childVNode, i, j, oldVNode, newDom, sibDom;
 
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode, true);
@@ -83,7 +84,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			}
 
 			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom);
+			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom, isSuspended, indent + '  ');
 
 			// Only proceed if the vnode has not been unmounted by `diff()` above.
 			if (newDom!=null) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -23,8 +23,8 @@ import { removeNode } from '../util';
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  */
-export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom, isSuspended, indent) {
-	console.log(indent, 'diffChildren of ', newParentVNode && newParentVNode.type && (newParentVNode.type.displayName || newParentVNode.type.name || newParentVNode.type));
+export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, oldDom, _, indent = '#', needsToSuspendChildDom) {
+	console.log(indent, 'diffChildren of ', newParentVNode && newParentVNode.type && (newParentVNode.type.displayName || newParentVNode.type.name || newParentVNode.type), needsToSuspendChildDom);
 	let childVNode, i, j, oldVNode, newDom, sibDom;
 
 	let newChildren = newParentVNode._children || toChildArray(newParentVNode.props.children, newParentVNode._children=[], coerceToVNode, true);
@@ -84,7 +84,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			}
 
 			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom, isSuspended, indent + '  ');
+			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, ancestorComponent, null, oldDom, null, indent + '  ', needsToSuspendChildDom);
 
 			// Only proceed if the vnode has not been unmounted by `diff()` above.
 			if (newDom!=null) {

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -95,7 +95,7 @@ describe('suspense', () => {
 		teardown(scratch);
 	});
 
-	xit('should suspend when using lazy', () => {
+	it('should suspend when using lazy', () => {
 		let prom;
 
 		const Lazy = lazy(() => {
@@ -127,7 +127,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should suspend when a promise is throw', () => {
+	it('should suspend when a promise is throw', () => {
 		const s = createSuspension('regular case', 0, null);
 
 		render(
@@ -153,7 +153,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should suspend with custom error boundary', () => {
+	it('should suspend with custom error boundary', () => {
 		const s = createSuspension('within error boundary', 0, null);
 
 		render(
@@ -177,7 +177,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should support throwing suspense', () => {
+	it('should support throwing suspense', () => {
 		const s = createSuspension('throwing', 0, new Error('Thrown in suspense'));
 
 		render(
@@ -201,7 +201,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should call multiple suspending components render in one go', () => {
+	it('should call multiple suspending components render in one go', () => {
 		const s1 = createSuspension('first', 0, null);
 		const s2 = createSuspension('second', 0, null);
 		const LoggedCustomSuspense = sinon.spy(CustomSuspense);
@@ -231,7 +231,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should call multiple nested suspending components render in one go', () => {
+	it('should call multiple nested suspending components render in one go', () => {
 		const s1 = createSuspension('first', 5, null);
 		const s2 = createSuspension('second', 5, null);
 		const LoggedCustomSuspense = sinon.spy(CustomSuspense);
@@ -263,7 +263,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should support suspension nested in a Fragment', () => {
+	it('should support suspension nested in a Fragment', () => {
 		const s = createSuspension('nested in a Fragment', 0, null);
 
 		render(
@@ -290,7 +290,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should support multiple non-nested Suspense', () => {
+	it('should support multiple non-nested Suspense', () => {
 		const s1 = createSuspension('1', 0, null);
 		const s2 = createSuspension('2', 0, null);
 
@@ -354,7 +354,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should only suspend the most inner Suspend', () => {
+	it('should only suspend the most inner Suspend', () => {
 		const s = createSuspension('1', 0, null);
 
 		render(
@@ -381,7 +381,7 @@ describe('suspense', () => {
 		});
 	});
 
-	xit('should throw when missing Suspense', () => {
+	it('should throw when missing Suspense', () => {
 		const s = createSuspension('1', 0, null);
 
 		render(
@@ -396,7 +396,7 @@ describe('suspense', () => {
 		);
 	});
 
-	xit('should throw when lazy\'s loader throws', () => {
+	it('should throw when lazy\'s loader throws', () => {
 		let prom;
 
 		const ThrowingLazy = lazy(() => {
@@ -429,7 +429,7 @@ describe('suspense', () => {
 		});
 	});
 
-	it('should keep state when suspending', () => {
+	it.only('should keep state when suspending', () => {
 		class Suspender extends Component {
 			suspend() {
 				let resolve;
@@ -520,6 +520,9 @@ describe('suspense', () => {
 			<Suspense fallback={<div>Suspended...</div>}>
 				Test
 				<Fragment>
+					Text in Fragment
+				</Fragment>
+				<Fragment>
 					<Logger id="before" />
 				</Fragment>
 				<WrappedTextNode />
@@ -536,11 +539,12 @@ describe('suspense', () => {
 		console.log('initial render done ----------------------------');
 		expect(scratch.innerHTML).to.eql(dedent`
 			Test
+			Text in Fragment
 			<div>
 				<p>Logger before</p>
 			</div>
 			wrapped text
-			<section id="wrapped" />
+			<section id="wrapped"></section>
 			<div>
 				<p>Logger outer</p>
 				<div>

--- a/test/browser/suspense.test.js
+++ b/test/browser/suspense.test.js
@@ -486,6 +486,14 @@ describe('suspense', () => {
 			}
 		}
 
+		function WrappedTextNode() {
+			return 'wrapped text';
+		}
+
+		function WrappedDomNode() {
+			return <section id="wrapped" />;
+		}
+
 		function dedent(strs) {
 			return strs
 				.map(str => str
@@ -514,6 +522,8 @@ describe('suspense', () => {
 				<Fragment>
 					<Logger id="before" />
 				</Fragment>
+				<WrappedTextNode />
+				<WrappedDomNode />
 				<Logger id="outer">
 					{suspender1}
 					{suspender2}
@@ -529,6 +539,8 @@ describe('suspense', () => {
 			<div>
 				<p>Logger before</p>
 			</div>
+			wrapped text
+			<section id="wrapped" />
 			<div>
 				<p>Logger outer</p>
 				<div>
@@ -560,6 +572,7 @@ describe('suspense', () => {
 			<div style="display: none;">
 				<p>Logger before</p>
 			</div>
+			<section id="wrapped" style="display: none;" />
 			<div style="display: none;">
 				<p>Logger outer</p>
 				<div>
@@ -587,6 +600,7 @@ describe('suspense', () => {
 			<div style="display: none;">
 				<p>Logger before</p>
 			</div>
+			<section id="wrapped" style="display: none;" />
 			<div style="display: none;">
 				<p>Logger outer</p>
 				<div>
@@ -613,6 +627,7 @@ describe('suspense', () => {
 			<div style="display: none;">
 				<p>Logger before</p>
 			</div>
+			<section id="wrapped" style="display: none;" />
 			<div style="display: none;">
 				<p>Logger outer</p>
 				<div>
@@ -639,6 +654,7 @@ describe('suspense', () => {
 			<div style="display: none;">
 				<p>Logger before</p>
 			</div>
+			<section id="wrapped" style="display: none;" />
 			<div style="display: none;">
 				<p>Logger outer</p>
 			</div>
@@ -660,6 +676,7 @@ describe('suspense', () => {
 				<div style="display: none;">
 					<p>Logger before</p>
 				</div>
+				<section id="wrapped" style="display: none;" />
 				<div style="display: none;">
 					<p>Logger outer</p>
 					<div>
@@ -682,11 +699,12 @@ describe('suspense', () => {
 				rerender();
 				console.log('render suspension resolved done ------------');
 				console.log(scratch);
-				// TODO: The text node `Test` is moved to the end because of the ordering issue with Fragments
+				// TODO: The text nodes `Test` and `wrapped text` are moved to the end because of the ordering issue with Fragments. See #1605
 				expect(scratch.innerHTML).to.eql(dedent`
 					<div style="">
 						<p>Logger before</p>
 					</div>
+					<section id="wrapped" style="" />
 					<div style="">
 						<p>Logger outer</p>
 						<div>
@@ -706,6 +724,7 @@ describe('suspense', () => {
 					<article style="">
 						<h1>stateful</h1>{"tag":"article"}
 					</article>
+					wrapped text
 					Test
 				`);
 				console.log('--------------------------------------------');


### PR DESCRIPTION
This PR aims to provide an implementation of Suspense that matches the behaviour of React more closely:

- Keep suspended DOM but hide it using `display: none` (Text nodes are removed)
  - This results in keeping state


*Open things*
- [x] Allow for multiple pending promises thrown in the render methods of `Suspense`s children
- [ ] More tests
- [ ] Clean up the Implementation (maybe we can make some things easier / more optimized)
- [ ] Byte-golfing
- [ ] Handle text nodes nested below children